### PR TITLE
Remove render model params

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,12 +40,11 @@
     import { renderBlinxForm } from './lib/blinx.form.js';
     import { renderBlinxTable } from './lib/blinx.table.js';
 
-    const store = createBlinxStore(initialDataset);
+    const store = createBlinxStore(initialDataset, productModel);
     const ui = new BlinxDefaultAdapter();
 
     const { formApi } = renderBlinxForm({
       root: document.getElementById('form-container'),
-      model: productModel,
       view: productFormView,
       store,
       ui,
@@ -64,7 +63,6 @@
 
     const { tableApi } = renderBlinxTable({
       root: document.getElementById('table-container'),
-      model: productModel,
       view: productTableView,
       store,
       ui,

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -2,7 +2,7 @@
 import { validateField } from './blinx.validate.js';
 
 export function renderBlinxForm({
-  root, model, view, store, ui,
+  root, view, store, ui,
   recordIndex = 0,
   controls = {
     saveButtonId: null,
@@ -15,6 +15,14 @@ export function renderBlinxForm({
     saveStatusId: null,
   }
 }) {
+  if (!store || typeof store.getModel !== 'function') {
+    throw new Error('renderBlinxForm requires a store that exposes getModel().');
+  }
+  const model = store.getModel();
+  if (!model || !model.fields) {
+    throw new Error('renderBlinxForm requires the store model to define fields.');
+  }
+
   root.innerHTML = '';
 
   let currentIndex = recordIndex;

--- a/lib/blinx.table.js
+++ b/lib/blinx.table.js
@@ -1,6 +1,6 @@
 
 export function renderBlinxTable({
-  root, model, view, store, ui,
+  root, view, store, ui,
   pageSize = 20,
   onRowClick,
   controls = {
@@ -9,6 +9,14 @@ export function renderBlinxTable({
     statusId: null,
   }
 }) {
+  if (!store || typeof store.getModel !== 'function') {
+    throw new Error('renderBlinxTable requires a store that exposes getModel().');
+  }
+  const model = store.getModel();
+  if (!model || !model.fields) {
+    throw new Error('renderBlinxTable requires the store model to define fields.');
+  }
+
   root.innerHTML = '';
   let page = 0;
   let selected = new Set();


### PR DESCRIPTION
Remove `model` parameter from `renderBlinxForm` and `renderBlinxTable` as they now retrieve the model directly from the `store`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c912e65b-a1ea-4fbb-a2a0-3df090e90286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c912e65b-a1ea-4fbb-a2a0-3df090e90286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Form and table now fetch `model` from the `store`; callers updated and store is initialized with the model.
> 
> - **API changes**:
>   - `renderBlinxForm` and `renderBlinxTable` no longer accept `model`; both validate and read `model` via `store.getModel()`.
> - **Implementation**:
>   - Added guard clauses to ensure `store.getModel()` exists and `model.fields` is defined in both renderers.
>   - Internal usage updated to reference `model` from the store for field definitions, validation, and record creation.
> - **Integration** (`index.html`):
>   - `createBlinxStore` now called with `(initialDataset, productModel)`.
>   - Calls to `renderBlinxForm`/`renderBlinxTable` updated to omit `model`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0691b3033423a64882ff808576cade73d7d160c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->