### PR TITLE
Merge update-store-event-notification

### DIFF
--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -8,6 +8,14 @@ export const DataTypes = {
   array: 'array',
 };
 
+export const EventTypes = {
+  add: 'add',
+  remove: 'remove',
+  update: 'update',
+  commit: 'commit',
+  reset: 'reset',
+};
+
 export function createBlinxStore(initialArray, dataModel) {
   let original = JSON.parse(JSON.stringify(initialArray));
   let current = JSON.parse(JSON.stringify(initialArray));
@@ -29,7 +37,7 @@ export function createBlinxStore(initialArray, dataModel) {
 
   function addRecord(record, atIndex = current.length) {
     current.splice(atIndex, 0, record);
-    notify(['add', atIndex], record);
+    notify([EventTypes.add, atIndex], record);
     return atIndex;
   }
 
@@ -38,7 +46,7 @@ export function createBlinxStore(initialArray, dataModel) {
     sorted.forEach(i => {
       if (i >= 0 && i < current.length) {
         const removed = current.splice(i, 1);
-        notify(['remove', i], removed[0]);
+        notify([EventTypes.remove, i], removed[0]);
       }
     });
     return sorted.length;
@@ -66,12 +74,16 @@ export function createBlinxStore(initialArray, dataModel) {
     return changes;
   }
 
-  function commit() { original = JSON.parse(JSON.stringify(current)); }
-  function reset() { current = JSON.parse(JSON.stringify(original)); notify(['reset'], null); }
+  function commit() {
+    const snapshot = JSON.parse(JSON.stringify(current));
+    original = snapshot;
+    notify([EventTypes.commit], snapshot);
+  }
+
+  function reset() { current = JSON.parse(JSON.stringify(original)); notify([EventTypes.reset], null); }
 
   return {
     getRecord, getLength, setField, addRecord, removeRecords,
     subscribe, toJSON, diff, commit, reset, getModel,
-    subscribe, toJSON, diff, commit, reset,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Standardizes store event notifications via EventTypes and adds commit/reset event emissions with a snapshot payload.
> 
> - **Store events**:
>   - Introduce `EventTypes` constants (`add`, `remove`, `update`, `commit`, `reset`).
>   - Switch notifications to use `EventTypes` for `add`/`remove` paths.
>   - `commit()` now emits a `commit` event with a snapshot payload.
>   - `reset()` now emits a `reset` event.
> - **API**:
>   - Return object tidied; `getModel` included alongside existing methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 549f8e669f850b0a30a6fe08a691b5ee82edd00f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->