### PR TITLE
Optimize record events and updates

### DIFF
--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -16,14 +16,17 @@ export const EventTypes = {
   reset: 'reset',
 };
 
+const clone = value => JSON.parse(JSON.stringify(value));
+
 export function createBlinxStore(initialArray, dataModel) {
-  let original = JSON.parse(JSON.stringify(initialArray));
-  let current = JSON.parse(JSON.stringify(initialArray));
+  let original = clone(initialArray);
+  let current = clone(initialArray);
   const model = dataModel;
   const subs = new Set();
+  let storeApi;
 
   function notify(path, value) {
-    subs.forEach(fn => fn({ path, value, data: current }));
+    subs.forEach(fn => fn({ path, value, data: current, store: storeApi }));
   }
 
   function getRecord(idx) { return current[idx]; }
@@ -43,17 +46,37 @@ export function createBlinxStore(initialArray, dataModel) {
 
   function removeRecords(indexes) {
     const sorted = Array.from(new Set(indexes)).sort((a, b) => b - a);
+    const removed = [];
     sorted.forEach(i => {
       if (i >= 0 && i < current.length) {
-        const removed = current.splice(i, 1);
-        notify([EventTypes.remove, i], removed[0]);
+        const [record] = current.splice(i, 1);
+        removed.push({ index: i, record });
       }
     });
-    return sorted.length;
+    if (removed.length > 0) {
+      const removedIndexes = removed.map(item => item.index);
+      const removedRecords = removed.map(item => item.record);
+      notify([EventTypes.remove, removedIndexes], removedRecords);
+    }
+    return removed.length;
+  }
+
+  function updateIndex(index) {
+    if (index < 0 || index >= current.length) return null;
+    const record = current[index];
+    notify([EventTypes.update, index], record);
+    return record;
+  }
+
+  function update(index, record) {
+    if (index < 0 || index >= current.length) return null;
+    current[index] = record;
+    notify([EventTypes.update, index], record);
+    return record;
   }
 
   function subscribe(fn) { subs.add(fn); return () => subs.delete(fn); }
-  function toJSON() { return JSON.parse(JSON.stringify(current)); }
+  function toJSON() { return clone(current); }
 
   function diff() {
     const changes = [];
@@ -75,15 +98,31 @@ export function createBlinxStore(initialArray, dataModel) {
   }
 
   function commit() {
-    const snapshot = JSON.parse(JSON.stringify(current));
+    const snapshot = clone(current);
     original = snapshot;
     notify([EventTypes.commit], snapshot);
   }
 
-  function reset() { current = JSON.parse(JSON.stringify(original)); notify([EventTypes.reset], null); }
+  function reset() {
+    current = clone(original);
+    current.forEach((record, idx) => notify([EventTypes.reset, idx], record));
+  }
 
-  return {
-    getRecord, getLength, setField, addRecord, removeRecords,
-    subscribe, toJSON, diff, commit, reset, getModel,
+  storeApi = {
+    getRecord,
+    getLength,
+    setField,
+    addRecord,
+    removeRecords,
+    updateIndex,
+    update,
+    subscribe,
+    toJSON,
+    diff,
+    commit,
+    reset,
+    getModel,
   };
+
+  return storeApi;
 }


### PR DESCRIPTION
Standardize store event granularity and introduce explicit record update methods to improve performance for batched operations and provide clear APIs for notifying listeners about record changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-382ed272-68a3-4cda-90de-b13d582ea041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-382ed272-68a3-4cda-90de-b13d582ea041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `update`/`updateIndex`, batches `remove` notifications, emits per-record `reset`, standardizes cloning, and includes the store ref in event payloads; docs updated accordingly.
> 
> - **Store (`lib/blinx.store.js`)**:
>   - **Update APIs**: Add `update(index, record)` and `updateIndex(index)`; both emit `update` events.
>   - **Event payloads**: `notify` now includes `{ store }` alongside `data`.
>   - **Remove batching**: `removeRecords` emits a single `remove` event with all removed indexes and records; returns removed count.
>   - **Granular reset**: `reset()` now emits `reset` once per record with `[reset, index]` path.
>   - **Cloning utility**: Introduce `clone(...)` and use it for `original`, `current`, `toJSON()`, and `commit()` snapshots.
>   - **API shape**: Return a consolidated `storeApi` object exposing new methods.
> - **Docs (`README.md`)**:
>   - Document new mutators (`update`, `updateIndex`) and revised event semantics (batched `remove`, per-record `reset`, `commit` includes dataset snapshot + store reference).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d505afa1442fb3c4675c7bd162aa9e925f48768a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->