### PR TITLE
Update form and table status

### DIFF
--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -1,5 +1,6 @@
 
 import { validateField } from './blinx.validate.js';
+import { EventTypes } from './blinx.store.js';
 
 export function renderBlinxForm({
   root, view, store, ui,
@@ -27,6 +28,24 @@ export function renderBlinxForm({
 
   let currentIndex = recordIndex;
   let sectionEls = [];
+  let internalChangeDepth = 0;
+  let pendingResetSync = null;
+
+  const trackedStoreEvents = new Set([
+    EventTypes.add,
+    EventTypes.remove,
+    EventTypes.update,
+    EventTypes.commit,
+    EventTypes.reset,
+  ]);
+
+  const externalStatusMessages = {
+    [EventTypes.add]: 'Record added elsewhere; refreshed view.',
+    [EventTypes.remove]: 'Record removed elsewhere; refreshed view.',
+    [EventTypes.update]: 'Record updated elsewhere; refreshed view.',
+    [EventTypes.commit]: 'Changes committed elsewhere; refreshed view.',
+    [EventTypes.reset]: 'Store reset elsewhere; refreshed view.',
+  };
 
   const dom = {
     saveBtn: controls.saveButtonId ? document.getElementById(controls.saveButtonId) : null,
@@ -59,6 +78,15 @@ export function renderBlinxForm({
     if (dom.status) dom.status.textContent = '';
   }
 
+  function runInternalChange(fn) {
+    internalChangeDepth += 1;
+    try {
+      return fn();
+    } finally {
+      internalChangeDepth = Math.max(0, internalChangeDepth - 1);
+    }
+  }
+
   function buildSections() {
     sectionEls = [];
     const record = store.getRecord(currentIndex);
@@ -85,7 +113,10 @@ export function renderBlinxForm({
           fieldKey: key,
           def,
           value,
-          onChange: val => { if (store.getRecord(currentIndex)) store.setField(currentIndex, key, val); }
+          onChange: val => {
+            if (!store.getRecord(currentIndex)) return;
+            runInternalChange(() => store.setField(currentIndex, key, val));
+          }
         });
 
         const cell = document.createElement('div');
@@ -111,37 +142,48 @@ export function renderBlinxForm({
     );
   }
 
-  function rebind(newIndex) {
+  function rebind(newIndex, options = {}) {
+    const { skipStatusClear = false } = options;
     const total = store.getLength();
     if (total === 0) {
       currentIndex = 0;
       buildSections();
       updateIndicator();
-      clearStatus();
+      if (!skipStatusClear) clearStatus();
       return true;
     }
     if (newIndex < 0 || newIndex >= total) return false;
     currentIndex = newIndex;
     buildSections();
     updateIndicator();
-    clearStatus();
+    if (!skipStatusClear) clearStatus();
     return true;
   }
 
   buildSections();
   updateIndicator();
 
+  function handleExternalStoreEvent(action) {
+    const total = store.getLength();
+    const nextIndex = total === 0 ? 0 : Math.min(currentIndex, total - 1);
+    rebind(nextIndex, { skipStatusClear: true });
+    const message = externalStatusMessages[action] || 'Store changed externally; refreshed view.';
+    setStatus(message, '#3182ce');
+  }
+
   store.subscribe(ev => {
-    if (Array.isArray(ev.path)) {
-      const [action, idx] = ev.path;
-      if (action === 'reset' || action === 'remove') {
-        const len = store.getLength();
-        currentIndex = len === 0 ? 0 : Math.min(currentIndex, len - 1);
-        buildSections();
-        updateIndicator();
-        clearStatus();
-      }
+    if (!ev || internalChangeDepth > 0 || !Array.isArray(ev.path)) return;
+    const [action] = ev.path;
+    if (!trackedStoreEvents.has(action)) return;
+    if (action === EventTypes.reset) {
+      if (pendingResetSync) return;
+      pendingResetSync = setTimeout(() => {
+        pendingResetSync = null;
+        handleExternalStoreEvent(action);
+      }, 0);
+      return;
     }
+    handleExternalStoreEvent(action);
   });
 
   async function runInterceptors(type, executor) {
@@ -161,14 +203,25 @@ export function renderBlinxForm({
     if (!ok) return setStatus('Fix validation errors.', '#e53e3e');
     const diff = store.diff();
     if (diff.length > 0) {
-      store.commit();
+      runInternalChange(() => store.commit());
       setStatus(`Saved changes: ${JSON.stringify(diff)}`, '#2f855a');
     } else setStatus('No changes to save.', '#4a5568');
   }
 
-  async function doReset() { store.reset(); buildSections(); updateIndicator(); setStatus('Reset done.', '#4a5568'); }
-  async function doCreate() { const idx = store.addRecord(Object.fromEntries(Object.keys(model.fields).map(k => [k, '']))); rebind(idx); setStatus('New record created.', '#2f855a'); }
-  async function doDelete() { if (store.getLength() === 0) return setStatus('No records to delete.', '#e53e3e'); store.removeRecords([currentIndex]); setStatus('Record deleted.', '#2f855a'); }
+  async function doReset() { runInternalChange(() => store.reset()); buildSections(); updateIndicator(); setStatus('Reset done.', '#4a5568'); }
+  async function doCreate() {
+    const idx = runInternalChange(() => store.addRecord(Object.fromEntries(Object.keys(model.fields).map(k => [k, '']))));
+    rebind(idx);
+    setStatus('New record created.', '#2f855a');
+  }
+  async function doDelete() {
+    if (store.getLength() === 0) return setStatus('No records to delete.', '#e53e3e');
+    runInternalChange(() => store.removeRecords([currentIndex]));
+    const len = store.getLength();
+    const nextIndex = len === 0 ? 0 : Math.min(currentIndex, len - 1);
+    rebind(nextIndex);
+    setStatus('Record deleted.', '#2f855a');
+  }
   async function doNext() { if (!rebind(currentIndex + 1)) setStatus('Already at last record.', '#e53e3e'); }
   async function doPrev() { if (!rebind(currentIndex - 1)) setStatus('Already at first record.', '#e53e3e'); }
 

--- a/lib/blinx.table.js
+++ b/lib/blinx.table.js
@@ -1,4 +1,6 @@
 
+import { EventTypes } from './blinx.store.js';
+
 export function renderBlinxTable({
   root, view, store, ui,
   pageSize = 20,
@@ -20,6 +22,24 @@ export function renderBlinxTable({
   root.innerHTML = '';
   let page = 0;
   let selected = new Set();
+  let internalChangeDepth = 0;
+  let pendingResetSync = null;
+
+  const trackedStoreEvents = new Set([
+    EventTypes.add,
+    EventTypes.remove,
+    EventTypes.update,
+    EventTypes.commit,
+    EventTypes.reset,
+  ]);
+
+  const externalStatusMessages = {
+    [EventTypes.add]: 'Rows added elsewhere; refreshed table.',
+    [EventTypes.remove]: 'Rows removed elsewhere; refreshed table.',
+    [EventTypes.update]: 'Rows updated elsewhere; refreshed table.',
+    [EventTypes.commit]: 'Changes committed elsewhere; refreshed table.',
+    [EventTypes.reset]: 'Store reset elsewhere; refreshed table.',
+  };
 
   const dom = {
     createBtn: controls.createButtonId ? document.getElementById(controls.createButtonId) : null,
@@ -31,6 +51,15 @@ export function renderBlinxTable({
     if (!dom.status) return;
     dom.status.textContent = msg;
     dom.status.style.color = color;
+  }
+
+  function runInternalChange(fn) {
+    internalChangeDepth += 1;
+    try {
+      return fn();
+    } finally {
+      internalChangeDepth = Math.max(0, internalChangeDepth - 1);
+    }
   }
 
   const toolbar = document.createElement('div');
@@ -55,6 +84,11 @@ export function renderBlinxTable({
   function renderPage() {
     tbody.innerHTML = '';
     const data = store.toJSON();
+    const maxPage = data.length === 0 ? 0 : Math.max(0, Math.ceil(data.length / pageSize) - 1);
+    page = Math.min(Math.max(page, 0), maxPage);
+    const prunedSelection = new Set();
+    selected.forEach(idx => { if (idx >= 0 && idx < data.length) prunedSelection.add(idx); });
+    selected = prunedSelection;
     const start = page * pageSize;
     const end = Math.min(data.length, start + pageSize);
     const frag = document.createDocumentFragment();
@@ -99,14 +133,14 @@ export function renderBlinxTable({
   }
 
   async function doCreate() {
-    store.addRecord(Object.fromEntries(Object.keys(model.fields).map(k => [k, ''])));
+    runInternalChange(() => store.addRecord(Object.fromEntries(Object.keys(model.fields).map(k => [k, '']))));
     renderPage();
     setStatus('New row created.', '#2f855a');
   }
 
   async function doDeleteSelected() {
     if (selected.size === 0) return setStatus('No rows selected.', '#e53e3e');
-    store.removeRecords(Array.from(selected));
+    runInternalChange(() => store.removeRecords(Array.from(selected)));
     selected.clear();
     renderPage();
     setStatus('Selected rows deleted.', '#2f855a');
@@ -115,7 +149,34 @@ export function renderBlinxTable({
   if (dom.createBtn) dom.createBtn.addEventListener('click', () => runInterceptors('create', doCreate));
   if (dom.deleteSelectedBtn) dom.deleteSelectedBtn.addEventListener('click', () => runInterceptors('deleteSelected', doDeleteSelected));
 
-  store.subscribe(renderPage);
+  function handleExternalStoreEvent(action) {
+    const message = externalStatusMessages[action] || 'Table data changed externally; refreshed view.';
+    setStatus(message, '#3182ce');
+  }
+
+  function scheduleResetRefresh(action) {
+    if (pendingResetSync) return;
+    pendingResetSync = setTimeout(() => {
+      pendingResetSync = null;
+      renderPage();
+      handleExternalStoreEvent(action);
+    }, 0);
+  }
+
+  store.subscribe(ev => {
+    if (internalChangeDepth > 0) return;
+    if (!ev || !Array.isArray(ev.path)) {
+      renderPage();
+      return;
+    }
+    const [action] = ev.path;
+    if (action === EventTypes.reset) {
+      scheduleResetRefresh(action);
+      return;
+    }
+    renderPage();
+    if (trackedStoreEvents.has(action)) handleExternalStoreEvent(action);
+  });
   renderPage();
 
   return {


### PR DESCRIPTION
Enable `renderBlinxForm` and `renderBlinxTable` to listen to store events and refresh their UI to stay synchronized with external data changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-e97d06b4-70aa-492d-95ed-110e437c9554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e97d06b4-70aa-492d-95ed-110e437c9554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

