### PR TITLE
Unit test coverage report

### DIFF
--- a/.github/workflows/ci-unit-jest.yml
+++ b/.github/workflows/ci-unit-jest.yml
@@ -25,7 +25,12 @@ jobs:
         run: npm ci
 
       - name: Run Jest unit tests
-        run: npm run test:ci
+        run: npm run test:ci:coverage
+
+      - name: Add coverage summary
+        if: always()
+        run: |
+          node -e "const fs=require('fs'); const p='coverage/coverage-summary.json'; if(!fs.existsSync(p)){ console.log('No coverage summary found at', p); process.exit(0);} const s=JSON.parse(fs.readFileSync(p,'utf8')).total; const pct=v=> (v && typeof v.pct==='number') ? v.pct : 0; const md=[ '## Jest coverage', '', '| Metric | % | Covered / Total |', '|---|---:|---:|', `| Lines | ${pct(s.lines)} | ${s.lines.covered} / ${s.lines.total} |`, `| Statements | ${pct(s.statements)} | ${s.statements.covered} / ${s.statements.total} |`, `| Functions | ${pct(s.functions)} | ${s.functions.covered} / ${s.functions.total} |`, `| Branches | ${pct(s.branches)} | ${s.branches.covered} / ${s.branches.total} |`, '' ].join('\\n'); fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, md);"
 
       - name: Upload JUnit report
         if: always()
@@ -33,4 +38,12 @@ jobs:
         with:
           name: jest-junit-report
           path: reports/junit/jest-junit.xml
+          if-no-files-found: ignore
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jest-coverage-report
+          path: coverage
           if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 reports/
+coverage/

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -13,4 +13,6 @@ module.exports = {
     }],
   ],
   collectCoverageFrom: ['lib/**/*.js', 'model/**/*.js'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text-summary', 'lcov', 'html', 'json-summary'],
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "test": "jest --runInBand",
-    "test:ci": "jest --ci --runInBand"
+    "test:ci": "jest --ci --runInBand",
+    "test:coverage": "jest --runInBand --coverage",
+    "test:ci:coverage": "jest --ci --runInBand --coverage"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
Add Jest unit test coverage reports to the CI pipeline.

---
<a href="https://cursor.com/background-agent?bcId=bc-25986311-0685-4e5c-9a96-030ba657e419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25986311-0685-4e5c-9a96-030ba657e419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable Jest coverage in CI with job summary and artifacts, adding coverage config and scripts.
> 
> - **CI (GitHub Actions)**
>   - Run Jest with coverage via `npm run test:ci:coverage` in `.github/workflows/ci-unit-jest.yml`.
>   - Append coverage summary (lines/statements/functions/branches) to the job summary from `coverage/coverage-summary.json`.
>   - Upload coverage artifact from `coverage/` alongside existing JUnit report.
> - **Jest config**
>   - Set `coverageDirectory: 'coverage'` and add `coverageReporters: ['text-summary', 'lcov', 'html', 'json-summary']`.
> - **NPM scripts**
>   - Add `test:coverage` and `test:ci:coverage`.
> - **Repo hygiene**
>   - Ignore `coverage/` in `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d48a84bbf95461d545531cdb2e1c0a6ad273d016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->