### PR TITLE
Test click handler cleanup

### DIFF
--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -2,6 +2,31 @@
 import { validateField } from './blinx.validate.js';
 import { EventTypes } from './blinx.store.js';
 
+// Prevent handler accumulation when renderBlinxForm is called multiple times
+// with the same DOM controls (common in tests and re-renders).
+const CONTROL_CLICK_BINDINGS = new WeakMap();
+const ROOT_CLEANUP = Symbol('blinxFormCleanup');
+
+function bindClick(controlEl, role, handler) {
+  if (!controlEl) return () => {};
+  let bindings = CONTROL_CLICK_BINDINGS.get(controlEl);
+  if (!bindings) {
+    bindings = new Map();
+    CONTROL_CLICK_BINDINGS.set(controlEl, bindings);
+  }
+  const prev = bindings.get(role);
+  if (prev) controlEl.removeEventListener('click', prev);
+  bindings.set(role, handler);
+  controlEl.addEventListener('click', handler);
+  return () => {
+    const current = bindings.get(role);
+    if (current === handler) {
+      controlEl.removeEventListener('click', handler);
+      bindings.delete(role);
+    }
+  };
+}
+
 export function renderBlinxForm({
   root, view, store, ui,
   recordIndex = 0,
@@ -24,12 +49,18 @@ export function renderBlinxForm({
     throw new Error('renderBlinxForm requires the store model to define fields.');
   }
 
+  // If the same root is re-rendered, clean up prior subscriptions/handlers first.
+  if (root && typeof root[ROOT_CLEANUP] === 'function') {
+    try { root[ROOT_CLEANUP](); } catch { /* ignore */ }
+  }
+
   root.innerHTML = '';
 
   let currentIndex = recordIndex;
   let sectionEls = [];
   let internalChangeDepth = 0;
   let pendingResetSync = null;
+  const cleanupFns = [];
 
   const trackedStoreEvents = new Set([
     EventTypes.add,
@@ -171,7 +202,7 @@ export function renderBlinxForm({
     setStatus(message, '#3182ce');
   }
 
-  store.subscribe(ev => {
+  const unsubscribe = store.subscribe(ev => {
     if (!ev || internalChangeDepth > 0 || !Array.isArray(ev.path)) return;
     const [action] = ev.path;
     if (!trackedStoreEvents.has(action)) return;
@@ -185,6 +216,7 @@ export function renderBlinxForm({
     }
     handleExternalStoreEvent(action);
   });
+  if (typeof unsubscribe === 'function') cleanupFns.push(unsubscribe);
 
   async function runInterceptors(type, executor) {
     const procs = listeners[type];
@@ -225,12 +257,27 @@ export function renderBlinxForm({
   async function doNext() { if (!rebind(currentIndex + 1)) setStatus('Already at last record.', '#e53e3e'); }
   async function doPrev() { if (!rebind(currentIndex - 1)) setStatus('Already at first record.', '#e53e3e'); }
 
-  if (dom.saveBtn) dom.saveBtn.addEventListener('click', () => runInterceptors('save', doSave));
-  if (dom.resetBtn) dom.resetBtn.addEventListener('click', () => runInterceptors('reset', doReset));
-  if (dom.createBtn) dom.createBtn.addEventListener('click', () => runInterceptors('create', doCreate));
-  if (dom.deleteBtn) dom.deleteBtn.addEventListener('click', () => runInterceptors('delete', doDelete));
-  if (dom.nextBtn) dom.nextBtn.addEventListener('click', () => runInterceptors('next', doNext));
-  if (dom.prevBtn) dom.prevBtn.addEventListener('click', () => runInterceptors('prev', doPrev));
+  cleanupFns.push(bindClick(dom.saveBtn, 'save', () => runInterceptors('save', doSave)));
+  cleanupFns.push(bindClick(dom.resetBtn, 'reset', () => runInterceptors('reset', doReset)));
+  cleanupFns.push(bindClick(dom.createBtn, 'create', () => runInterceptors('create', doCreate)));
+  cleanupFns.push(bindClick(dom.deleteBtn, 'delete', () => runInterceptors('delete', doDelete)));
+  cleanupFns.push(bindClick(dom.nextBtn, 'next', () => runInterceptors('next', doNext)));
+  cleanupFns.push(bindClick(dom.prevBtn, 'prev', () => runInterceptors('prev', doPrev)));
+
+  function destroy() {
+    if (pendingResetSync) {
+      clearTimeout(pendingResetSync);
+      pendingResetSync = null;
+    }
+    // Unbind in reverse order in case any dependencies exist.
+    while (cleanupFns.length) {
+      const fn = cleanupFns.pop();
+      try { fn && fn(); } catch { /* ignore */ }
+    }
+    if (root && root[ROOT_CLEANUP] === destroy) delete root[ROOT_CLEANUP];
+  }
+
+  if (root) root[ROOT_CLEANUP] = destroy;
 
   return {
     formApi: {
@@ -241,6 +288,7 @@ export function renderBlinxForm({
       onDelete: fn => listeners.delete.push(fn),
       onNext: fn => listeners.next.push(fn),
       onPrev: fn => listeners.prev.push(fn),
+      destroy,
     }
   };
 }


### PR DESCRIPTION
Prevent click handler and store subscription accumulation when `renderBlinxForm` is called multiple times on the same root element.

This fixes a bug where repeated calls to `renderBlinxForm` on the same DOM elements would stack event listeners and store subscriptions, leading to non-deterministic behavior in tests and potential runtime issues due to multiple handlers firing for a single event.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a6e4cfc-8687-4bf6-9687-9ab3fb2aa27e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a6e4cfc-8687-4bf6-9687-9ab3fb2aa27e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add cleanup and idempotent binding to avoid accumulating click handlers and store subscriptions when re-rendering the same form root.
> 
> - **Form rendering/cleanup**:
>   - Introduce `ROOT_CLEANUP` and per-render `cleanupFns`; invoke prior root cleanup before re-render.
>   - Add `destroy()` to clear timeouts, unbind all listeners, and detach root cleanup; expose via `formApi.destroy`.
> - **Event binding**:
>   - Add `bindClick()` with `CONTROL_CLICK_BINDINGS` to idempotently attach button click handlers and provide unbind fns.
>   - Replace direct `addEventListener` calls with `bindClick()` for `save/reset/create/delete/next/prev` controls.
> - **Store subscription**:
>   - Capture `unsubscribe` from `store.subscribe(...)` and include in `cleanupFns`.
>   - Preserve existing external change handling and reset coalescing via `pendingResetSync`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0392b138ac2f382643a354697fbcbbbf0d65ca65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->