### PR TITLE
RenderBlinxTable design discussion

### DIFF
--- a/__tests__/blinx.collection.test.js
+++ b/__tests__/blinx.collection.test.js
@@ -1,0 +1,120 @@
+/** @jest-environment jsdom */
+
+import { createBlinxStore } from '../lib/blinx.store.js';
+import { renderBlinxCollection } from '../lib/blinx.collection.js';
+import { BlinxDefaultAdapter } from '../lib/blinx.adapters.default.js';
+
+function setupButtons(ids = {}) {
+  document.body.innerHTML = '';
+  for (const [key, id] of Object.entries(ids)) {
+    if (!id) continue;
+    const el = document.createElement(key.includes('status') ? 'div' : 'button');
+    el.id = id;
+    document.body.appendChild(el);
+  }
+}
+
+describe('renderBlinxCollection', () => {
+  test('renders built-in table layout and supports onItemClick', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = createBlinxStore([{ name: 'A' }, { name: 'B' }], model);
+    const ui = new BlinxDefaultAdapter();
+    const root = document.createElement('div');
+    const onItemClick = jest.fn();
+
+    renderBlinxCollection({
+      root,
+      store,
+      ui,
+      view: { layout: 'table', columns: [{ field: 'name', label: 'Name' }] },
+      paging: { pageSize: 20 },
+      onItemClick,
+    });
+
+    const rows = root.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(2);
+    rows[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onItemClick).toHaveBeenCalledWith({ index: 0, record: { name: 'A' } });
+  });
+
+  test('supports custom layout registry via view.layout key', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = createBlinxStore([{ name: 'A' }], model);
+    const ui = new BlinxDefaultAdapter();
+    const root = document.createElement('div');
+
+    const customLayout = {
+      mount({ root: mountRoot, controller }) {
+        const el = document.createElement('div');
+        el.className = 'custom';
+        mountRoot.appendChild(el);
+        return {
+          update() {
+            const state = controller.getState();
+            el.textContent = `count=${state.items.length};page=${state.page + 1}`;
+          }
+        };
+      }
+    };
+
+    renderBlinxCollection({
+      root,
+      store,
+      ui,
+      view: { layout: 'x-custom' },
+      layouts: { 'x-custom': customLayout },
+      paging: { pageSize: 20 },
+    });
+
+    expect(root.querySelector('.custom').textContent).toBe('count=1;page=1');
+    store.addRecord({ name: 'B' });
+    expect(root.querySelector('.custom').textContent).toBe('count=2;page=1');
+  });
+
+  test('create/deleteSelected actions + interceptors work via external controls', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = createBlinxStore([{ name: 'A' }], model);
+    const ui = new BlinxDefaultAdapter();
+    const root = document.createElement('div');
+
+    setupButtons({ createBtn: 'create', deleteBtn: 'del', status: 'status' });
+
+    const { api } = renderBlinxCollection({
+      root,
+      store,
+      ui,
+      view: { layout: 'table', columns: [{ field: 'name', label: 'Name' }] },
+      paging: { pageSize: 20 },
+      controls: {
+        createButtonId: 'create',
+        deleteSelectedButtonId: 'del',
+        statusId: 'status',
+      }
+    });
+
+    api.onCreate(async ({ proceed }) => {
+      // block default create
+      void proceed;
+    });
+
+    document.getElementById('create').click();
+    await Promise.resolve();
+    expect(store.getLength()).toBe(1);
+
+    // allow create now
+    api.onCreate(async ({ proceed }) => proceed());
+    document.getElementById('create').click();
+    await Promise.resolve();
+    expect(store.getLength()).toBe(2);
+
+    // select first row and delete selected
+    const firstRowCb = root.querySelector('tbody tr input[type="checkbox"]');
+    firstRowCb.checked = true;
+    firstRowCb.dispatchEvent(new Event('change', { bubbles: true }));
+
+    document.getElementById('del').click();
+    await Promise.resolve();
+    expect(store.getLength()).toBe(1);
+  });
+});
+

--- a/__tests__/blinx.collection.test.js
+++ b/__tests__/blinx.collection.test.js
@@ -37,6 +37,39 @@ describe('renderBlinxCollection', () => {
     expect(onItemClick).toHaveBeenCalledWith({ index: 0, record: { name: 'A' } });
   });
 
+  test('single selection mode refreshes UI so only one checkbox stays checked', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = createBlinxStore([{ name: 'A' }, { name: 'B' }], model);
+    const ui = new BlinxDefaultAdapter();
+    const root = document.createElement('div');
+
+    renderBlinxCollection({
+      root,
+      store,
+      ui,
+      view: { layout: 'table', columns: [{ field: 'name', label: 'Name' }] },
+      paging: { pageSize: 20 },
+      selection: { mode: 'single' },
+    });
+
+    let cbs = root.querySelectorAll('tbody tr input[type="checkbox"]');
+    expect(cbs.length).toBe(2);
+
+    cbs[0].checked = true;
+    cbs[0].dispatchEvent(new Event('change', { bubbles: true }));
+
+    cbs = root.querySelectorAll('tbody tr input[type="checkbox"]');
+    expect(cbs[0].checked).toBe(true);
+    expect(cbs[1].checked).toBe(false);
+
+    cbs[1].checked = true;
+    cbs[1].dispatchEvent(new Event('change', { bubbles: true }));
+
+    cbs = root.querySelectorAll('tbody tr input[type="checkbox"]');
+    expect(cbs[0].checked).toBe(false);
+    expect(cbs[1].checked).toBe(true);
+  });
+
   test('supports custom layout registry via view.layout key', () => {
     const model = { fields: { name: { type: 'string' } } };
     const store = createBlinxStore([{ name: 'A' }], model);

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -1,0 +1,492 @@
+import { EventTypes } from './blinx.store.js';
+
+const ROOT_CLEANUP = Symbol('blinxCollectionCleanup');
+
+function getDomControls(controls = {}) {
+  return {
+    createBtn: controls.createButtonId ? document.getElementById(controls.createButtonId) : null,
+    deleteSelectedBtn: controls.deleteSelectedButtonId ? document.getElementById(controls.deleteSelectedButtonId) : null,
+    status: controls.statusId ? document.getElementById(controls.statusId) : null,
+    prevBtn: controls.prevButtonId ? document.getElementById(controls.prevButtonId) : null,
+    nextBtn: controls.nextButtonId ? document.getElementById(controls.nextButtonId) : null,
+    pageLabel: controls.pageLabelId ? document.getElementById(controls.pageLabelId) : null,
+  };
+}
+
+function setStatus(dom, msg, color = '#4a5568') {
+  if (!dom.status) return;
+  dom.status.textContent = msg;
+  dom.status.style.color = color;
+}
+
+function createInternalPager(root) {
+  const toolbar = document.createElement('div');
+  toolbar.className = 'flex';
+  const prevBtn = document.createElement('button'); prevBtn.className = 'btn'; prevBtn.textContent = 'Prev';
+  const nextBtn = document.createElement('button'); nextBtn.className = 'btn'; nextBtn.textContent = 'Next';
+  const pageLabel = document.createElement('span'); pageLabel.textContent = 'Page: 1';
+  toolbar.append(prevBtn, nextBtn, pageLabel);
+  root.appendChild(toolbar);
+  return { prevBtn, nextBtn, pageLabel, toolbar };
+}
+
+function defaultExternalStatusMessages(layout) {
+  // Preserve historic table phrasing for backwards compatibility and tests.
+  if (layout === 'table') {
+    return {
+      [EventTypes.add]: 'Rows added elsewhere; refreshed table.',
+      [EventTypes.remove]: 'Rows removed elsewhere; refreshed table.',
+      [EventTypes.update]: 'Rows updated elsewhere; refreshed table.',
+      [EventTypes.commit]: 'Changes committed elsewhere; refreshed table.',
+      [EventTypes.reset]: 'Store reset elsewhere; refreshed table.',
+    };
+  }
+  return {
+    [EventTypes.add]: 'Items added elsewhere; refreshed view.',
+    [EventTypes.remove]: 'Items removed elsewhere; refreshed view.',
+    [EventTypes.update]: 'Items updated elsewhere; refreshed view.',
+    [EventTypes.commit]: 'Changes committed elsewhere; refreshed view.',
+    [EventTypes.reset]: 'Store reset elsewhere; refreshed view.',
+  };
+}
+
+function resolveLayout(layout, builtins, customLayouts) {
+  if (typeof layout === 'function') return { mount: layout };
+  if (layout && typeof layout === 'object' && typeof layout.mount === 'function') return layout;
+  const key = layout || 'table';
+  return customLayouts[key] || builtins[key];
+}
+
+function createTableLayout() {
+  return {
+    mount({ root, model, view, ui, controller, onItemClick }) {
+      const table = document.createElement('table');
+      const thead = document.createElement('thead');
+      const thr = document.createElement('tr');
+      const thSel = document.createElement('th'); thSel.textContent = 'Sel'; thr.appendChild(thSel);
+      (view.columns || []).forEach(col => {
+        const th = document.createElement('th');
+        th.textContent = col.label;
+        thr.appendChild(th);
+      });
+      thead.appendChild(thr);
+      table.appendChild(thead);
+      const tbody = document.createElement('tbody');
+      table.appendChild(tbody);
+      root.appendChild(table);
+
+      function update() {
+        tbody.innerHTML = '';
+        const { items } = controller.getState();
+        const frag = document.createDocumentFragment();
+        for (const { index, record } of items) {
+          const tr = document.createElement('tr');
+          const tdSel = document.createElement('td');
+          const cb = document.createElement('input');
+          cb.type = 'checkbox';
+          cb.checked = controller.isSelected(index);
+          cb.addEventListener('change', () => controller.toggleSelected(index, cb.checked));
+          tdSel.appendChild(cb);
+          tr.appendChild(tdSel);
+
+          if (onItemClick) {
+            tr.addEventListener('click', e => {
+              if (e.target !== cb) onItemClick({ index, record });
+            });
+          }
+
+          (view.columns || []).forEach(col => {
+            const td = document.createElement('td');
+            td.textContent = ui.formatCell(record?.[col.field], model.fields[col.field]);
+            tr.appendChild(td);
+          });
+          frag.appendChild(tr);
+        }
+        tbody.appendChild(frag);
+      }
+
+      return {
+        update,
+        destroy: () => { /* no-op */ },
+      };
+    }
+  };
+}
+
+function createCardsLayout() {
+  return {
+    mount({ root, view, controller, onItemClick }) {
+      const grid = document.createElement('div');
+      grid.className = 'blinx-grid';
+      root.appendChild(grid);
+
+      function update() {
+        grid.innerHTML = '';
+        const { items } = controller.getState();
+        const frag = document.createDocumentFragment();
+        for (const { index, record } of items) {
+          const card = document.createElement('article');
+          card.className = 'blinx-card';
+
+          const titleField = view.item?.titleField;
+          if (titleField) {
+            const h = document.createElement('header');
+            h.className = 'blinx-card__title';
+            h.textContent = record?.[titleField] ?? '';
+            card.appendChild(h);
+          }
+
+          if (onItemClick) card.addEventListener('click', () => onItemClick({ index, record }));
+          frag.appendChild(card);
+        }
+        grid.appendChild(frag);
+      }
+
+      return { update, destroy: () => {} };
+    }
+  };
+}
+
+function createFeedLayout() {
+  return {
+    mount({ root, view, controller, onItemClick }) {
+      const list = document.createElement('div');
+      list.className = 'blinx-feed';
+      root.appendChild(list);
+
+      function update() {
+        list.innerHTML = '';
+        const { items } = controller.getState();
+        const frag = document.createDocumentFragment();
+        for (const { index, record } of items) {
+          const item = document.createElement('article');
+          item.className = 'blinx-feedItem';
+          const titleField = view.item?.titleField;
+          const bodyField = view.item?.bodyField;
+          if (titleField) {
+            const h = document.createElement('h3');
+            h.textContent = record?.[titleField] ?? '';
+            item.appendChild(h);
+          }
+          if (bodyField) {
+            const p = document.createElement('p');
+            p.textContent = record?.[bodyField] ?? '';
+            item.appendChild(p);
+          }
+          if (onItemClick) item.addEventListener('click', () => onItemClick({ index, record }));
+          frag.appendChild(item);
+        }
+        list.appendChild(frag);
+      }
+
+      return { update, destroy: () => {} };
+    }
+  };
+}
+
+/**
+ * Generic, extensible multi-record renderer.
+ *
+ * Layouts can be:
+ * - built-in string: 'table' | 'cards' | 'feed'
+ * - custom string key resolved via `layouts`
+ * - a layout object: { mount({ root, controller, ... }) => { update(), destroy? } }
+ */
+export function renderBlinxCollection({
+  root,
+  view,
+  store,
+  ui,
+  paging = {},
+  selection = { mode: 'multi' },
+  actions = { create: true, deleteSelected: true },
+  controls = {},
+  layouts = {},
+  onItemClick,
+}) {
+  if (!store || typeof store.getModel !== 'function') {
+    throw new Error('renderBlinxCollection requires a store that exposes getModel().');
+  }
+  const model = store.getModel();
+  if (!model || !model.fields) {
+    throw new Error('renderBlinxCollection requires the store model to define fields.');
+  }
+  if (!root) throw new Error('renderBlinxCollection requires a root element.');
+  if (!view) throw new Error('renderBlinxCollection requires a view.');
+  if (!ui) throw new Error('renderBlinxCollection requires a ui adapter.');
+
+  // If the same root is re-rendered, clean up prior subscriptions/handlers first.
+  if (root && typeof root[ROOT_CLEANUP] === 'function') {
+    try { root[ROOT_CLEANUP](); } catch { /* ignore */ }
+  }
+
+  root.innerHTML = '';
+
+  const layoutKey = typeof view.layout === 'string' ? view.layout : (view.layout ? 'custom' : 'table');
+  const builtins = {
+    table: createTableLayout(),
+    cards: createCardsLayout(),
+    feed: createFeedLayout(),
+  };
+  const layout = resolveLayout(view.layout, builtins, layouts);
+  if (!layout || typeof layout.mount !== 'function') {
+    throw new Error(`Unknown layout "${String(view.layout)}".`);
+  }
+
+  let pageSize = Number.isFinite(paging.pageSize) ? paging.pageSize : 20;
+  let page = Number.isFinite(paging.page) ? paging.page : 0;
+  let selected = new Set();
+  let internalChangeDepth = 0;
+  let pendingResetSync = null;
+  const cleanupFns = [];
+
+  const dom = getDomControls(controls);
+  let internalPager = null;
+  const trackedStoreEvents = new Set([
+    EventTypes.add,
+    EventTypes.remove,
+    EventTypes.update,
+    EventTypes.commit,
+    EventTypes.reset,
+  ]);
+  const externalStatusMessages = defaultExternalStatusMessages(layoutKey);
+
+  function runInternalChange(fn) {
+    internalChangeDepth += 1;
+    try {
+      return fn();
+    } finally {
+      internalChangeDepth = Math.max(0, internalChangeDepth - 1);
+    }
+  }
+
+  function getDataSnapshot() {
+    return store.toJSON();
+  }
+
+  function getMaxPage(len) {
+    if (len <= 0) return 0;
+    return Math.max(0, Math.ceil(len / pageSize) - 1);
+  }
+
+  function pruneSelection(len) {
+    const next = new Set();
+    selected.forEach(idx => {
+      if (idx >= 0 && idx < len) next.add(idx);
+    });
+    selected = next;
+  }
+
+  function getItemsForCurrentPage(data) {
+    const maxPage = getMaxPage(data.length);
+    page = Math.min(Math.max(page, 0), maxPage);
+    pruneSelection(data.length);
+    const start = page * pageSize;
+    const end = Math.min(data.length, start + pageSize);
+    const items = [];
+    for (let i = start; i < end; i++) items.push({ index: i, record: data[i] });
+    return { items, start, end, total: data.length, maxPage };
+  }
+
+  function updatePagerLabel() {
+    const labelEl = dom.pageLabel || internalPager?.pageLabel;
+    if (labelEl) labelEl.textContent = `Page: ${page + 1}`;
+  }
+
+  function refresh() {
+    const data = getDataSnapshot();
+    const { items } = getItemsForCurrentPage(data);
+    layoutApi.update();
+    updatePagerLabel();
+    return items;
+  }
+
+  function isSelected(index) {
+    return selected.has(index);
+  }
+
+  function toggleSelected(index, checked) {
+    if (selection?.mode === 'none') return;
+    if (selection?.mode === 'single') selected.clear();
+    if (checked) selected.add(index);
+    else selected.delete(index);
+  }
+
+  const listeners = { create: [], deleteSelected: [] };
+
+  async function runInterceptors(type, executor) {
+    const procs = listeners[type];
+    let executed = false;
+    const data = getDataSnapshot();
+    const { items, start, end, total } = getItemsForCurrentPage(data);
+    const processor = {
+      state: {
+        page,
+        pageSize,
+        selected: new Set(selected),
+        selectionMode: selection?.mode || 'multi',
+        visibleRange: { start, end },
+        total,
+        items,
+        store,
+      },
+      controls: dom,
+      proceed: async () => { if (executed) return; executed = true; return executor(); }
+    };
+    if (procs.length === 0) return processor.proceed();
+    for (const fn of procs) await fn(processor);
+  }
+
+  async function doCreate() {
+    runInternalChange(() => store.addRecord(Object.fromEntries(Object.keys(model.fields).map(k => [k, '']))));
+    refresh();
+    setStatus(dom, 'New row created.', '#2f855a');
+  }
+
+  async function doDeleteSelected() {
+    if (selected.size === 0) return setStatus(dom, 'No rows selected.', '#e53e3e');
+    runInternalChange(() => store.removeRecords(Array.from(selected)));
+    selected.clear();
+    refresh();
+    setStatus(dom, 'Selected rows deleted.', '#2f855a');
+  }
+
+  function handleExternalStoreEvent(action) {
+    const message = externalStatusMessages[action] || 'Data changed externally; refreshed view.';
+    setStatus(dom, message, '#3182ce');
+  }
+
+  function scheduleResetRefresh(action) {
+    if (pendingResetSync) return;
+    pendingResetSync = setTimeout(() => {
+      pendingResetSync = null;
+      refresh();
+      handleExternalStoreEvent(action);
+    }, 0);
+  }
+
+  function bindPagerButtons() {
+    const prevEl = dom.prevBtn || internalPager?.prevBtn;
+    const nextEl = dom.nextBtn || internalPager?.nextBtn;
+    if (prevEl) {
+      const onPrev = () => { page = Math.max(0, page - 1); refresh(); };
+      prevEl.addEventListener('click', onPrev);
+      cleanupFns.push(() => prevEl.removeEventListener('click', onPrev));
+    }
+    if (nextEl) {
+      const onNext = () => {
+        const maxPage = Math.floor((store.getLength() - 1) / pageSize);
+        page = Math.min(maxPage, page + 1);
+        refresh();
+      };
+      nextEl.addEventListener('click', onNext);
+      cleanupFns.push(() => nextEl.removeEventListener('click', onNext));
+    }
+  }
+
+  function bindActionButtons() {
+    if (dom.createBtn && actions?.create) {
+      const onCreate = () => runInterceptors('create', doCreate);
+      dom.createBtn.addEventListener('click', onCreate);
+      cleanupFns.push(() => dom.createBtn.removeEventListener('click', onCreate));
+    }
+    if (dom.deleteSelectedBtn && actions?.deleteSelected) {
+      const onDeleteSelected = () => runInterceptors('deleteSelected', doDeleteSelected);
+      dom.deleteSelectedBtn.addEventListener('click', onDeleteSelected);
+      cleanupFns.push(() => dom.deleteSelectedBtn.removeEventListener('click', onDeleteSelected));
+    }
+  }
+
+  // If external pager controls are not provided, mount internal pager by default.
+  if (!dom.prevBtn && !dom.nextBtn && !dom.pageLabel) {
+    internalPager = createInternalPager(root);
+    cleanupFns.push(() => {
+      try { internalPager?.toolbar?.remove(); } catch { /* ignore */ }
+      internalPager = null;
+    });
+  }
+
+  const controller = {
+    getState: () => {
+      const data = getDataSnapshot();
+      const { items, start, end, total, maxPage } = getItemsForCurrentPage(data);
+      return {
+        page,
+        pageSize,
+        selected: new Set(selected),
+        selectionMode: selection?.mode || 'multi',
+        visibleRange: { start, end },
+        total,
+        maxPage,
+        items,
+      };
+    },
+    setPage: (next) => {
+      page = Math.max(0, Number(next) || 0);
+      refresh();
+    },
+    isSelected,
+    toggleSelected,
+    clearSelection: () => { selected.clear(); refresh(); },
+    runInternalChange,
+  };
+
+  const layoutApi = layout.mount({
+    root,
+    model,
+    view,
+    ui,
+    controller,
+    onItemClick,
+  });
+
+  if (!layoutApi || typeof layoutApi.update !== 'function') {
+    throw new Error('Layout mount() must return an object with update().');
+  }
+  cleanupFns.push(() => { try { layoutApi.destroy && layoutApi.destroy(); } catch { /* ignore */ } });
+
+  bindPagerButtons();
+  bindActionButtons();
+
+  const unsubscribe = store.subscribe(ev => {
+    if (internalChangeDepth > 0) return;
+    if (!ev || !Array.isArray(ev.path)) {
+      refresh();
+      return;
+    }
+    const [action] = ev.path;
+    if (action === EventTypes.reset) {
+      scheduleResetRefresh(action);
+      return;
+    }
+    refresh();
+    if (trackedStoreEvents.has(action)) handleExternalStoreEvent(action);
+  });
+  if (typeof unsubscribe === 'function') cleanupFns.push(unsubscribe);
+
+  refresh();
+
+  function destroy() {
+    if (pendingResetSync) {
+      clearTimeout(pendingResetSync);
+      pendingResetSync = null;
+    }
+    while (cleanupFns.length) {
+      const fn = cleanupFns.pop();
+      try { fn && fn(); } catch { /* ignore */ }
+    }
+    if (root && root[ROOT_CLEANUP] === destroy) delete root[ROOT_CLEANUP];
+  }
+  root[ROOT_CLEANUP] = destroy;
+
+  return {
+    api: {
+      onCreate: fn => listeners.create.push(fn),
+      onDeleteSelected: fn => listeners.deleteSelected.push(fn),
+      setPage: controller.setPage,
+      getState: controller.getState,
+      destroy,
+    }
+  };
+}
+

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -307,9 +307,13 @@ export function renderBlinxCollection({
 
   function toggleSelected(index, checked) {
     if (selection?.mode === 'none') return;
-    if (selection?.mode === 'single') selected.clear();
+    const needsRefresh = selection?.mode === 'single';
+    if (needsRefresh) selected.clear();
     if (checked) selected.add(index);
     else selected.delete(index);
+    // In single-selection mode, selecting a new row invalidates other rows' checked state,
+    // so we must refresh to keep the UI in sync.
+    if (needsRefresh) refresh();
   }
 
   const listeners = { create: [], deleteSelected: [] };

--- a/lib/blinx.table.js
+++ b/lib/blinx.table.js
@@ -1,5 +1,5 @@
 
-import { EventTypes } from './blinx.store.js';
+import { renderBlinxCollection } from './blinx.collection.js';
 
 export function renderBlinxTable({
   root, view, store, ui,
@@ -11,6 +11,7 @@ export function renderBlinxTable({
     statusId: null,
   }
 }) {
+  // Preserve existing error messages for compatibility.
   if (!store || typeof store.getModel !== 'function') {
     throw new Error('renderBlinxTable requires a store that exposes getModel().');
   }
@@ -19,170 +20,23 @@ export function renderBlinxTable({
     throw new Error('renderBlinxTable requires the store model to define fields.');
   }
 
-  root.innerHTML = '';
-  let page = 0;
-  let selected = new Set();
-  let internalChangeDepth = 0;
-  let pendingResetSync = null;
-
-  const trackedStoreEvents = new Set([
-    EventTypes.add,
-    EventTypes.remove,
-    EventTypes.update,
-    EventTypes.commit,
-    EventTypes.reset,
-  ]);
-
-  const externalStatusMessages = {
-    [EventTypes.add]: 'Rows added elsewhere; refreshed table.',
-    [EventTypes.remove]: 'Rows removed elsewhere; refreshed table.',
-    [EventTypes.update]: 'Rows updated elsewhere; refreshed table.',
-    [EventTypes.commit]: 'Changes committed elsewhere; refreshed table.',
-    [EventTypes.reset]: 'Store reset elsewhere; refreshed table.',
-  };
-
-  const dom = {
-    createBtn: controls.createButtonId ? document.getElementById(controls.createButtonId) : null,
-    deleteSelectedBtn: controls.deleteSelectedButtonId ? document.getElementById(controls.deleteSelectedButtonId) : null,
-    status: controls.statusId ? document.getElementById(controls.statusId) : null,
-  };
-
-  function setStatus(msg, color = '#4a5568') {
-    if (!dom.status) return;
-    dom.status.textContent = msg;
-    dom.status.style.color = color;
-  }
-
-  function runInternalChange(fn) {
-    internalChangeDepth += 1;
-    try {
-      return fn();
-    } finally {
-      internalChangeDepth = Math.max(0, internalChangeDepth - 1);
-    }
-  }
-
-  const toolbar = document.createElement('div');
-  toolbar.className = 'flex';
-  const prevBtn = document.createElement('button'); prevBtn.className = 'btn'; prevBtn.textContent = 'Prev';
-  const nextBtn = document.createElement('button'); nextBtn.className = 'btn'; nextBtn.textContent = 'Next';
-  const pageLabel = document.createElement('span'); pageLabel.textContent = `Page: ${page + 1}`;
-  toolbar.append(prevBtn, nextBtn, pageLabel);
-  root.appendChild(toolbar);
-
-  const table = document.createElement('table');
-  const thead = document.createElement('thead');
-  const thr = document.createElement('tr');
-  const thSel = document.createElement('th'); thSel.textContent = 'Sel'; thr.appendChild(thSel);
-  view.columns.forEach(col => { const th = document.createElement('th'); th.textContent = col.label; thr.appendChild(th); });
-  thead.appendChild(thr);
-  table.appendChild(thead);
-  const tbody = document.createElement('tbody');
-  table.appendChild(tbody);
-  root.appendChild(table);
-
-  function renderPage() {
-    tbody.innerHTML = '';
-    const data = store.toJSON();
-    const maxPage = data.length === 0 ? 0 : Math.max(0, Math.ceil(data.length / pageSize) - 1);
-    page = Math.min(Math.max(page, 0), maxPage);
-    const prunedSelection = new Set();
-    selected.forEach(idx => { if (idx >= 0 && idx < data.length) prunedSelection.add(idx); });
-    selected = prunedSelection;
-    const start = page * pageSize;
-    const end = Math.min(data.length, start + pageSize);
-    const frag = document.createDocumentFragment();
-
-    for (let i = start; i < end; i++) {
-      const tr = document.createElement('tr');
-      const tdSel = document.createElement('td');
-      const cb = document.createElement('input'); cb.type = 'checkbox'; cb.checked = selected.has(i);
-      cb.addEventListener('change', () => { cb.checked ? selected.add(i) : selected.delete(i); });
-      tdSel.appendChild(cb);
-      tr.appendChild(tdSel);
-
-      if (onRowClick) tr.addEventListener('click', e => { if (e.target !== cb) onRowClick(i); });
-
-      view.columns.forEach(col => {
-        const td = document.createElement('td');
-        td.textContent = ui.formatCell(data[i][col.field], model.fields[col.field]);
-        tr.appendChild(td);
-      });
-
-      frag.appendChild(tr);
-    }
-    tbody.appendChild(frag);
-    pageLabel.textContent = `Page: ${page + 1}`;
-  }
-
-  prevBtn.addEventListener('click', () => { page = Math.max(0, page - 1); renderPage(); });
-  nextBtn.addEventListener('click', () => { const maxPage = Math.floor((store.getLength() - 1) / pageSize); page = Math.min(maxPage, page + 1); renderPage(); });
-
-  const listeners = { create: [], deleteSelected: [] };
-
-  async function runInterceptors(type, executor) {
-    const procs = listeners[type];
-    let executed = false;
-    const processor = {
-      state: { page, selected: new Set(selected), store },
-      controls: dom,
-      proceed: async () => { if (executed) return; executed = true; return executor(); }
-    };
-    if (procs.length === 0) return processor.proceed();
-    for (const fn of procs) await fn(processor);
-  }
-
-  async function doCreate() {
-    runInternalChange(() => store.addRecord(Object.fromEntries(Object.keys(model.fields).map(k => [k, '']))));
-    renderPage();
-    setStatus('New row created.', '#2f855a');
-  }
-
-  async function doDeleteSelected() {
-    if (selected.size === 0) return setStatus('No rows selected.', '#e53e3e');
-    runInternalChange(() => store.removeRecords(Array.from(selected)));
-    selected.clear();
-    renderPage();
-    setStatus('Selected rows deleted.', '#2f855a');
-  }
-
-  if (dom.createBtn) dom.createBtn.addEventListener('click', () => runInterceptors('create', doCreate));
-  if (dom.deleteSelectedBtn) dom.deleteSelectedBtn.addEventListener('click', () => runInterceptors('deleteSelected', doDeleteSelected));
-
-  function handleExternalStoreEvent(action) {
-    const message = externalStatusMessages[action] || 'Table data changed externally; refreshed view.';
-    setStatus(message, '#3182ce');
-  }
-
-  function scheduleResetRefresh(action) {
-    if (pendingResetSync) return;
-    pendingResetSync = setTimeout(() => {
-      pendingResetSync = null;
-      renderPage();
-      handleExternalStoreEvent(action);
-    }, 0);
-  }
-
-  store.subscribe(ev => {
-    if (internalChangeDepth > 0) return;
-    if (!ev || !Array.isArray(ev.path)) {
-      renderPage();
-      return;
-    }
-    const [action] = ev.path;
-    if (action === EventTypes.reset) {
-      scheduleResetRefresh(action);
-      return;
-    }
-    renderPage();
-    if (trackedStoreEvents.has(action)) handleExternalStoreEvent(action);
+  const { api } = renderBlinxCollection({
+    root,
+    store,
+    ui,
+    view: { ...view, layout: 'table' },
+    paging: { pageSize, page: 0 },
+    selection: { mode: 'multi' },
+    actions: { create: true, deleteSelected: true },
+    controls,
+    onItemClick: onRowClick ? ({ index }) => onRowClick(index) : null,
   });
-  renderPage();
 
   return {
     tableApi: {
-      onCreate: fn => listeners.create.push(fn),
-      onDeleteSelected: fn => listeners.deleteSelected.push(fn),
+      onCreate: fn => api.onCreate(fn),
+      onDeleteSelected: fn => api.onDeleteSelected(fn),
+      destroy: () => api.destroy(),
     }
   };
 }


### PR DESCRIPTION
Introduce `renderBlinxCollection` for extensible multi-record layouts and refactor `renderBlinxTable` as a compatibility wrapper.

The original `renderBlinxTable` tightly coupled collection control (paging, selection) with table-specific DOM rendering, preventing easy extension to other multi-record displays like card grids or news feeds. This PR extracts a layout-agnostic collection controller and introduces a layout registry, making the system extensible while maintaining backward compatibility for `renderBlinxTable`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ef71312-5090-4fd7-a9e6-7f36f7eb4d89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ef71312-5090-4fd7-a9e6-7f36f7eb4d89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an extensible multi-record renderer with built-in layouts (table/cards/feed), selection, paging, external controls, and refactors renderBlinxTable to delegate to it.
> 
> - **Core**:
>   - Add `renderBlinxCollection` with layout-agnostic controller: paging, selection modes (`multi`/`single`/`none`), actions (`create`/`deleteSelected`) with interceptors, external/internal pager controls, status updates on store events, and `onItemClick`.
>   - Support built-in layouts: `table`, `cards`, `feed`; resolve custom layouts via `layouts` registry or function/object.
> - **Table**:
>   - Refactor `renderBlinxTable` to a thin wrapper over `renderBlinxCollection`, preserving error messages and exposing mapped API (`onCreate`, `onDeleteSelected`, `destroy`).
> - **Tests**:
>   - Add `__tests__/blinx.collection.test.js` covering table layout click handling, single-selection refresh behavior, custom layout registry, and actions/interceptors via external controls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8112579d9d4ef68dad052c619c1b28ba91b8db4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->