### PR TITLE
Single selection UI refresh

### DIFF
--- a/__tests__/blinx.collection.test.js
+++ b/__tests__/blinx.collection.test.js
@@ -37,6 +37,39 @@ describe('renderBlinxCollection', () => {
     expect(onItemClick).toHaveBeenCalledWith({ index: 0, record: { name: 'A' } });
   });
 
+  test('single selection mode refreshes UI so only one checkbox stays checked', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = createBlinxStore([{ name: 'A' }, { name: 'B' }], model);
+    const ui = new BlinxDefaultAdapter();
+    const root = document.createElement('div');
+
+    renderBlinxCollection({
+      root,
+      store,
+      ui,
+      view: { layout: 'table', columns: [{ field: 'name', label: 'Name' }] },
+      paging: { pageSize: 20 },
+      selection: { mode: 'single' },
+    });
+
+    let cbs = root.querySelectorAll('tbody tr input[type="checkbox"]');
+    expect(cbs.length).toBe(2);
+
+    cbs[0].checked = true;
+    cbs[0].dispatchEvent(new Event('change', { bubbles: true }));
+
+    cbs = root.querySelectorAll('tbody tr input[type="checkbox"]');
+    expect(cbs[0].checked).toBe(true);
+    expect(cbs[1].checked).toBe(false);
+
+    cbs[1].checked = true;
+    cbs[1].dispatchEvent(new Event('change', { bubbles: true }));
+
+    cbs = root.querySelectorAll('tbody tr input[type="checkbox"]');
+    expect(cbs[0].checked).toBe(false);
+    expect(cbs[1].checked).toBe(true);
+  });
+
   test('supports custom layout registry via view.layout key', () => {
     const model = { fields: { name: { type: 'string' } } };
     const store = createBlinxStore([{ name: 'A' }], model);

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -307,9 +307,13 @@ export function renderBlinxCollection({
 
   function toggleSelected(index, checked) {
     if (selection?.mode === 'none') return;
-    if (selection?.mode === 'single') selected.clear();
+    const needsRefresh = selection?.mode === 'single';
+    if (needsRefresh) selected.clear();
     if (checked) selected.add(index);
     else selected.delete(index);
+    // In single-selection mode, selecting a new row invalidates other rows' checked state,
+    // so we must refresh to keep the UI in sync.
+    if (needsRefresh) refresh();
   }
 
   const listeners = { create: [], deleteSelected: [] };


### PR DESCRIPTION
Fix: Single selection mode now refreshes the UI properly.

`toggleSelected()` now calls `refresh()` when `selection.mode === 'single'`, ensuring that previously selected checkboxes are visually unchecked when a new row is selected. This resolves a bug where the UI would not update, showing multiple checkboxes as checked despite only one being truly selected. A new Jest test covers this behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-24ae3c87-4ede-49bc-b169-fc9ad31ad0bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-24ae3c87-4ede-49bc-b169-fc9ad31ad0bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure single-selection mode refreshes so only one checkbox remains checked.
> 
> - **Core (`lib/blinx.collection.js`)**:
>   - Update `toggleSelected()` to clear selection and call `refresh()` when `selection.mode === 'single'`, keeping checkbox states in sync.
> - **Tests (`__tests__/blinx.collection.test.js`)**:
>   - Add test verifying single-selection mode re-renders so only one checkbox stays checked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69e2e5dfc1fece5797ffa375c29fe690934f6d3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->