### PR TITLE
BlinxCollection ui param cleanup

### DIFF
--- a/__tests__/blinx.collection.test.js
+++ b/__tests__/blinx.collection.test.js
@@ -14,6 +14,19 @@ function setupButtons(ids = {}) {
 }
 
 describe('blinxCollection', () => {
+  test('does not accept legacy ui parameter', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+
+    expect(() => blinxCollection({
+      root,
+      store,
+      view: { layout: 'table', columns: [{ field: 'name', label: 'Name' }] },
+      ui: { any: 'thing' },
+    })).toThrow('does not accept a ui parameter');
+  });
+
   test('renders built-in table layout and supports onItemClick', () => {
     const model = { fields: { name: { type: 'string' } } };
     const store = blinxStore([{ name: 'A' }, { name: 'B' }], model);

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -199,14 +199,13 @@ export function blinxCollection({
   root,
   view,
   store,
-  ui,
   paging = {},
   selection = { mode: 'multi' },
   actions = { create: true, deleteSelected: true },
   controls = {},
   layouts = {},
   onItemClick,
-}) {
+} = {}) {
   if (!store || typeof store.getModel !== 'function') {
     throw new Error('blinxCollection requires a store that exposes getModel().');
   }
@@ -216,8 +215,10 @@ export function blinxCollection({
   }
   if (!root) throw new Error('blinxCollection requires a root element.');
   if (!view) throw new Error('blinxCollection requires a view.');
-  if (ui !== undefined) {
-    throw new Error('blinxCollection no longer accepts a ui parameter. Use RegisteredUI.register() and view/field renderer names instead.');
+  // Note: legacy API used to accept `ui`. It is intentionally not supported anymore.
+  // If callers still pass it, fail fast with a helpful message.
+  if (Object.prototype.hasOwnProperty.call(arguments?.[0] || {}, 'ui')) {
+    throw new Error('blinxCollection does not accept a ui parameter. Use RegisteredUI.register() and view/field renderer names instead.');
   }
 
   RegisteredUI.__internal_onRenderStart();


### PR DESCRIPTION
Remove unused `ui` parameter from `blinxCollection` to align with current `RegisteredUI.register()` approach.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c42dc8b-f017-44ad-b601-1dd814a1192f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c42dc8b-f017-44ad-b601-1dd814a1192f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the legacy `ui` parameter from `blinxCollection` and adds a fail-fast error when it’s passed; adds a test to assert the rejection.
> 
> - **Core (`lib/blinx.collection.js`)**:
>   - Remove `ui` from `blinxCollection` options and default-destructure args (`= {}`).
>   - Add explicit check for a passed `ui` key and throw: `does not accept a ui parameter`.
>   - Keep `RegisteredUI` usage; no behavior changes to layouts, paging, selection, or actions.
> - **Tests (`__tests__/blinx.collection.test.js`)**:
>   - Add test verifying legacy `ui` parameter is rejected with the expected error message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aa4f6af3c57143d3da47e8dc955462f3f8e6033. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->