### PR TITLE
Render strict mode bypass

### DIFF
--- a/__tests__/blinx.registered-ui.strict-mode.test.js
+++ b/__tests__/blinx.registered-ui.strict-mode.test.js
@@ -1,0 +1,39 @@
+/**
+ * These tests validate RegisteredUI strict-mode behavior.
+ *
+ * IMPORTANT: RegisteredUI is stateful at module scope, so tests use fresh imports.
+ */
+
+describe('RegisteredUI strict mode', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('does not bypass strict-mode check after a failed render start', async () => {
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+
+    RegisteredUI.requireLockBeforeRender(true);
+
+    expect(() => RegisteredUI.__internal_onRenderStart())
+      .toThrow('RegisteredUI is not locked. Call RegisteredUI.lock() before rendering.');
+
+    // Regression: a failed strict-mode check must not mark render as started.
+    // If it did, the second call would return early and not throw.
+    expect(() => RegisteredUI.__internal_onRenderStart())
+      .toThrow('RegisteredUI is not locked. Call RegisteredUI.lock() before rendering.');
+  });
+
+  test('when locked first, strict-mode allows render start and prevents further registration', async () => {
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+
+    RegisteredUI.lock();
+    RegisteredUI.requireLockBeforeRender(true);
+
+    expect(() => RegisteredUI.__internal_onRenderStart()).not.toThrow();
+
+    expect(() => RegisteredUI.register('x-test', {
+      createField() {},
+      formatCell() {},
+    })).toThrow('RegisteredUI is locked. Renderer registration is disabled.');
+  });
+});

--- a/lib/blinx.registered-ui.js
+++ b/lib/blinx.registered-ui.js
@@ -27,11 +27,12 @@ let requireLockBeforeRender = false;
 
 function onRenderStart() {
   if (renderStarted) return;
-  renderStarted = true;
 
   if (requireLockBeforeRender && !locked) {
     throw new Error('RegisteredUI is not locked. Call RegisteredUI.lock() before rendering.');
   }
+
+  renderStarted = true;
 
   // Safety-by-default: once any component renders, prevent further mutation.
   locked = true;


### PR DESCRIPTION
Reorder `renderStarted` flag assignment to fix strict-mode check bypass after a failed render.

A failed strict-mode check in `onRenderStart` previously set `renderStarted` to true, causing subsequent render attempts to return early and bypass the strict-mode lock check entirely. This change ensures `renderStarted` is only set after the lock requirement passes.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b8f8198-fe55-4162-8ccd-aa4312cd8824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b8f8198-fe55-4162-8ccd-aa4312cd8824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders `renderStarted` assignment to occur after the strict-mode lock check and adds tests to validate behavior.
> 
> - **Core logic**:
>   - In `lib/blinx.registered-ui.js`, move `renderStarted = true` to after the strict-mode lock check in `onRenderStart()` to prevent bypass on failed checks; still auto-locks post-render.
> - **Tests**:
>   - Add `__tests__/blinx.registered-ui.strict-mode.test.js` covering failed render-start not marking render as started and successful render after pre-locking, including registration prevention post-render.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb1b3911f0221f556b7d0fc7a268191b063171ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->