### PR TITLE
Blinx data source abstraction

### DIFF
--- a/__tests__/blinx.datasource.array.test.js
+++ b/__tests__/blinx.datasource.array.test.js
@@ -1,0 +1,140 @@
+import { BlinxArrayDataSource } from '../lib/blinx.datasource.js';
+
+describe('BlinxArrayDataSource', () => {
+  test('query(): supports object filter + sort + page mode "page" and returns pageInfo.totalCount', async () => {
+    const ds = new BlinxArrayDataSource(
+      [
+        { id: 1, name: 'B', category: 'x' },
+        { id: 2, name: 'A', category: 'x' },
+        { id: 3, name: 'C', category: 'y' },
+      ],
+      { entityType: 'Product', keyField: 'id', versionField: 'version' }
+    );
+
+    const res = await ds.query({
+      resource: 'products',
+      entityType: 'Product',
+      filter: { category: 'x' },
+      sort: [{ field: 'name', dir: 'asc' }],
+      page: { mode: 'page', page: 0, limit: 1 },
+    });
+
+    expect(res.pageInfo.totalCount).toBe(2);
+    expect(res.result).toEqual([{ type: 'Product', id: '2' }]); // A first
+    expect(res.entities.Product[0]).toEqual(expect.objectContaining({ id: 2, name: 'A' }));
+    // version is auto-added in query results when missing
+    expect(res.entities.Product[0].version).toBeDefined();
+  });
+
+  test('query(): supports predicate filter + page mode "offset"', async () => {
+    const ds = new BlinxArrayDataSource(
+      [{ id: 1, n: 10 }, { id: 2, n: 20 }, { id: 3, n: 30 }, { id: 4, n: 40 }],
+      { entityType: 'Thing', keyField: 'id', versionField: 'version' }
+    );
+
+    const res = await ds.query({
+      resource: 'things',
+      entityType: 'Thing',
+      filter: (r) => r.n >= 20,
+      page: { mode: 'offset', offset: 1, limit: 2 }, // after filtering => [20,30,40] -> offset 1 => [30,40]
+    });
+
+    expect(res.result.map(x => x.id)).toEqual(['3', '4']);
+    expect(res.pageInfo.totalCount).toBe(3);
+  });
+
+  test('query(): supports page mode "cursor" with next/prev cursor info', async () => {
+    const ds = new BlinxArrayDataSource(
+      [{ id: 1 }, { id: 2 }, { id: 3 }],
+      { entityType: 'Item', keyField: 'id', versionField: 'version' }
+    );
+
+    const first = await ds.query({
+      resource: 'items',
+      entityType: 'Item',
+      page: { mode: 'cursor', after: null, limit: 2 },
+    });
+
+    expect(first.result.map(x => x.id)).toEqual(['1', '2']);
+    expect(first.pageInfo.nextCursor).toBe('2');
+    expect(first.pageInfo.prevCursor).toBeNull();
+    expect(first.pageInfo.hasNext).toBe(true);
+    expect(first.pageInfo.hasPrev).toBe(false);
+
+    const next = await ds.query({
+      resource: 'items',
+      entityType: 'Item',
+      page: { mode: 'cursor', after: first.pageInfo.nextCursor, limit: 2 },
+    });
+
+    expect(next.result.map(x => x.id)).toEqual(['3']);
+    expect(next.pageInfo.nextCursor).toBeNull();
+    expect(next.pageInfo.prevCursor).toBe('0');
+    expect(next.pageInfo.hasNext).toBe(false);
+    expect(next.pageInfo.hasPrev).toBe(true);
+  });
+
+  test('mutate(): create/update/delete + version bumping', async () => {
+    const ds = new BlinxArrayDataSource(
+      [{ id: 1, name: 'A', version: '1' }],
+      { entityType: 'Product', keyField: 'id', versionField: 'version' }
+    );
+
+    const created = await ds.mutate([
+      { opId: 'c1', type: 'create', entity: { type: 'Product' }, data: { id: 2, name: 'B' } },
+    ]);
+
+    expect(created.applied).toEqual([expect.objectContaining({ opId: 'c1', status: 'applied', serverId: '2' })]);
+    expect(created.entities.Product[0]).toEqual(expect.objectContaining({ id: '2', name: 'B', version: '1' }));
+
+    const updated = await ds.mutate([
+      { opId: 'u1', type: 'update', entity: { type: 'Product', id: 1 }, patch: { name: 'A2' }, baseVersion: '1' },
+    ]);
+
+    expect(updated.conflicts).toEqual([]);
+    expect(updated.rejected).toEqual([]);
+    expect(updated.entities.Product[0]).toEqual(expect.objectContaining({ id: 1, name: 'A2', version: '2' }));
+
+    const deleted = await ds.mutate([
+      { opId: 'd1', type: 'delete', entity: { type: 'Product', id: 2 }, baseVersion: '1' },
+    ]);
+
+    expect(deleted.conflicts).toEqual([]);
+    expect(deleted.rejected).toEqual([]);
+
+    const after = await ds.query({ resource: 'products', entityType: 'Product', page: { mode: 'page', page: 0, limit: 10 } });
+    expect(after.result.map(x => x.id)).toEqual(['1']);
+  });
+
+  test('mutate(): detects conflicts via baseVersion', async () => {
+    const ds = new BlinxArrayDataSource(
+      [{ id: 1, name: 'A', version: '5' }],
+      { entityType: 'Product', keyField: 'id', versionField: 'version' }
+    );
+
+    const res = await ds.mutate([
+      { opId: 'u1', type: 'update', entity: { type: 'Product', id: 1 }, patch: { name: 'A2' }, baseVersion: '4' },
+    ]);
+
+    expect(res.conflicts).toEqual([
+      expect.objectContaining({ opId: 'u1', status: 'conflict', latestVersion: '5' }),
+    ]);
+  });
+
+  test('mutate(): rejects unsupported op types and not-found update/delete', async () => {
+    const ds = new BlinxArrayDataSource([{ id: 1, version: '1' }], { entityType: 'Product', keyField: 'id', versionField: 'version' });
+
+    const res = await ds.mutate([
+      { opId: 'x1', type: 'nope', entity: { type: 'Product', id: 1 } },
+      { opId: 'u404', type: 'update', entity: { type: 'Product', id: 999 }, patch: { name: 'X' }, baseVersion: '1' },
+      { opId: 'd404', type: 'delete', entity: { type: 'Product', id: 999 }, baseVersion: '1' },
+    ]);
+
+    expect(res.rejected).toEqual(expect.arrayContaining([
+      expect.objectContaining({ opId: 'x1', status: 'rejected', error: expect.objectContaining({ code: 'unsupported' }) }),
+      expect.objectContaining({ opId: 'u404', status: 'rejected', error: expect.objectContaining({ code: 'not_found' }) }),
+      expect.objectContaining({ opId: 'd404', status: 'rejected', error: expect.objectContaining({ code: 'not_found' }) }),
+    ]));
+  });
+});
+

--- a/__tests__/blinx.datasource.integration.test.js
+++ b/__tests__/blinx.datasource.integration.test.js
@@ -1,0 +1,54 @@
+import { blinxStore, BlinxArrayDataSource } from '../lib/blinx.store.js';
+
+describe('Blinx remote data layer (query/mutate) integration', () => {
+  test('remote-mode store can loadFirst, edit, and save via BlinxArrayDataSource', async () => {
+    const model = { fields: { id: { type: 'number' }, name: { type: 'string' } } };
+    const ds = new BlinxArrayDataSource([{ id: 1, name: 'A' }], { entityType: 'Product', keyField: 'id', versionField: 'version' });
+
+    const store = blinxStore({
+      model,
+      dataSource: ds,
+      view: { name: 'products', resource: 'products', entityType: 'Product', keyField: 'id', defaultPage: { mode: 'page', page: 0, limit: 20 } },
+    });
+
+    await store.loadFirst();
+    expect(store.getLength()).toBe(1);
+    expect(store.getRecord(0).name).toBe('A');
+
+    store.setField(0, 'name', 'B');
+    expect(store.diff()).toEqual([{ index: 0, field: 'name', from: 'A', to: 'B' }]);
+
+    const res = await store.save();
+    expect(res.conflicts || []).toEqual([]);
+    expect(res.rejected || []).toEqual([]);
+    expect(store.diff()).toEqual([]);
+    expect(store.getRecord(0).name).toBe('B');
+  });
+
+  test('remote-mode store supports pagination via pageNext/pagePrev', async () => {
+    const model = { fields: { id: { type: 'number' }, name: { type: 'string' } } };
+    const ds = new BlinxArrayDataSource(
+      [{ id: 1, name: 'A' }, { id: 2, name: 'B' }, { id: 3, name: 'C' }],
+      { entityType: 'Product', keyField: 'id', versionField: 'version' }
+    );
+
+    const store = blinxStore({
+      model,
+      dataSource: ds,
+      view: { name: 'products', resource: 'products', entityType: 'Product', keyField: 'id', defaultPage: { mode: 'cursor', after: null, limit: 2 } },
+    });
+
+    await store.loadFirst();
+    expect(store.toJSON().map(r => r.id)).toEqual([1, 2]);
+    expect(store.getPagingState().pageState.pageIndex).toBe(0);
+
+    await store.pageNext();
+    expect(store.toJSON().map(r => r.id)).toEqual([3]);
+    expect(store.getPagingState().pageState.pageIndex).toBe(1);
+
+    await store.pagePrev();
+    expect(store.toJSON().map(r => r.id)).toEqual([1, 2]);
+    expect(store.getPagingState().pageState.pageIndex).toBe(0);
+  });
+});
+

--- a/__tests__/blinx.registered-ui.test.js
+++ b/__tests__/blinx.registered-ui.test.js
@@ -1,0 +1,82 @@
+/**
+ * RegisteredUI has module-scope state; each test uses a fresh import.
+ */
+
+describe('RegisteredUI', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('get() returns the default renderer when name omitted', async () => {
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+    const ui = RegisteredUI.get();
+    expect(ui).toBeDefined();
+    expect(typeof ui.createField).toBe('function');
+    expect(typeof ui.formatCell).toBe('function');
+  });
+
+  test('get() throws for unknown renderer name', async () => {
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+    expect(() => RegisteredUI.get('nope')).toThrow('RegisteredUI: unknown renderer "nope".');
+  });
+
+  test('register() validates name and renderer shape', async () => {
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+
+    expect(() => RegisteredUI.register('', { createField() {}, formatCell() {} }))
+      .toThrow('RegisteredUI.register(name, renderer) requires a non-empty string name.');
+
+    expect(() => RegisteredUI.register('x', null))
+      .toThrow('RegisteredUI.register(name, renderer) requires a renderer object.');
+
+    expect(() => RegisteredUI.register('x', { formatCell() {} }))
+      .toThrow('RegisteredUI renderer must implement createField({ fieldKey, def, value, onChange }).');
+
+    expect(() => RegisteredUI.register('x', { createField() {} }))
+      .toThrow('RegisteredUI renderer must implement formatCell(value, def).');
+  });
+
+  test('register() works before render and get() retrieves it', async () => {
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+
+    const renderer = { createField() {}, formatCell() {} };
+    RegisteredUI.register('x-test', renderer);
+
+    expect(RegisteredUI.get('x-test')).toBe(renderer);
+  });
+
+  test('lock() flips isLocked() and prevents registration', async () => {
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+    expect(RegisteredUI.isLocked()).toBe(false);
+
+    RegisteredUI.lock();
+    expect(RegisteredUI.isLocked()).toBe(true);
+
+    expect(() => RegisteredUI.register('x-after-lock', { createField() {}, formatCell() {} }))
+      .toThrow('RegisteredUI is locked. Renderer registration is disabled.');
+  });
+
+  test('__internal_onRenderStart() locks registry (even without strict-mode)', async () => {
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+    expect(RegisteredUI.isLocked()).toBe(false);
+
+    expect(() => RegisteredUI.__internal_onRenderStart()).not.toThrow();
+    expect(RegisteredUI.isLocked()).toBe(true);
+
+    expect(() => RegisteredUI.register('x-after-render', { createField() {}, formatCell() {} }))
+      .toThrow('RegisteredUI is locked. Renderer registration is disabled.');
+  });
+
+  test('requireLockBeforeRender(true) enforces lock before render start', async () => {
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+
+    RegisteredUI.requireLockBeforeRender(true);
+    expect(() => RegisteredUI.__internal_onRenderStart())
+      .toThrow('RegisteredUI is not locked. Call RegisteredUI.lock() before rendering.');
+
+    // Once locked, render start should be allowed.
+    RegisteredUI.lock();
+    expect(() => RegisteredUI.__internal_onRenderStart()).not.toThrow();
+  });
+});
+

--- a/__tests__/blinx.renderer-selection.test.js
+++ b/__tests__/blinx.renderer-selection.test.js
@@ -1,0 +1,139 @@
+/** @jest-environment jsdom */
+
+function makeRenderer({ name, onCreateField, onFormatCell }) {
+  return {
+    createField({ fieldKey, def, value, onChange }) {
+      onCreateField?.({ renderer: name, fieldKey, def, value });
+      // Minimal widget contract needed by BlinxDefaultUI callers.
+      const el = document.createElement('div');
+      el.setAttribute('data-renderer', name);
+      el.setAttribute('data-field', fieldKey);
+      // Keep onChange reachable (not used by this test).
+      el.__blinx_onChange = onChange;
+      return {
+        el,
+        getValue: () => value,
+        setError: () => {},
+      };
+    },
+    formatCell(value, def) {
+      onFormatCell?.({ renderer: name, value, def });
+      return `${name}:${value ?? ''}`;
+    },
+  };
+}
+
+describe('Renderer selection (view.renderer + per-field/per-column override)', () => {
+  beforeEach(() => {
+    // RegisteredUI has module-scope state and auto-locks on first render start.
+    // Use fresh imports per test to avoid cross-test locking.
+    jest.resetModules();
+  });
+
+  test('blinxForm: view.renderer used by default; per-field renderer override respected', async () => {
+    const { blinxStore } = await import('../lib/blinx.store.js');
+    const { blinxForm } = await import('../lib/blinx.form.js');
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+
+    const calls = [];
+
+    const defaultRendererName = 'x-custom-form';
+    const fieldRendererName = 'x-field-form';
+
+    RegisteredUI.register(defaultRendererName, makeRenderer({
+      name: defaultRendererName,
+      onCreateField: (c) => calls.push(c),
+    }));
+    RegisteredUI.register(fieldRendererName, makeRenderer({
+      name: fieldRendererName,
+      onCreateField: (c) => calls.push(c),
+    }));
+
+    const model = {
+      fields: {
+        name: { type: 'string' },
+        price: { type: 'number' },
+      }
+    };
+    const store = blinxStore([{ name: 'A', price: 1 }], model);
+
+    const root = document.createElement('div');
+
+    blinxForm({
+      root,
+      store,
+      view: {
+        renderer: defaultRendererName,
+        sections: [{
+          title: 'Main',
+          columns: 2,
+          fields: [
+            { field: 'name', renderer: fieldRendererName },
+            'price',
+          ],
+        }]
+      },
+      controls: {},
+    });
+
+    // Assert renderer choice
+    expect(calls.map(c => `${c.renderer}:${c.fieldKey}`)).toEqual([
+      `${fieldRendererName}:name`,
+      `${defaultRendererName}:price`,
+    ]);
+  });
+
+  test('blinxCollection: view.renderer used by default; per-column renderer override respected', async () => {
+    const { blinxStore } = await import('../lib/blinx.store.js');
+    const { blinxCollection } = await import('../lib/blinx.collection.js');
+    const { RegisteredUI } = await import('../lib/blinx.registered-ui.js');
+
+    const formatCalls = [];
+
+    const defaultRendererName = 'x-custom-collection';
+    const columnRendererName = 'x-col-collection';
+
+    RegisteredUI.register(defaultRendererName, makeRenderer({
+      name: defaultRendererName,
+      onFormatCell: (c) => formatCalls.push(c),
+    }));
+    RegisteredUI.register(columnRendererName, makeRenderer({
+      name: columnRendererName,
+      onFormatCell: (c) => formatCalls.push(c),
+    }));
+
+    const model = {
+      fields: {
+        name: { type: 'string' },
+        price: { type: 'number' },
+      }
+    };
+    const store = blinxStore([{ name: 'A', price: 10 }], model);
+    const root = document.createElement('div');
+
+    blinxCollection({
+      root,
+      store,
+      view: {
+        renderer: defaultRendererName,
+        layout: 'table',
+        columns: [
+          { field: 'name', label: 'Name' }, // uses view.renderer
+          { field: 'price', label: 'Price', renderer: columnRendererName }, // override
+        ],
+      },
+      paging: { pageSize: 20 },
+    });
+
+    // One row, two columns => two formatCell calls.
+    const byRenderer = formatCalls.reduce((acc, c) => {
+      acc[c.renderer] = acc[c.renderer] || [];
+      acc[c.renderer].push(c.value);
+      return acc;
+    }, {});
+
+    expect(byRenderer[defaultRendererName]).toEqual(['A']);
+    expect(byRenderer[columnRendererName]).toEqual([10]);
+  });
+});
+

--- a/__tests__/blinx.store.multiview.test.js
+++ b/__tests__/blinx.store.multiview.test.js
@@ -1,0 +1,86 @@
+import { blinxStore } from '../lib/blinx.store.js';
+
+describe('blinxStore multi-view', () => {
+  test('store.collection(name) is stable and views keep independent state while sharing one dataSource', async () => {
+    const initCalls = [];
+    const queryCalls = [];
+    const mutateCalls = [];
+
+    const dataSource = {
+      init(args) { initCalls.push(args); },
+      async query(querySpec) {
+        queryCalls.push({ ...querySpec });
+        if (querySpec.resource === 'products') {
+          return {
+            entities: { Product: [{ id: 'p1', name: 'Milk', version: '1' }] },
+            result: [{ type: 'Product', id: 'p1' }],
+            pageInfo: { totalCount: 1, nextCursor: null, prevCursor: null },
+          };
+        }
+        if (querySpec.resource === 'orders') {
+          return {
+            entities: { Order: [{ id: 'o1', total: 10, version: '1' }] },
+            result: [{ type: 'Order', id: 'o1' }],
+            pageInfo: { totalCount: 1, nextCursor: null, prevCursor: null },
+          };
+        }
+        return { entities: {}, result: [], pageInfo: { totalCount: 0 } };
+      },
+      async mutate(ops) {
+        mutateCalls.push(ops.map(o => ({ type: o.type, entity: o.entity, patch: o.patch, data: o.data, opId: o.opId })));
+        return { applied: ops.map(o => ({ opId: o.opId, status: 'applied' })), rejected: [], conflicts: [], entities: {} };
+      },
+    };
+
+    const store = blinxStore({
+      model: { fields: { id: {}, name: {}, total: {}, version: {} } },
+      dataSource,
+      defaultView: 'products',
+      views: {
+        products: { resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version', defaultPage: { mode: 'page', page: 0, limit: 10 } },
+        orders: { resource: 'orders', entityType: 'Order', keyField: 'id', versionField: 'version', defaultPage: { mode: 'page', page: 0, limit: 10 } },
+      }
+    });
+
+    // Data source is initialized exactly once at store creation.
+    expect(initCalls.length).toBe(1);
+
+    const products1 = store.collection('products');
+    const products2 = store.collection('products');
+    const orders1 = store.collection('orders');
+    const orders2 = store.collection('orders');
+
+    expect(products1).toBe(products2);
+    expect(orders1).toBe(orders2);
+    expect(products1).not.toBe(orders1);
+
+    await products1.loadFirst();
+    await orders1.loadFirst();
+
+    expect(products1.getRecord(0)).toEqual(expect.objectContaining({ id: 'p1', name: 'Milk' }));
+    expect(orders1.getRecord(0)).toEqual(expect.objectContaining({ id: 'o1', total: 10 }));
+
+    // Independent criteria: search on one view doesn't mutate the other's state.
+    await orders1.search({ filter: { status: 'open' } });
+    expect(orders1.getStatus().criteria.filter).toEqual({ status: 'open' });
+    expect(products1.getStatus().criteria.filter).toBeNull();
+
+    // Independent pending ops: save only flushes ops for that view.
+    products1.setField(0, 'name', 'Milk2');
+    await products1.save();
+    expect(mutateCalls.length).toBe(1);
+    expect(mutateCalls[0].some(o => o.entity?.type === 'Product')).toBe(true);
+    expect(mutateCalls[0].some(o => o.entity?.type === 'Order')).toBe(false);
+
+    orders1.setField(0, 'total', 20);
+    await orders1.save();
+    expect(mutateCalls.length).toBe(2);
+    expect(mutateCalls[1].some(o => o.entity?.type === 'Order')).toBe(true);
+    expect(mutateCalls[1].some(o => o.entity?.type === 'Product')).toBe(false);
+
+    // Sanity: both views issued queries with their own resources.
+    expect(queryCalls.some(q => q.resource === 'products')).toBe(true);
+    expect(queryCalls.some(q => q.resource === 'orders')).toBe(true);
+  });
+});
+

--- a/__tests__/blinx.store.save.multifield.test.js
+++ b/__tests__/blinx.store.save.multifield.test.js
@@ -1,0 +1,66 @@
+import { blinxStore } from '../lib/blinx.store.js';
+
+describe('blinxStore save() multi-field edits', () => {
+  test('coalesces multiple setField updates into one op to avoid self-conflicts (regression)', async () => {
+    const mutateCalls = [];
+    const server = { id: '1', name: 'A', price: 1, version: '1' };
+
+    const dataSource = {
+      init() {},
+      async query() {
+        return {
+          entities: { Product: [server] },
+          result: [{ type: 'Product', id: '1' }],
+          pageInfo: { totalCount: 1 },
+        };
+      },
+      async mutate(ops) {
+        mutateCalls.push(ops);
+        // Simulate server-side optimistic concurrency: each update must match current version.
+        // If multiple update ops are sent with the same baseVersion, later ones conflict.
+        const applied = [];
+        const rejected = [];
+        const conflicts = [];
+
+        for (const op of ops) {
+          if (op.type !== 'update') continue;
+          if (String(op.baseVersion) !== String(server.version)) {
+            conflicts.push({ opId: op.opId, status: 'conflict', latestVersion: server.version, server: { ...server }, local: op });
+            continue;
+          }
+          Object.assign(server, op.patch || {});
+          server.version = String((parseInt(server.version, 10) || 0) + 1);
+          applied.push({ opId: op.opId, status: 'applied' });
+        }
+
+        return { applied, rejected, conflicts, entities: { Product: [{ ...server }] } };
+      },
+    };
+
+    const store = blinxStore({
+      model: { fields: { id: {}, name: {}, price: {} } },
+      dataSource,
+      view: { name: 'products', resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version', defaultPage: { mode: 'page', page: 0, limit: 10 } },
+    });
+
+    await store.loadFirst();
+
+    // User edits two fields before saving.
+    store.setField(0, 'name', 'B');
+    store.setField(0, 'price', 2);
+
+    const res = await store.save();
+
+    expect(res.conflicts || []).toEqual([]);
+    expect(mutateCalls.length).toBe(1);
+    // Regression assertion: should be a single update op with merged patch.
+    expect(mutateCalls[0].filter(o => o.type === 'update').length).toBe(1);
+    expect(mutateCalls[0][0]).toEqual(expect.objectContaining({
+      type: 'update',
+      entity: { type: 'Product', id: '1' },
+      patch: { name: 'B', price: 2 },
+      baseVersion: '1',
+    }));
+  });
+});
+

--- a/__tests__/blinx.store.save.requeue.test.js
+++ b/__tests__/blinx.store.save.requeue.test.js
@@ -1,0 +1,51 @@
+import { blinxStore } from '../lib/blinx.store.js';
+
+describe('blinxStore save() re-queue behavior', () => {
+  test('does not re-queue already-applied ops when some ops are rejected (regression)', async () => {
+    const calls = [];
+
+    const dataSource = {
+      init() {},
+      async query() {
+        return { entities: { Product: [] }, result: [], pageInfo: { totalCount: 0 } };
+      },
+      async mutate(ops) {
+        calls.push(ops.map(o => o.opId));
+        if (ops.length <= 1) {
+          return { applied: [{ opId: ops[0].opId, status: 'applied' }], rejected: [], conflicts: [], entities: {} };
+        }
+        // Apply only the first op, reject the rest.
+        return {
+          applied: [{ opId: ops[0].opId, status: 'applied' }],
+          rejected: ops.slice(1).map(o => ({ opId: o.opId, status: 'rejected', error: { code: 'x', message: 'fail' } })),
+          conflicts: [],
+          entities: {},
+        };
+      },
+    };
+
+    const store = blinxStore({
+      model: { fields: {} },
+      dataSource,
+      view: { name: 'products', resource: 'products', entityType: 'Product', keyField: 'id', defaultPage: { mode: 'page', page: 0, limit: 10 } },
+    });
+
+    // Queue two creates.
+    store.addRecord({ name: 'A' });
+    store.addRecord({ name: 'B' });
+
+    const first = await store.save();
+    expect(first.applied.length).toBe(1);
+    expect(first.rejected.length).toBe(1);
+    expect(calls.length).toBe(1);
+    expect(calls[0].length).toBe(2);
+
+    // Second save should retry ONLY the rejected op (not both).
+    const second = await store.save();
+    expect(second.applied.length).toBe(1);
+    expect(second.rejected.length).toBe(0);
+    expect(calls.length).toBe(2);
+    expect(calls[1]).toEqual([calls[0][1]]);
+  });
+});
+

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -278,11 +278,20 @@ export function blinxCollection({
 
   function runInternalChange(fn) {
     internalChangeDepth += 1;
+    let res;
     try {
-      return fn();
-    } finally {
+      res = fn();
+    } catch (e) {
       internalChangeDepth = Math.max(0, internalChangeDepth - 1);
+      throw e;
     }
+    if (res && typeof res.then === 'function') {
+      return res.finally(() => {
+        internalChangeDepth = Math.max(0, internalChangeDepth - 1);
+      });
+    }
+    internalChangeDepth = Math.max(0, internalChangeDepth - 1);
+    return res;
   }
 
   function getDataSnapshot() {
@@ -303,6 +312,14 @@ export function blinxCollection({
   }
 
   function getItemsForCurrentPage(data) {
+    const remotePaging = typeof store.pageNext === 'function' || typeof store.pagePrev === 'function';
+    if (remotePaging) {
+      page = 0;
+      pruneSelection(data.length);
+      const items = [];
+      for (let i = 0; i < data.length; i++) items.push({ index: i, record: data[i] });
+      return { items, start: 0, end: data.length, total: data.length, maxPage: 0 };
+    }
     const maxPage = getMaxPage(data.length);
     page = Math.min(Math.max(page, 0), maxPage);
     pruneSelection(data.length);
@@ -315,7 +332,15 @@ export function blinxCollection({
 
   function updatePagerLabel() {
     const labelEl = dom.pageLabel || internalPager?.pageLabel;
-    if (labelEl) labelEl.textContent = `Page: ${page + 1}`;
+    if (!labelEl) return;
+    if (typeof store.getPagingState === 'function') {
+      const s = store.getPagingState();
+      const ps = s?.pageState;
+      if (ps?.mode === 'page') { labelEl.textContent = `Page: ${(ps.page || 0) + 1}`; return; }
+      if (ps?.mode === 'offset') { labelEl.textContent = `Page: ${Math.floor((ps.offset || 0) / Math.max(1, ps.limit || 1)) + 1}`; return; }
+      if (ps?.mode === 'cursor') { labelEl.textContent = `Page: ${(ps.pageIndex || 0) + 1}`; return; }
+    }
+    labelEl.textContent = `Page: ${page + 1}`;
   }
 
   function refresh() {
@@ -398,12 +423,25 @@ export function blinxCollection({
     const prevEl = dom.prevBtn || internalPager?.prevBtn;
     const nextEl = dom.nextBtn || internalPager?.nextBtn;
     if (prevEl) {
-      const onPrev = () => { page = Math.max(0, page - 1); refresh(); };
+      const onPrev = async () => {
+        if (typeof store.pagePrev === 'function') {
+          await runInternalChange(() => store.pagePrev());
+          refresh();
+          return;
+        }
+        page = Math.max(0, page - 1);
+        refresh();
+      };
       prevEl.addEventListener('click', onPrev);
       cleanupFns.push(() => prevEl.removeEventListener('click', onPrev));
     }
     if (nextEl) {
-      const onNext = () => {
+      const onNext = async () => {
+        if (typeof store.pageNext === 'function') {
+          await runInternalChange(() => store.pageNext());
+          refresh();
+          return;
+        }
         const maxPage = Math.floor((store.getLength() - 1) / pageSize);
         page = Math.min(maxPage, page + 1);
         refresh();

--- a/lib/blinx.datasource.js
+++ b/lib/blinx.datasource.js
@@ -187,8 +187,11 @@ export class BlinxArrayDataSource extends BlinxDataSource {
     const conflicts = [];
     const entities = {};
 
+    // IMPORTANT: do NOT cache array indices here.
+    // Deletes mutate the array via splice(), which shifts indices and makes cached indices stale.
+    // Keep only record references, and compute current index at the moment of deletion.
     const byId = new Map();
-    this._data.forEach((rec, idx) => byId.set(this._getId(rec, idx), { rec, idx }));
+    this._data.forEach((rec, idx) => byId.set(this._getId(rec, idx), rec));
 
     for (const op of ops || []) {
       const opId = op?.opId || `op-${Date.now()}-${Math.random()}`;
@@ -204,6 +207,7 @@ export class BlinxArrayDataSource extends BlinxDataSource {
           data[this._keyField] = String(nextId);
           this._bumpVersion(data);
           this._data.push(data);
+          byId.set(String(nextId), data);
           if (!entities[entityType]) entities[entityType] = [];
           entities[entityType].push(clone(data));
           applied.push({ opId, status: 'applied', serverId: String(nextId) });
@@ -217,18 +221,25 @@ export class BlinxArrayDataSource extends BlinxDataSource {
             rejected.push({ opId, status: 'rejected', error: { code: 'not_found', message: `Not found: ${id}` } });
             continue;
           }
-          const currentVersion = this._getVersion(found.rec);
+          const currentVersion = this._getVersion(found);
           if (baseVersion !== null && currentVersion !== null && baseVersion !== currentVersion) {
             conflicts.push({
               opId,
               status: 'conflict',
               latestVersion: currentVersion,
-              server: clone(found.rec),
+              server: clone(found),
               local: op,
             });
             continue;
           }
-          this._data.splice(found.idx, 1);
+          const idx = this._data.findIndex(r => String(r?.[this._keyField]) === String(id));
+          if (idx < 0) {
+            // Record disappeared mid-batch (e.g., deleted earlier). Treat as not_found.
+            rejected.push({ opId, status: 'rejected', error: { code: 'not_found', message: `Not found: ${id}` } });
+            continue;
+          }
+          this._data.splice(idx, 1);
+          byId.delete(id);
           applied.push({ opId, status: 'applied' });
           continue;
         }
@@ -240,24 +251,24 @@ export class BlinxArrayDataSource extends BlinxDataSource {
             rejected.push({ opId, status: 'rejected', error: { code: 'not_found', message: `Not found: ${id}` } });
             continue;
           }
-          const currentVersion = this._getVersion(found.rec);
+          const currentVersion = this._getVersion(found);
           if (baseVersion !== null && currentVersion !== null && baseVersion !== currentVersion) {
             conflicts.push({
               opId,
               status: 'conflict',
               latestVersion: currentVersion,
-              server: clone(found.rec),
+              server: clone(found),
               local: op,
             });
             continue;
           }
           const patch = op?.patch ? clone(op.patch) : null;
           const data = op?.data ? clone(op.data) : null;
-          if (patch) Object.assign(found.rec, patch);
-          else if (data) Object.assign(found.rec, data);
-          this._bumpVersion(found.rec);
+          if (patch) Object.assign(found, patch);
+          else if (data) Object.assign(found, data);
+          this._bumpVersion(found);
           if (!entities[entityType]) entities[entityType] = [];
-          entities[entityType].push(clone(found.rec));
+          entities[entityType].push(clone(found));
           applied.push({ opId, status: 'applied' });
           continue;
         }

--- a/lib/blinx.datasource.js
+++ b/lib/blinx.datasource.js
@@ -1,0 +1,274 @@
+const clone = value => JSON.parse(JSON.stringify(value));
+
+function stableStringify(obj) {
+  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(stableStringify).join(',')}]`;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map(k => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(',')}}`;
+}
+
+function makeQueryKey(querySpec) {
+  // Intentional: deterministic, human-readable key for caching/invalidation.
+  // DataSource implementations may ignore it; store can also override.
+  return `${querySpec?.resource || 'resource'}:${stableStringify(querySpec || {})}`;
+}
+
+function applyFilter(records, filter) {
+  if (!filter) return records;
+  // Minimal, implementation-agnostic filter:
+  // - object => equality on fields
+  // - function => predicate(record) boolean
+  if (typeof filter === 'function') return records.filter(filter);
+  if (typeof filter !== 'object') return records;
+  const entries = Object.entries(filter);
+  if (entries.length === 0) return records;
+  return records.filter(rec => entries.every(([k, v]) => rec?.[k] === v));
+}
+
+function applySort(records, sort) {
+  if (!Array.isArray(sort) || sort.length === 0) return records;
+  const specs = sort
+    .filter(Boolean)
+    .map(s => ({ field: s.field, dir: (s.dir || 'asc').toLowerCase() === 'desc' ? 'desc' : 'asc' }))
+    .filter(s => typeof s.field === 'string' && s.field.length > 0);
+  if (specs.length === 0) return records;
+  const out = records.slice();
+  out.sort((a, b) => {
+    for (const s of specs) {
+      const av = a?.[s.field];
+      const bv = b?.[s.field];
+      if (av === bv) continue;
+      if (av === undefined || av === null) return s.dir === 'asc' ? 1 : -1;
+      if (bv === undefined || bv === null) return s.dir === 'asc' ? -1 : 1;
+      if (av < bv) return s.dir === 'asc' ? -1 : 1;
+      if (av > bv) return s.dir === 'asc' ? 1 : -1;
+    }
+    return 0;
+  });
+  return out;
+}
+
+function slicePage(records, page) {
+  const mode = page?.mode || 'offset';
+  const limit = Number.isFinite(page?.limit) ? page.limit : 20;
+
+  if (mode === 'page') {
+    const pageNumber = Number.isFinite(page?.page) ? page.page : 0;
+    const offset = Math.max(0, pageNumber) * Math.max(0, limit);
+    return { items: records.slice(offset, offset + limit), pageInfo: { page: pageNumber, limit } };
+  }
+
+  if (mode === 'cursor') {
+    // Cursor is an opaque token; for the array source we use numeric offset cursors.
+    const after = page?.after === null || page?.after === undefined ? null : String(page.after);
+    const offset = after ? Math.max(0, parseInt(after, 10) || 0) : 0;
+    const items = records.slice(offset, offset + limit);
+    const nextOffset = offset + items.length;
+    return {
+      items,
+      pageInfo: {
+        mode: 'cursor',
+        limit,
+        nextCursor: nextOffset < records.length ? String(nextOffset) : null,
+        prevCursor: offset > 0 ? String(Math.max(0, offset - limit)) : null,
+        hasNext: nextOffset < records.length,
+        hasPrev: offset > 0,
+      }
+    };
+  }
+
+  // offset mode (default)
+  const offset = Number.isFinite(page?.offset) ? page.offset : 0;
+  const items = records.slice(Math.max(0, offset), Math.max(0, offset) + limit);
+  return { items, pageInfo: { mode: 'offset', offset: Math.max(0, offset), limit } };
+}
+
+export class BlinxDataSource {
+  init({ model, defaults } = {}) {
+    this._model = model || null;
+    this._defaults = defaults || {};
+  }
+
+  capabilities() {
+    return {
+      pagination: ['cursor', 'page', 'offset'],
+      conflicts: true,
+      subscriptions: false,
+      offline: false,
+    };
+  }
+
+  // Implement in derived classes
+  async query(_querySpec, _options = {}) {
+    throw new Error('BlinxDataSource.query(querySpec, options) is not implemented.');
+  }
+
+  // Implement in derived classes
+  async mutate(_ops, _options = {}) {
+    throw new Error('BlinxDataSource.mutate(ops, options) is not implemented.');
+  }
+
+  async close() {}
+}
+
+/**
+ * In-memory adapter used for backwards compatibility and prototyping.
+ * Implements query/mutate on top of a plain array of records.
+ */
+export class BlinxArrayDataSource extends BlinxDataSource {
+  constructor(initialArray = [], { entityType = 'Record', keyField = 'id', versionField = 'version' } = {}) {
+    super();
+    this._entityType = entityType;
+    this._keyField = keyField;
+    this._versionField = versionField;
+    this._data = clone(initialArray);
+    this._nextTmpId = 1;
+  }
+
+  init({ model, defaults } = {}) {
+    super.init({ model, defaults });
+    if (defaults?.entityType) this._entityType = defaults.entityType;
+    if (defaults?.keyField) this._keyField = defaults.keyField;
+    if (defaults?.versionField) this._versionField = defaults.versionField;
+  }
+
+  _getId(rec, fallbackIndex) {
+    const v = rec?.[this._keyField];
+    if (v === undefined || v === null || v === '') return String(fallbackIndex);
+    return String(v);
+  }
+
+  _getVersion(rec) {
+    const v = rec?.[this._versionField];
+    return v === undefined ? null : String(v);
+  }
+
+  _bumpVersion(rec) {
+    const cur = this._getVersion(rec);
+    const next = cur === null ? 1 : (parseInt(cur, 10) || 0) + 1;
+    rec[this._versionField] = String(next);
+    return rec;
+  }
+
+  async query(querySpec = {}, _options = {}) {
+    const resource = querySpec.resource || 'resource';
+    const entityType = querySpec.entityType || this._entityType;
+
+    let rows = this._data.slice();
+    rows = applyFilter(rows, querySpec.filter);
+    rows = applySort(rows, querySpec.sort);
+
+    const totalCount = rows.length;
+    const { items, pageInfo } = slicePage(rows, querySpec.page || { mode: 'offset', offset: 0, limit: 20 });
+
+    const entities = { [entityType]: [] };
+    const result = [];
+
+    items.forEach((rec, idx) => {
+      const id = this._getId(rec, idx);
+      const withMeta = { ...clone(rec), [this._keyField]: rec?.[this._keyField] ?? id };
+      if (this._getVersion(withMeta) === null) this._bumpVersion(withMeta);
+      entities[entityType].push(withMeta);
+      result.push({ type: entityType, id });
+    });
+
+    return {
+      entities,
+      result,
+      pageInfo: { ...pageInfo, totalCount },
+      meta: { resource, queryKey: makeQueryKey({ ...querySpec, resource, entityType }), fetchedAt: Date.now() },
+    };
+  }
+
+  async mutate(ops = [], _options = {}) {
+    const entityTypeDefault = this._entityType;
+    const applied = [];
+    const rejected = [];
+    const conflicts = [];
+    const entities = {};
+
+    const byId = new Map();
+    this._data.forEach((rec, idx) => byId.set(this._getId(rec, idx), { rec, idx }));
+
+    for (const op of ops || []) {
+      const opId = op?.opId || `op-${Date.now()}-${Math.random()}`;
+      const type = op?.type;
+      const entityType = op?.entity?.type || op?.entityType || entityTypeDefault;
+      const id = op?.entity?.id !== undefined ? String(op.entity.id) : null;
+      const baseVersion = op?.baseVersion === undefined || op?.baseVersion === null ? null : String(op.baseVersion);
+
+      try {
+        if (type === 'create') {
+          const data = clone(op?.data || {});
+          const nextId = data?.[this._keyField] ?? `tmp-${this._nextTmpId++}`;
+          data[this._keyField] = String(nextId);
+          this._bumpVersion(data);
+          this._data.push(data);
+          if (!entities[entityType]) entities[entityType] = [];
+          entities[entityType].push(clone(data));
+          applied.push({ opId, status: 'applied', serverId: String(nextId) });
+          continue;
+        }
+
+        if (type === 'delete') {
+          if (!id) throw new Error('delete requires entity.id');
+          const found = byId.get(id);
+          if (!found) {
+            rejected.push({ opId, status: 'rejected', error: { code: 'not_found', message: `Not found: ${id}` } });
+            continue;
+          }
+          const currentVersion = this._getVersion(found.rec);
+          if (baseVersion !== null && currentVersion !== null && baseVersion !== currentVersion) {
+            conflicts.push({
+              opId,
+              status: 'conflict',
+              latestVersion: currentVersion,
+              server: clone(found.rec),
+              local: op,
+            });
+            continue;
+          }
+          this._data.splice(found.idx, 1);
+          applied.push({ opId, status: 'applied' });
+          continue;
+        }
+
+        if (type === 'update') {
+          if (!id) throw new Error('update requires entity.id');
+          const found = byId.get(id);
+          if (!found) {
+            rejected.push({ opId, status: 'rejected', error: { code: 'not_found', message: `Not found: ${id}` } });
+            continue;
+          }
+          const currentVersion = this._getVersion(found.rec);
+          if (baseVersion !== null && currentVersion !== null && baseVersion !== currentVersion) {
+            conflicts.push({
+              opId,
+              status: 'conflict',
+              latestVersion: currentVersion,
+              server: clone(found.rec),
+              local: op,
+            });
+            continue;
+          }
+          const patch = op?.patch ? clone(op.patch) : null;
+          const data = op?.data ? clone(op.data) : null;
+          if (patch) Object.assign(found.rec, patch);
+          else if (data) Object.assign(found.rec, data);
+          this._bumpVersion(found.rec);
+          if (!entities[entityType]) entities[entityType] = [];
+          entities[entityType].push(clone(found.rec));
+          applied.push({ opId, status: 'applied' });
+          continue;
+        }
+
+        rejected.push({ opId, status: 'rejected', error: { code: 'unsupported', message: `Unsupported op type: ${String(type)}` } });
+      } catch (e) {
+        rejected.push({ opId, status: 'rejected', error: { code: 'exception', message: e?.message || String(e) } });
+      }
+    }
+
+    return { applied, rejected, conflicts, entities, invalidations: [], meta: { mutatedAt: Date.now() } };
+  }
+}
+

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -133,11 +133,20 @@ export function blinxForm({
 
   function runInternalChange(fn) {
     internalChangeDepth += 1;
+    let res;
     try {
-      return fn();
-    } finally {
+      res = fn();
+    } catch (e) {
       internalChangeDepth = Math.max(0, internalChangeDepth - 1);
+      throw e;
     }
+    if (res && typeof res.then === 'function') {
+      return res.finally(() => {
+        internalChangeDepth = Math.max(0, internalChangeDepth - 1);
+      });
+    }
+    internalChangeDepth = Math.max(0, internalChangeDepth - 1);
+    return res;
   }
 
   function buildSections() {
@@ -258,12 +267,16 @@ export function blinxForm({
     if (!ok) return setStatus('Fix validation errors.', '#e53e3e');
     const diff = store.diff();
     if (diff.length > 0) {
-      runInternalChange(() => store.commit());
+      if (typeof store.save === 'function') {
+        await runInternalChange(() => store.save());
+      } else {
+        runInternalChange(() => store.commit());
+      }
       setStatus(`Saved changes: ${JSON.stringify(diff)}`, '#2f855a');
     } else setStatus('No changes to save.', '#4a5568');
   }
 
-  async function doReset() { runInternalChange(() => store.reset()); buildSections(); updateIndicator(); setStatus('Reset done.', '#4a5568'); }
+  async function doReset() { await runInternalChange(() => store.reset()); buildSections(); updateIndicator(); setStatus('Reset done.', '#4a5568'); }
   async function doCreate() {
     const idx = runInternalChange(() => store.addRecord(Object.fromEntries(Object.keys(model.fields).map(k => [k, '']))));
     rebind(idx);

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -402,12 +402,30 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     if (pendingOps.length === 0) return { applied: [], rejected: [], conflicts: [], entities: {} };
     status = 'saving'; error = null;
     const ops = pendingOps.splice(0, pendingOps.length).map(o => clone(o));
-    const res = await dataSource.mutate(ops, {});
+
+    let res;
+    try {
+      res = await dataSource.mutate(ops, {});
+    } catch (e) {
+      // Transport-level failure: restore all pending ops so nothing is lost.
+      pendingOps.unshift(...ops);
+      status = 'error';
+      error = e;
+      throw e;
+    }
+
     const conflicts = res?.conflicts || [];
     const rejected = res?.rejected || [];
+    const applied = res?.applied || [];
+    const appliedIds = new Set(applied.map(a => a?.opId).filter(Boolean));
+
     if (conflicts.length || rejected.length) {
-      // Re-queue failed ops for future retry, but do not commit snapshot.
-      pendingOps.unshift(...ops);
+      // Re-queue only ops that were NOT applied.
+      // This avoids retrying successful creates/updates and creating duplicates on the next save().
+      const failedOps = appliedIds.size > 0
+        ? ops.filter(o => !appliedIds.has(o?.opId))
+        : ops;
+      pendingOps.unshift(...failedOps);
       status = 'error';
       error = { conflicts, rejected };
       return res;

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -170,10 +170,6 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   let opSeq = 1;
   const pendingOps = []; // queued local ops (for offline / save batching)
 
-  if (dataSource && typeof dataSource.init === 'function') {
-    dataSource.init({ model, defaults: { entityType, keyField, versionField } });
-  }
-
   function notify(path, value) {
     subs.forEach(fn => fn({ path, value, data: current, store: storeApi }));
   }
@@ -528,6 +524,21 @@ export function blinxStore(arg1, arg2) {
   const views = cfg.views || {};
   const defaultView = cfg.defaultView || Object.keys(views)[0] || 'default';
   const defaultViewConfig = views[defaultView] || { name: defaultView, entityType: 'Record', resource: defaultView };
+
+  // Initialize data source once for the whole store.
+  // Per-view stores MUST NOT call init() again, otherwise view-specific defaults can leak across views
+  // when a data source keeps mutable config at instance scope.
+  if (ds && typeof ds.init === 'function') {
+    ds.init({
+      model,
+      defaults: {
+        entityType: defaultViewConfig.entityType || defaultViewConfig.entity || 'Record',
+        keyField: defaultViewConfig.keyField || 'id',
+        versionField: defaultViewConfig.versionField || 'version',
+        ...(cfg.dataSourceOptions || {}),
+      }
+    });
+  }
 
   // The returned store is the default view controller, with `collection(name)` to access others.
   const defaultStore = createRemoteViewStore({ model, dataSource: ds, viewName: defaultView, viewConfig: { ...defaultViewConfig, name: defaultView } });

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -1,3 +1,4 @@
+import { BlinxArrayDataSource, BlinxDataSource } from './blinx.datasource.js';
 
 export const DataTypes = {
   string: 'string',
@@ -18,7 +19,7 @@ export const EventTypes = {
 
 const clone = value => JSON.parse(JSON.stringify(value));
 
-export function blinxStore(initialArray, dataModel) {
+function createLegacyArrayStore(initialArray, dataModel) {
   let original = clone(initialArray);
   let current = clone(initialArray);
   const model = dataModel;
@@ -127,5 +128,386 @@ export function blinxStore(initialArray, dataModel) {
   return storeApi;
 }
 
+function normalizeViewsConfig(input) {
+  if (input && typeof input === 'object' && !Array.isArray(input) && input.views) {
+    const views = input.views || {};
+    const keys = Object.keys(views);
+    const defaultView = input.defaultView || keys[0] || 'default';
+    return { ...input, views, defaultView };
+  }
+  // Allow single view config via `view`
+  if (input && typeof input === 'object' && !Array.isArray(input) && input.view) {
+    const viewName = input.view.name || 'default';
+    return { ...input, views: { [viewName]: input.view }, defaultView: viewName };
+  }
+  return null;
+}
+
+function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
+  const subs = new Set();
+  let storeApi;
+
+  const entityType = viewConfig.entityType || viewConfig.entity || 'Record';
+  const keyField = viewConfig.keyField || 'id';
+  const versionField = viewConfig.versionField || 'version';
+  const resource = viewConfig.resource || viewConfig.name || viewName || 'resource';
+  const defaultPage = viewConfig.defaultPage || viewConfig.page || { mode: 'cursor', limit: 20, after: null };
+
+  let original = []; // last loaded/saved snapshot (page-local)
+  let current = [];  // current working set (page-local)
+  let pageInfo = null;
+  let pageState = {
+    mode: defaultPage.mode || 'cursor',
+    cursor: defaultPage.after ?? null,
+    page: defaultPage.page ?? 0,
+    offset: defaultPage.offset ?? 0,
+    limit: defaultPage.limit ?? 20,
+    pageIndex: 0, // used for cursor-mode UX (best-effort)
+  };
+  let criteria = { filter: viewConfig.defaultFilter || null, sort: viewConfig.defaultSort || null, select: viewConfig.defaultSelect || null };
+  let status = 'idle';
+  let error = null;
+  let opSeq = 1;
+  const pendingOps = []; // queued local ops (for offline / save batching)
+
+  if (dataSource && typeof dataSource.init === 'function') {
+    dataSource.init({ model, defaults: { entityType, keyField, versionField } });
+  }
+
+  function notify(path, value) {
+    subs.forEach(fn => fn({ path, value, data: current, store: storeApi }));
+  }
+
+  function getModel() { return model; }
+  function getLength() { return current.length; }
+  function getRecord(idx) { return current[idx]; }
+  function subscribe(fn) { subs.add(fn); return () => subs.delete(fn); }
+  function toJSON() { return clone(current); }
+  function getStatus() { return { status, error, pageInfo, pageState: { ...pageState }, criteria: clone(criteria) }; }
+
+  function diff() {
+    // Keep legacy diff shape (index-based) for UI messaging/debugging.
+    const changes = [];
+    const max = Math.max(current.length, original.length);
+    for (let i = 0; i < max; i++) {
+      const rec = current[i];
+      const orig = original[i];
+      if (rec && !orig) { changes.push({ index: i, added: true, to: rec }); continue; }
+      if (!rec && orig) { changes.push({ index: i, deleted: true, from: orig }); continue; }
+      if (rec && orig) {
+        for (const k of Object.keys(rec)) {
+          if (JSON.stringify(rec[k]) !== JSON.stringify(orig[k])) {
+            changes.push({ index: i, field: k, from: orig[k], to: rec[k] });
+          }
+        }
+      }
+    }
+    return changes;
+  }
+
+  function commit() {
+    // Local snapshot only (does not sync remotely). Provided for backwards compatibility.
+    const snapshot = clone(current);
+    original = snapshot;
+    notify([EventTypes.commit], snapshot);
+  }
+
+  function reset() {
+    // Discard local edits and queued ops for this view.
+    pendingOps.length = 0;
+    current = clone(original);
+    current.forEach((record, idx) => notify([EventTypes.reset, idx], record));
+  }
+
+  function ensureRecord(idx) {
+    if (idx < 0 || idx >= current.length) return null;
+    const rec = current[idx];
+    if (!rec || typeof rec !== 'object') return null;
+    return rec;
+  }
+
+  function enqueue(op) {
+    pendingOps.push(op);
+    return op;
+  }
+
+  function setField(idx, field, value) {
+    const rec = ensureRecord(idx);
+    if (!rec) return;
+    rec[field] = value;
+    notify([idx, field], value);
+
+    const id = rec?.[keyField];
+    const baseVersion = (original[idx] && original[idx][versionField] !== undefined) ? String(original[idx][versionField]) : null;
+    if (id !== undefined && id !== null) {
+      enqueue({
+        opId: `op-${viewName}-${opSeq++}`,
+        type: 'update',
+        entity: { type: entityType, id: String(id) },
+        patch: { [field]: value },
+        baseVersion,
+      });
+    }
+  }
+
+  function addRecord(record, atIndex = current.length) {
+    const rec = clone(record || {});
+    if (rec[keyField] === undefined || rec[keyField] === null || rec[keyField] === '') {
+      rec[keyField] = `tmp-${viewName}-${opSeq++}`;
+    }
+    if (rec[versionField] === undefined) rec[versionField] = '0';
+    current.splice(atIndex, 0, rec);
+    notify([EventTypes.add, atIndex], rec);
+
+    enqueue({
+      opId: `op-${viewName}-${opSeq++}`,
+      type: 'create',
+      entity: { type: entityType },
+      data: clone(rec),
+    });
+    return atIndex;
+  }
+
+  function removeRecords(indexes) {
+    const sorted = Array.from(new Set(indexes)).sort((a, b) => b - a);
+    const removed = [];
+    sorted.forEach(i => {
+      if (i >= 0 && i < current.length) {
+        const [record] = current.splice(i, 1);
+        removed.push({ index: i, record });
+        const id = record?.[keyField];
+        const baseVersion = record?.[versionField] !== undefined ? String(record[versionField]) : null;
+        if (id !== undefined && id !== null) {
+          enqueue({
+            opId: `op-${viewName}-${opSeq++}`,
+            type: 'delete',
+            entity: { type: entityType, id: String(id) },
+            baseVersion,
+          });
+        }
+      }
+    });
+    if (removed.length > 0) {
+      const removedIndexes = removed.map(item => item.index);
+      const removedRecords = removed.map(item => item.record);
+      notify([EventTypes.remove, removedIndexes], removedRecords);
+    }
+    return removed.length;
+  }
+
+  function updateIndex(index) {
+    if (index < 0 || index >= current.length) return null;
+    const record = current[index];
+    notify([EventTypes.update, index], record);
+    return record;
+  }
+
+  function update(index, record) {
+    if (index < 0 || index >= current.length) return null;
+    current[index] = clone(record);
+    notify([EventTypes.update, index], current[index]);
+    return current[index];
+  }
+
+  function buildQuerySpec(overrides = {}) {
+    const page = (() => {
+      const mode = pageState.mode || 'cursor';
+      if (mode === 'page') return { mode: 'page', page: pageState.page || 0, limit: pageState.limit };
+      if (mode === 'offset') return { mode: 'offset', offset: pageState.offset || 0, limit: pageState.limit };
+      return { mode: 'cursor', after: pageState.cursor ?? null, limit: pageState.limit };
+    })();
+
+    return {
+      resource,
+      entityType,
+      select: criteria.select || null,
+      filter: criteria.filter || null,
+      sort: criteria.sort || null,
+      page,
+      params: {},
+      ...overrides,
+    };
+  }
+
+  async function loadFirst(nextCriteria = null) {
+    if (!dataSource || typeof dataSource.query !== 'function') {
+      throw new Error('Remote store requires a dataSource with query().');
+    }
+    if (nextCriteria) criteria = { ...criteria, ...clone(nextCriteria) };
+    status = 'loading'; error = null;
+    pageState = { ...pageState, cursor: defaultPage.after ?? null, page: defaultPage.page ?? 0, offset: defaultPage.offset ?? 0, pageIndex: 0 };
+    const res = await dataSource.query(buildQuerySpec(), {});
+    // Materialize as page-local array
+    const records = (res?.entities?.[entityType] || []).map(r => clone(r));
+    current = records;
+    original = clone(records);
+    pageInfo = res?.pageInfo || null;
+    status = 'success';
+    notify([EventTypes.reset, 0], current[0] || null);
+    return res;
+  }
+
+  async function pageNext() {
+    if (!dataSource || typeof dataSource.query !== 'function') throw new Error('Remote store requires a dataSource with query().');
+    const mode = pageState.mode || 'cursor';
+    if (mode === 'page') pageState = { ...pageState, page: (pageState.page || 0) + 1 };
+    else if (mode === 'offset') pageState = { ...pageState, offset: (pageState.offset || 0) + (pageState.limit || 20) };
+    else {
+      const next = pageInfo?.nextCursor;
+      if (next === null || next === undefined) return null;
+      pageState = { ...pageState, cursor: next, pageIndex: (pageState.pageIndex || 0) + 1 };
+    }
+    status = 'loading'; error = null;
+    const res = await dataSource.query(buildQuerySpec(), {});
+    const records = (res?.entities?.[entityType] || []).map(r => clone(r));
+    current = records;
+    original = clone(records);
+    pageInfo = res?.pageInfo || null;
+    status = 'success';
+    notify([EventTypes.reset, 0], current[0] || null);
+    return res;
+  }
+
+  async function pagePrev() {
+    if (!dataSource || typeof dataSource.query !== 'function') throw new Error('Remote store requires a dataSource with query().');
+    const mode = pageState.mode || 'cursor';
+    if (mode === 'page') pageState = { ...pageState, page: Math.max(0, (pageState.page || 0) - 1) };
+    else if (mode === 'offset') pageState = { ...pageState, offset: Math.max(0, (pageState.offset || 0) - (pageState.limit || 20)) };
+    else {
+      const prev = pageInfo?.prevCursor;
+      if (prev === null || prev === undefined) return null;
+      pageState = { ...pageState, cursor: prev, pageIndex: Math.max(0, (pageState.pageIndex || 0) - 1) };
+    }
+    status = 'loading'; error = null;
+    const res = await dataSource.query(buildQuerySpec(), {});
+    const records = (res?.entities?.[entityType] || []).map(r => clone(r));
+    current = records;
+    original = clone(records);
+    pageInfo = res?.pageInfo || null;
+    status = 'success';
+    notify([EventTypes.reset, 0], current[0] || null);
+    return res;
+  }
+
+  async function search(nextCriteria) {
+    return loadFirst(nextCriteria || {});
+  }
+
+  async function save() {
+    if (!dataSource || typeof dataSource.mutate !== 'function') {
+      // No remote: fallback to local commit to keep behavior consistent.
+      commit();
+      return { applied: [], rejected: [], conflicts: [] };
+    }
+    if (pendingOps.length === 0) return { applied: [], rejected: [], conflicts: [], entities: {} };
+    status = 'saving'; error = null;
+    const ops = pendingOps.splice(0, pendingOps.length).map(o => clone(o));
+    const res = await dataSource.mutate(ops, {});
+    const conflicts = res?.conflicts || [];
+    const rejected = res?.rejected || [];
+    if (conflicts.length || rejected.length) {
+      // Re-queue failed ops for future retry, but do not commit snapshot.
+      pendingOps.unshift(...ops);
+      status = 'error';
+      error = { conflicts, rejected };
+      return res;
+    }
+    // Apply canonical entities (if provided) and snapshot.
+    const canonical = res?.entities?.[entityType] || null;
+    if (canonical && Array.isArray(canonical)) {
+      // Replace by id for any returned records; keep current ordering.
+      const byId = new Map(canonical.map(r => [String(r?.[keyField]), clone(r)]));
+      current = current.map(r => {
+        const id = String(r?.[keyField]);
+        return byId.has(id) ? byId.get(id) : r;
+      });
+    }
+    original = clone(current);
+    status = 'success';
+    notify([EventTypes.commit], clone(current));
+    return res;
+  }
+
+  storeApi = {
+    getModel,
+    getRecord,
+    getLength,
+    setField,
+    addRecord,
+    removeRecords,
+    updateIndex,
+    update,
+    subscribe,
+    toJSON,
+    diff,
+    commit,
+    reset,
+
+    // Remote/view-oriented API
+    loadFirst,
+    pageNext,
+    pagePrev,
+    search,
+    save,
+    getStatus,
+    getPagingState: () => ({ pageInfo, pageState: { ...pageState } }),
+
+    // View compatibility (if store is used as a collection controller)
+    collection: () => storeApi,
+  };
+
+  return storeApi;
+}
+
+export function blinxStore(arg1, arg2) {
+  // Legacy: blinxStore(initialArray, model)
+  if (Array.isArray(arg1)) return createLegacyArrayStore(arg1, arg2);
+
+  const cfg = normalizeViewsConfig(arg1);
+  if (!cfg) {
+    throw new Error('blinxStore: expected (initialArray, model) or ({ model, dataSource, views, defaultView } | { model, dataSource, view }).');
+  }
+
+  const model = cfg.model;
+  if (!model) throw new Error('blinxStore: missing required model.');
+
+  let ds = cfg.dataSource;
+  if (Array.isArray(ds)) {
+    ds = new BlinxArrayDataSource(ds, cfg.dataSourceOptions || {});
+  }
+  if (!ds) {
+    // Backward compatible: allow `initialArray` key on config for convenience.
+    if (Array.isArray(cfg.initialArray)) ds = new BlinxArrayDataSource(cfg.initialArray, cfg.dataSourceOptions || {});
+  }
+  if (!ds) throw new Error('blinxStore: missing required dataSource (or initialArray).');
+  if (!(ds instanceof BlinxDataSource) && (typeof ds.query !== 'function' || typeof ds.mutate !== 'function')) {
+    throw new Error('blinxStore: dataSource must implement query() and mutate().');
+  }
+
+  const views = cfg.views || {};
+  const defaultView = cfg.defaultView || Object.keys(views)[0] || 'default';
+  const defaultViewConfig = views[defaultView] || { name: defaultView, entityType: 'Record', resource: defaultView };
+
+  // The returned store is the default view controller, with `collection(name)` to access others.
+  const defaultStore = createRemoteViewStore({ model, dataSource: ds, viewName: defaultView, viewConfig: { ...defaultViewConfig, name: defaultView } });
+
+  const viewStores = new Map([[defaultView, defaultStore]]);
+
+  defaultStore.collection = (name = defaultView) => {
+    const key = name || defaultView;
+    if (viewStores.has(key)) return viewStores.get(key);
+    const vc = views[key];
+    if (!vc) throw new Error(`Unknown collection/view "${String(key)}".`);
+    const vs = createRemoteViewStore({ model, dataSource: ds, viewName: key, viewConfig: { ...vc, name: key } });
+    viewStores.set(key, vs);
+    return vs;
+  };
+
+  return defaultStore;
+}
+
 // Backwards-compatible alias (deprecated)
 export { blinxStore as createBlinxStore };
+
+// Re-export data source types for convenience
+export { BlinxDataSource, BlinxArrayDataSource };

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -231,6 +231,35 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     return op;
   }
 
+  function enqueueUpdate(entityId, baseVersion, patch) {
+    const eid = entityId === undefined || entityId === null ? null : String(entityId);
+    if (!eid) return null;
+    // Coalesce multiple field edits on the same record into a single update op.
+    // This avoids "self-conflicts" where multiple ops share the same baseVersion.
+    for (let i = pendingOps.length - 1; i >= 0; i--) {
+      const existing = pendingOps[i];
+      if (
+        existing &&
+        existing.type === 'update' &&
+        existing.entity &&
+        existing.entity.type === entityType &&
+        String(existing.entity.id) === eid
+      ) {
+        existing.patch = { ...(existing.patch || {}), ...(patch || {}) };
+        return existing;
+      }
+    }
+    const op = {
+      opId: `op-${viewName}-${opSeq++}`,
+      type: 'update',
+      entity: { type: entityType, id: eid },
+      patch: { ...(patch || {}) },
+      baseVersion,
+    };
+    pendingOps.push(op);
+    return op;
+  }
+
   function setField(idx, field, value) {
     const rec = ensureRecord(idx);
     if (!rec) return;
@@ -240,13 +269,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     const id = rec?.[keyField];
     const baseVersion = (original[idx] && original[idx][versionField] !== undefined) ? String(original[idx][versionField]) : null;
     if (id !== undefined && id !== null) {
-      enqueue({
-        opId: `op-${viewName}-${opSeq++}`,
-        type: 'update',
-        entity: { type: entityType, id: String(id) },
-        patch: { [field]: value },
-        baseVersion,
-      });
+      enqueueUpdate(id, baseVersion, { [field]: value });
     }
   }
 


### PR DESCRIPTION
Introduce a remote-capable data layer and refactor `blinxStore` to support it, enabling Blinx to connect to actual data sources.

This shifts the data access model from chunk-based to a query/mutation API, supporting pagination, optimistic updates, and conflict resolution for realistic applications, while maintaining backward compatibility for existing array-based stores.

---
<a href="https://cursor.com/background-agent?bcId=bc-6846e397-2dbf-4b65-a831-9fc4bcddf369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6846e397-2dbf-4b65-a831-9fc4bcddf369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce BlinxDataSource/BlinxArrayDataSource with query/mutate and refactor blinxStore and UI to support remote pagination/saving while preserving legacy array-store compatibility.
> 
> - **Data Layer**:
>   - **New** `BlinxDataSource` base and `BlinxArrayDataSource` implementation providing `query`/`mutate`, filtering, sorting, and pagination (`cursor`/`page`/`offset`) with versioning/conflict handling.
>   - Re-export data source types via `lib/blinx.store.js`.
> - **Store** (`blinx.store.js`):
>   - Add remote-capable store creation (`blinxStore({ model, dataSource, view|views })`) with per-view state.
>   - New APIs: `loadFirst`, `pageNext`, `pagePrev`, `save`, `search`, `getStatus`, `getPagingState`; maintain legacy array-store path.
>   - Track pending ops (create/update/delete) and apply via data source; snapshotting/back-compat `commit/reset` retained.
> - **UI**:
>   - `blinx.collection`: support remote paging (buttons call `store.pageNext/pagePrev`), pager label reflects remote page state; robust async `runInternalChange`.
>   - `blinx.form`: `save` uses `store.save()` when available; `reset`/internal changes handle async.
> - **Tests**:
>   - Add unit tests for array data source (filters/sorts/pagination/mutation/conflicts).
>   - Add integration tests for remote store (load/edit/save, cursor pagination).
>   - Add UI tests for renderer registration/locking and renderer selection overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3508b4c90b9efca2bb14e794038b2eebf1b8639e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->