### PR TITLE
Blinx rest data source design

### DIFF
--- a/__tests__/blinx.datasource.rest.test.js
+++ b/__tests__/blinx.datasource.rest.test.js
@@ -60,6 +60,15 @@ describe('BlinxRestDataSource', () => {
     expect(res.entities.Product[0].version).toBeDefined();
   });
 
+  test('query(): throws on non-2xx HTTP responses (does not silently return empty data)', async () => {
+    const fetch = async () => makeResponse({ status: 500, json: { message: 'server down' } });
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+    ds.init({ defaults: { entityType: 'Product', keyField: 'id', versionField: 'version' } });
+
+    await expect(ds.query({ resource: 'products', entityType: 'Product' })).rejects.toThrow('server down');
+  });
+
   test('mutate(update): sends If-Match from baseVersion and returns canonical entity with ETag as version', async () => {
     const fetchCalls = [];
     const fetch = async (url, init) => {

--- a/__tests__/blinx.datasource.rest.test.js
+++ b/__tests__/blinx.datasource.rest.test.js
@@ -1,0 +1,144 @@
+import { BlinxRestDataSource } from '../lib/blinx.datasource.js';
+
+function makeHeaders(map = {}) {
+  const lower = new Map(Object.entries(map).map(([k, v]) => [String(k).toLowerCase(), String(v)]));
+  return {
+    get(name) {
+      return lower.has(String(name).toLowerCase()) ? lower.get(String(name).toLowerCase()) : null;
+    }
+  };
+}
+
+function makeResponse({ status = 200, json = null, headers = {} } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: makeHeaders(headers),
+    async json() {
+      if (json instanceof Error) throw json;
+      return json;
+    },
+  };
+}
+
+describe('BlinxRestDataSource', () => {
+  test('query(): builds URL with filter/sort/paging and normalizes entities/result', async () => {
+    const fetchCalls = [];
+    const fetch = async (url, init) => {
+      fetchCalls.push({ url, init });
+      return makeResponse({
+        status: 200,
+        headers: { 'x-total-count': '2' },
+        json: [{ id: 2, name: 'B' }],
+      });
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+    ds.init({ defaults: { entityType: 'Product', keyField: 'id', versionField: 'version' } });
+
+    const res = await ds.query({
+      resource: 'products',
+      entityType: 'Product',
+      filter: { category: 'x' },
+      sort: [{ field: 'name', dir: 'desc' }],
+      page: { mode: 'page', page: 1, limit: 10 },
+    });
+
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].init.method).toBe('GET');
+    // URL shape is default-mapped and should include key params.
+    expect(fetchCalls[0].url).toContain('https://api.test/products');
+    expect(fetchCalls[0].url).toContain('category=x');
+    expect(fetchCalls[0].url).toContain('sort=-name');
+    expect(fetchCalls[0].url).toContain('page=1');
+    expect(fetchCalls[0].url).toContain('limit=10');
+
+    expect(res.pageInfo.totalCount).toBe(2);
+    expect(res.result).toEqual([{ type: 'Product', id: '2' }]);
+    expect(res.entities.Product[0]).toEqual(expect.objectContaining({ id: '2', name: 'B' }));
+    // Version is always materialized (best-effort) so the store can compute baseVersion.
+    expect(res.entities.Product[0].version).toBeDefined();
+  });
+
+  test('mutate(update): sends If-Match from baseVersion and returns canonical entity with ETag as version', async () => {
+    const fetchCalls = [];
+    const fetch = async (url, init) => {
+      fetchCalls.push({ url, init });
+      return makeResponse({
+        status: 200,
+        headers: { etag: '"v2"' },
+        json: { id: '1', name: 'B' },
+      });
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+    ds.init({ defaults: { entityType: 'Product', keyField: 'id', versionField: 'version' } });
+
+    const res = await ds.mutate([
+      { opId: 'u1', type: 'update', entity: { type: 'Product', id: '1' }, patch: { name: 'B' }, baseVersion: '"v1"' }
+    ], { resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version' });
+
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toBe('https://api.test/products/1');
+    expect(fetchCalls[0].init.method).toBe('PATCH');
+    expect(fetchCalls[0].init.headers['If-Match']).toBe('"v1"');
+
+    expect(res.rejected).toEqual([]);
+    expect(res.conflicts).toEqual([]);
+    expect(res.applied).toEqual([expect.objectContaining({ opId: 'u1', status: 'applied' })]);
+    expect(res.entities.Product[0]).toEqual(expect.objectContaining({ id: '1', name: 'B', version: '"v2"' }));
+  });
+
+  test('mutate(update): maps 412 to conflict and fetches latest record for conflict payload', async () => {
+    const fetchCalls = [];
+    const fetch = async (url, init) => {
+      fetchCalls.push({ url, init });
+      // First call: PATCH => precondition failed.
+      if (fetchCalls.length === 1) {
+        return makeResponse({ status: 412, json: { message: 'stale' } });
+      }
+      // Second call: GET latest
+      return makeResponse({
+        status: 200,
+        headers: { etag: '"v2"' },
+        json: { id: '1', name: 'Server', version: '"v2"' },
+      });
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+    ds.init({ defaults: { entityType: 'Product', keyField: 'id', versionField: 'version' } });
+
+    const res = await ds.mutate([
+      { opId: 'u1', type: 'update', entity: { type: 'Product', id: '1' }, patch: { name: 'Local' }, baseVersion: '"v1"' }
+    ], { resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version' });
+
+    expect(fetchCalls.length).toBe(2);
+    expect(fetchCalls[0].init.method).toBe('PATCH');
+    expect(fetchCalls[1].init.method).toBe('GET');
+
+    expect(res.applied).toEqual([]);
+    expect(res.rejected).toEqual([]);
+    expect(res.conflicts).toEqual([
+      expect.objectContaining({
+        opId: 'u1',
+        status: 'conflict',
+        latestVersion: '"v2"',
+        server: expect.objectContaining({ id: '1', name: 'Server' }),
+        httpStatus: 412,
+      })
+    ]);
+  });
+
+  test('mutate(): throws on transport failure (so store can re-queue all ops)', async () => {
+    const fetch = async () => {
+      throw new Error('network down');
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+    ds.init({ defaults: { entityType: 'Product', keyField: 'id', versionField: 'version' } });
+
+    await expect(ds.mutate([
+      { opId: 'u1', type: 'update', entity: { type: 'Product', id: '1' }, patch: { name: 'B' }, baseVersion: '"v1"' }
+    ], { resource: 'products', entityType: 'Product' })).rejects.toThrow('network down');
+  });
+});

--- a/__tests__/blinx.datasource.rest.test.js
+++ b/__tests__/blinx.datasource.rest.test.js
@@ -141,4 +141,170 @@ describe('BlinxRestDataSource', () => {
       { opId: 'u1', type: 'update', entity: { type: 'Product', id: '1' }, patch: { name: 'B' }, baseVersion: '"v1"' }
     ], { resource: 'products', entityType: 'Product' })).rejects.toThrow('network down');
   });
+
+  test('mutate(): multi-op same record => first update applied, second update 412 + GET latest => conflict (order: PATCH, PATCH, GET)', async () => {
+    const fetchCalls = [];
+    const fetch = async (url, init) => {
+      fetchCalls.push({ url, init });
+
+      // 1) PATCH #1 -> ok
+      if (fetchCalls.length === 1) {
+        return makeResponse({ status: 200, headers: { etag: '"v2"' }, json: { id: '1', name: 'B' } });
+      }
+      // 2) PATCH #2 -> 412 conflict
+      if (fetchCalls.length === 2) {
+        return makeResponse({ status: 412, json: { message: 'stale' } });
+      }
+      // 3) GET latest for conflict payload
+      return makeResponse({ status: 200, headers: { etag: '"v9"' }, json: { id: '1', name: 'Server', version: '"v9"' } });
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+    ds.init({ defaults: { entityType: 'Product', keyField: 'id', versionField: 'version' } });
+
+    const res = await ds.mutate([
+      { opId: 'u1', type: 'update', entity: { type: 'Product', id: '1' }, patch: { name: 'B' }, baseVersion: '"v1"' },
+      { opId: 'u2', type: 'update', entity: { type: 'Product', id: '1' }, patch: { price: 2 }, baseVersion: '"v1"' },
+    ], { resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version' });
+
+    expect(fetchCalls.length).toBe(3);
+    expect(fetchCalls.map(c => c.init.method)).toEqual(['PATCH', 'PATCH', 'GET']);
+    expect(fetchCalls[0].url).toBe('https://api.test/products/1');
+    expect(fetchCalls[1].url).toBe('https://api.test/products/1');
+    expect(fetchCalls[2].url).toBe('https://api.test/products/1');
+    expect(fetchCalls[0].init.headers['If-Match']).toBe('"v1"');
+    expect(fetchCalls[1].init.headers['If-Match']).toBe('"v1"');
+
+    expect(res.applied.map(a => a.opId)).toEqual(['u1']);
+    expect(res.rejected).toEqual([]);
+    expect(res.conflicts).toEqual([
+      expect.objectContaining({
+        opId: 'u2',
+        status: 'conflict',
+        latestVersion: '"v9"',
+        server: expect.objectContaining({ id: '1', name: 'Server' }),
+        local: expect.objectContaining({ opId: 'u2' }),
+        httpStatus: 412,
+      }),
+    ]);
+    expect(res.entities.Product).toEqual([expect.objectContaining({ id: '1', name: 'B', version: '"v2"' })]);
+  });
+
+  test('mutate(): same record, multiple ops on different fields (both applied, in order, no merging at datasource layer)', async () => {
+    const fetchCalls = [];
+    const fetch = async (url, init) => {
+      fetchCalls.push({ url, init });
+      // Echo back what server would return as canonical record.
+      if (fetchCalls.length === 1) {
+        return makeResponse({ status: 200, headers: { etag: '"v2"' }, json: { id: '1', name: 'B' } });
+      }
+      return makeResponse({ status: 200, headers: { etag: '"v3"' }, json: { id: '1', price: 2 } });
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+    ds.init({ defaults: { entityType: 'Product', keyField: 'id', versionField: 'version' } });
+
+    const res = await ds.mutate([
+      { opId: 'u1', type: 'update', entity: { type: 'Product', id: '1' }, patch: { name: 'B' }, baseVersion: '"v1"' },
+      { opId: 'u2', type: 'update', entity: { type: 'Product', id: '1' }, patch: { price: 2 }, baseVersion: '"v2"' },
+    ], { resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version' });
+
+    expect(fetchCalls.length).toBe(2);
+    expect(fetchCalls.map(c => c.init.method)).toEqual(['PATCH', 'PATCH']);
+    expect(fetchCalls[0].init.headers['If-Match']).toBe('"v1"');
+    expect(fetchCalls[1].init.headers['If-Match']).toBe('"v2"');
+    expect(JSON.parse(fetchCalls[0].init.body)).toEqual({ name: 'B' });
+    expect(JSON.parse(fetchCalls[1].init.body)).toEqual({ price: 2 });
+
+    expect(res.conflicts).toEqual([]);
+    expect(res.rejected).toEqual([]);
+    expect(res.applied.map(a => a.opId)).toEqual(['u1', 'u2']);
+    // Datasource returns canonical records per successful op; store decides how to apply.
+    expect(res.entities.Product.map(r => r.version)).toEqual(['"v2"', '"v3"']);
+  });
+
+  test('mutate(): different records, mixed results in one call (u1 applied, u2 412+GET conflict)', async () => {
+    const fetchCalls = [];
+    const fetch = async (url, init) => {
+      fetchCalls.push({ url, init });
+      // 1) PATCH /1 -> ok
+      if (fetchCalls.length === 1) {
+        return makeResponse({ status: 200, headers: { etag: '"v2"' }, json: { id: '1', name: 'B' } });
+      }
+      // 2) PATCH /2 -> 412
+      if (fetchCalls.length === 2) {
+        return makeResponse({ status: 412, json: { message: 'stale' } });
+      }
+      // 3) GET /2 latest
+      return makeResponse({ status: 200, headers: { etag: '"v8"' }, json: { id: '2', name: 'Server2', version: '"v8"' } });
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+    ds.init({ defaults: { entityType: 'Product', keyField: 'id', versionField: 'version' } });
+
+    const res = await ds.mutate([
+      { opId: 'u1', type: 'update', entity: { type: 'Product', id: '1' }, patch: { name: 'B' }, baseVersion: '"v1"' },
+      { opId: 'u2', type: 'update', entity: { type: 'Product', id: '2' }, patch: { name: 'X' }, baseVersion: '"v1"' },
+    ], { resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version' });
+
+    expect(fetchCalls.length).toBe(3);
+    expect(fetchCalls.map(c => `${c.init.method} ${c.url}`)).toEqual([
+      'PATCH https://api.test/products/1',
+      'PATCH https://api.test/products/2',
+      'GET https://api.test/products/2',
+    ]);
+    expect(res.applied.map(a => a.opId)).toEqual(['u1']);
+    expect(res.conflicts.map(c => c.opId)).toEqual(['u2']);
+    expect(res.entities.Product).toEqual([expect.objectContaining({ id: '1', name: 'B', version: '"v2"' })]);
+  });
+
+  test('mutate(): throws when transport fails mid-batch (best-effort semantics delegated to store re-queue)', async () => {
+    const fetchCalls = [];
+    const fetch = async (url, init) => {
+      fetchCalls.push({ url, init });
+      if (fetchCalls.length === 1) {
+        return makeResponse({ status: 200, headers: { etag: '"v2"' }, json: { id: '1', name: 'B' } });
+      }
+      throw new Error('network down');
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+    ds.init({ defaults: { entityType: 'Product', keyField: 'id', versionField: 'version' } });
+
+    await expect(ds.mutate([
+      { opId: 'u1', type: 'update', entity: { type: 'Product', id: '1' }, patch: { name: 'B' }, baseVersion: '"v1"' },
+      { opId: 'u2', type: 'update', entity: { type: 'Product', id: '2' }, patch: { name: 'C' }, baseVersion: '"v1"' },
+    ], { resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version' })).rejects.toThrow('network down');
+
+    expect(fetchCalls.length).toBe(2);
+    expect(fetchCalls[0].init.method).toBe('PATCH');
+    expect(fetchCalls[1].init.method).toBe('PATCH');
+  });
+
+  test('mutate(): supports mixed applied + rejected within one call (does not throw)', async () => {
+    const fetchCalls = [];
+    const fetch = async (url, init) => {
+      fetchCalls.push({ url, init });
+      if (url.endsWith('/1')) {
+        return makeResponse({ status: 200, headers: { etag: '"v2"' }, json: { id: '1', name: 'B' } });
+      }
+      // Not found for record 2
+      return makeResponse({ status: 404, json: { message: 'Not found' } });
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+    ds.init({ defaults: { entityType: 'Product', keyField: 'id', versionField: 'version' } });
+
+    const res = await ds.mutate([
+      { opId: 'u1', type: 'update', entity: { type: 'Product', id: '1' }, patch: { name: 'B' }, baseVersion: '"v1"' },
+      { opId: 'u2', type: 'update', entity: { type: 'Product', id: '2' }, patch: { name: 'C' }, baseVersion: '"v1"' },
+    ], { resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version' });
+
+    expect(fetchCalls.length).toBe(2);
+    expect(res.applied.map(a => a.opId)).toEqual(['u1']);
+    expect(res.conflicts).toEqual([]);
+    expect(res.rejected).toEqual([
+      expect.objectContaining({ opId: 'u2', status: 'rejected', error: expect.objectContaining({ code: 'not_found', httpStatus: 404 }) }),
+    ]);
+  });
 });

--- a/__tests__/blinx.store.rest.create-and-requeue.test.js
+++ b/__tests__/blinx.store.rest.create-and-requeue.test.js
@@ -1,0 +1,89 @@
+import { blinxStore } from '../lib/blinx.store.js';
+import { BlinxRestDataSource } from '../lib/blinx.datasource.js';
+
+function makeHeaders(map = {}) {
+  const lower = new Map(Object.entries(map).map(([k, v]) => [String(k).toLowerCase(), String(v)]));
+  return {
+    get(name) {
+      return lower.has(String(name).toLowerCase()) ? lower.get(String(name).toLowerCase()) : null;
+    }
+  };
+}
+
+function makeResponse({ status = 200, json = null, headers = {} } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: makeHeaders(headers),
+    async json() { return json; },
+  };
+}
+
+describe('blinxStore + BlinxRestDataSource', () => {
+  test('save(): when mutate throws, all ops are re-queued and retried on next save()', async () => {
+    const calls = [];
+    let shouldThrow = true;
+
+    const fetch = async (url, init) => {
+      calls.push({ url, init });
+      if (shouldThrow) {
+        shouldThrow = false;
+        throw new Error('network down');
+      }
+      // Create succeeds on retry.
+      return makeResponse({ status: 201, headers: { etag: '"v1"' }, json: { id: 'p1', name: 'A', version: '"v1"' } });
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+
+    const store = blinxStore({
+      model: { fields: { id: {}, name: {}, version: {} } },
+      dataSource: ds,
+      view: { name: 'products', resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version', defaultPage: { mode: 'page', page: 0, limit: 10 } },
+    });
+
+    store.addRecord({ name: 'A' });
+
+    await expect(store.save()).rejects.toThrow('network down');
+    // Next save retries the same create.
+    const res = await store.save();
+
+    expect(res.rejected || []).toEqual([]);
+    expect(res.conflicts || []).toEqual([]);
+    expect(res.applied.length).toBe(1);
+    // Two fetch attempts: first threw, second succeeded.
+    expect(calls.length).toBe(2);
+    expect(calls[0].init.method).toBe('POST');
+    expect(calls[1].init.method).toBe('POST');
+  });
+
+  test('save(): reconciles server-assigned ids for create ops when serverId is returned', async () => {
+    const fetch = async (url, init) => {
+      // The store generates a tmp id, but the server returns a canonical id.
+      if (init.method === 'POST') {
+        return makeResponse({ status: 201, headers: { etag: '"v1"' }, json: { id: 'p100', name: 'A', version: '"v1"' } });
+      }
+      throw new Error(`Unexpected request: ${init.method} ${url}`);
+    };
+
+    const ds = new BlinxRestDataSource({ baseUrl: 'https://api.test', fetch });
+
+    const store = blinxStore({
+      model: { fields: { id: {}, name: {}, version: {} } },
+      dataSource: ds,
+      view: { name: 'products', resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version', defaultPage: { mode: 'page', page: 0, limit: 10 } },
+    });
+
+    const idx = store.addRecord({ name: 'A' });
+    const before = store.getRecord(idx).id;
+    expect(String(before)).toContain('tmp-');
+
+    const res = await store.save();
+    expect(res.rejected || []).toEqual([]);
+    expect(res.conflicts || []).toEqual([]);
+
+    const after = store.getRecord(idx).id;
+    expect(after).toBe('p100');
+    expect(store.getRecord(idx)).toEqual(expect.objectContaining({ id: 'p100', name: 'A', version: '"v1"' }));
+  });
+});

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented here.
 
+## [Unreleased]
+- Added `BlinxRestDataSource` for HTTP-backed query/mutate to support client-server applications.
+- Store now passes view context to `dataSource.query/mutate` and reconciles server-assigned IDs for creates.
+- Added thorough REST unit tests (If-Match/ETag, 409/412 conflicts with latest fetch, multi-op batches, and transport failure behavior).
+
 ## [0.3.0] - 2025-12-11
 - Added formal design notes under `docs/design-notes.md` to capture architectural decisions and future bets.
 - Documented change history to improve onboarding for new contributors.

--- a/lib/blinx.datasource.js
+++ b/lib/blinx.datasource.js
@@ -283,3 +283,401 @@ export class BlinxArrayDataSource extends BlinxDataSource {
   }
 }
 
+function makeHeadersObject(input) {
+  const out = {};
+  if (!input) return out;
+  if (typeof input !== 'object') return out;
+  for (const [k, v] of Object.entries(input)) {
+    if (v === undefined || v === null) continue;
+    out[String(k)] = String(v);
+  }
+  return out;
+}
+
+function getHeader(headers, name) {
+  if (!headers || !name) return null;
+  if (typeof headers.get === 'function') return headers.get(name);
+  // Fallback for plain objects
+  const key = String(name).toLowerCase();
+  for (const [k, v] of Object.entries(headers)) {
+    if (String(k).toLowerCase() === key) return v;
+  }
+  return null;
+}
+
+function parseJsonSafely(res) {
+  if (!res || typeof res.json !== 'function') return Promise.resolve(null);
+  return res.json().catch(() => null);
+}
+
+function joinUrl(baseUrl, path) {
+  const b = String(baseUrl || '').replace(/\/+$/, '');
+  const p = String(path || '').replace(/^\/+/, '');
+  if (!b) return `/${p}`;
+  if (!p) return b;
+  return `${b}/${p}`;
+}
+
+function encodeQueryParams(params) {
+  const parts = [];
+  for (const [k, v] of Object.entries(params || {})) {
+    if (v === undefined || v === null) continue;
+    if (Array.isArray(v)) {
+      v.forEach(item => parts.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(item))}`));
+      continue;
+    }
+    parts.push(`${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`);
+  }
+  return parts.length ? `?${parts.join('&')}` : '';
+}
+
+function coerceListPayload(json) {
+  // Common list response shapes:
+  // - Array => items
+  // - { items: [] } / { results: [] } / { data: [] }
+  if (Array.isArray(json)) return { items: json, meta: {} };
+  if (json && typeof json === 'object') {
+    if (Array.isArray(json.items)) return { items: json.items, meta: json };
+    if (Array.isArray(json.results)) return { items: json.results, meta: json };
+    if (Array.isArray(json.data)) return { items: json.data, meta: json };
+  }
+  return { items: [], meta: json || {} };
+}
+
+/**
+ * REST/HTTP data source.
+ *
+ * Goals:
+ * - Match the existing Blinx store contract: query() => {entities, result, pageInfo}; mutate() => {applied, rejected, conflicts, entities}
+ * - Provide optimistic concurrency with ETag/If-Match (mapping store's baseVersion to If-Match).
+ *
+ * This is intentionally adapter-driven to work with many "test APIs":
+ * - URL building is configurable but has sensible defaults:
+ *   - list:   `${baseUrl}/${resource}`
+ *   - item:   `${baseUrl}/${resource}/${id}`
+ * - list parsing supports common shapes: array, {items}, {results}, {data}
+ * - totalCount may be read from `x-total-count` header or `totalCount/total` fields.
+ */
+export class BlinxRestDataSource extends BlinxDataSource {
+  constructor({
+    baseUrl = '',
+    fetch: fetchImpl = null,
+    headers = {},
+    // Optional per-resource config: { [resource]: { path, itemPath, entityType, keyField, versionField } }
+    resources = {},
+    // Concurrency settings (store baseVersion => If-Match by default)
+    concurrency = { mode: 'etag', ifMatchHeader: 'If-Match', etagHeader: 'ETag' },
+  } = {}) {
+    super();
+    this._baseUrl = baseUrl;
+    this._fetch = fetchImpl;
+    this._headers = makeHeadersObject(headers);
+    this._resources = resources || {};
+    this._concurrency = {
+      mode: concurrency?.mode || 'etag',
+      ifMatchHeader: concurrency?.ifMatchHeader || 'If-Match',
+      etagHeader: concurrency?.etagHeader || 'ETag',
+    };
+
+    // Defaults; may be overridden by init() from store.
+    this._entityType = 'Record';
+    this._keyField = 'id';
+    this._versionField = 'version';
+  }
+
+  init({ model, defaults } = {}) {
+    super.init({ model, defaults });
+    if (defaults?.entityType) this._entityType = defaults.entityType;
+    if (defaults?.keyField) this._keyField = defaults.keyField;
+    if (defaults?.versionField) this._versionField = defaults.versionField;
+  }
+
+  capabilities() {
+    return {
+      pagination: ['cursor', 'page', 'offset'],
+      conflicts: true,
+      subscriptions: false,
+      offline: false,
+    };
+  }
+
+  _getFetch() {
+    const f = this._fetch || globalThis.fetch;
+    if (typeof f !== 'function') {
+      throw new Error('BlinxRestDataSource: fetch is not available. Provide { fetch } in constructor options.');
+    }
+    return f;
+  }
+
+  _resourceConfig(resource, entityTypeFromQuery) {
+    const cfg = (resource && this._resources && this._resources[resource]) ? this._resources[resource] : null;
+    const entityType = cfg?.entityType || entityTypeFromQuery || this._entityType;
+    const keyField = cfg?.keyField || this._keyField;
+    const versionField = cfg?.versionField || this._versionField;
+    const basePath = cfg?.path || resource || 'resource';
+    const itemPathTemplate = cfg?.itemPath || `${basePath}/{id}`;
+    return { entityType, keyField, versionField, basePath, itemPathTemplate };
+  }
+
+  _buildListUrl(querySpec) {
+    const resource = querySpec?.resource || 'resource';
+    const { basePath } = this._resourceConfig(resource, querySpec?.entityType);
+    const params = { ...(querySpec?.params || {}) };
+
+    // Filter: object => shallow equality params
+    if (querySpec?.filter && typeof querySpec.filter === 'object' && !Array.isArray(querySpec.filter)) {
+      for (const [k, v] of Object.entries(querySpec.filter)) {
+        if (v === undefined || v === null) continue;
+        params[k] = v;
+      }
+    }
+
+    // Sort: `sort=field1,-field2` (common convention)
+    if (Array.isArray(querySpec?.sort) && querySpec.sort.length) {
+      const parts = querySpec.sort
+        .filter(Boolean)
+        .map(s => {
+          const field = s?.field;
+          if (!field) return null;
+          const dir = (s?.dir || 'asc').toLowerCase() === 'desc' ? 'desc' : 'asc';
+          return dir === 'desc' ? `-${field}` : String(field);
+        })
+        .filter(Boolean);
+      if (parts.length) params.sort = parts.join(',');
+    }
+
+    // Paging
+    const page = querySpec?.page || { mode: 'offset', offset: 0, limit: 20 };
+    const limit = Number.isFinite(page?.limit) ? page.limit : 20;
+    if ((page?.mode || 'offset') === 'page') {
+      params.page = Number.isFinite(page?.page) ? page.page : 0;
+      params.limit = limit;
+    } else if ((page?.mode || 'offset') === 'cursor') {
+      params.after = page?.after ?? null;
+      params.limit = limit;
+    } else {
+      params.offset = Number.isFinite(page?.offset) ? page.offset : 0;
+      params.limit = limit;
+    }
+
+    return joinUrl(this._baseUrl, String(basePath)) + encodeQueryParams(params);
+  }
+
+  _buildItemUrl({ resource, id }) {
+    const cfg = this._resourceConfig(resource, null);
+    const path = String(cfg.itemPathTemplate || '').replace('{id}', encodeURIComponent(String(id)));
+    return joinUrl(this._baseUrl, path);
+  }
+
+  _normalizeRecord(rec, { keyField, versionField, fallbackVersion = '0' } = {}) {
+    if (!rec || typeof rec !== 'object') return rec;
+    const out = { ...clone(rec) };
+    // Ensure version exists so the store can always compute baseVersion (even if it becomes "0" best-effort).
+    if (out[versionField] === undefined) out[versionField] = fallbackVersion;
+    // Ensure id is stringy to match the rest of Blinx normalization.
+    if (out[keyField] !== undefined && out[keyField] !== null) out[keyField] = String(out[keyField]);
+    return out;
+  }
+
+  async query(querySpec = {}, _options = {}) {
+    const resource = querySpec?.resource || 'resource';
+    const { entityType, keyField, versionField } = this._resourceConfig(resource, querySpec?.entityType);
+    const fetchImpl = this._getFetch();
+
+    const url = this._buildListUrl({ ...querySpec, resource, entityType });
+    const res = await fetchImpl(url, {
+      method: 'GET',
+      headers: { ...this._headers },
+    });
+
+    const json = await parseJsonSafely(res);
+    const { items, meta } = coerceListPayload(json);
+
+    const totalCountHeader = getHeader(res?.headers, 'x-total-count');
+    const totalCountFromHeader = totalCountHeader !== null && totalCountHeader !== undefined ? parseInt(String(totalCountHeader), 10) : null;
+    const totalCountFromBody = (meta && typeof meta === 'object')
+      ? (meta.totalCount ?? meta.total ?? meta?.pageInfo?.totalCount ?? null)
+      : null;
+    const totalCount = Number.isFinite(totalCountFromHeader) ? totalCountFromHeader : (Number.isFinite(totalCountFromBody) ? totalCountFromBody : items.length);
+
+    const pageInfoFromBody = (meta && typeof meta === 'object' && meta.pageInfo && typeof meta.pageInfo === 'object') ? meta.pageInfo : null;
+    const page = querySpec?.page || { mode: 'offset', offset: 0, limit: 20 };
+    const pageInfo = {
+      ...(pageInfoFromBody || {}),
+      mode: page?.mode || 'offset',
+      limit: Number.isFinite(page?.limit) ? page.limit : 20,
+      totalCount,
+    };
+
+    const entities = { [entityType]: [] };
+    const result = [];
+    const defaultEtag = getHeader(res?.headers, this._concurrency.etagHeader);
+    const fallbackVersion = defaultEtag || '0';
+
+    items.forEach((raw, idx) => {
+      const rec = this._normalizeRecord(raw, { keyField, versionField, fallbackVersion });
+      const id = rec?.[keyField] !== undefined && rec?.[keyField] !== null ? String(rec[keyField]) : String(idx);
+      if (rec && typeof rec === 'object') rec[keyField] = id;
+      entities[entityType].push(rec);
+      result.push({ type: entityType, id });
+    });
+
+    return {
+      entities,
+      result,
+      pageInfo,
+      meta: { resource, queryKey: makeQueryKey({ ...querySpec, resource, entityType }), fetchedAt: Date.now(), httpStatus: res?.status },
+    };
+  }
+
+  async _fetchLatestForConflict({ resource, entityType, keyField, versionField, id }) {
+    const fetchImpl = this._getFetch();
+    const url = this._buildItemUrl({ resource, id });
+    const res = await fetchImpl(url, { method: 'GET', headers: { ...this._headers } });
+    const etag = getHeader(res?.headers, this._concurrency.etagHeader);
+    const json = await parseJsonSafely(res);
+    const record = this._normalizeRecord(json, { keyField, versionField, fallbackVersion: etag || '0' });
+    const latestVersion = record?.[versionField] !== undefined ? String(record[versionField]) : (etag ? String(etag) : null);
+    return { record, latestVersion, httpStatus: res?.status };
+  }
+
+  _errorFromHttp(res, body) {
+    const status = res?.status;
+    const message = (body && typeof body === 'object' && (body.message || body.error)) ? (body.message || body.error) : `HTTP ${String(status)}`;
+    if (status === 404) return { code: 'not_found', message, httpStatus: status };
+    if (status === 401) return { code: 'unauthorized', message, httpStatus: status };
+    if (status === 403) return { code: 'forbidden', message, httpStatus: status };
+    if (status === 400 || status === 422) return { code: 'validation', message, httpStatus: status };
+    return { code: 'http_error', message, httpStatus: status };
+  }
+
+  async mutate(ops = [], options = {}) {
+    const applied = [];
+    const rejected = [];
+    const conflicts = [];
+    const entities = {};
+    const fetchImpl = this._getFetch();
+
+    for (const op of ops || []) {
+      const opId = op?.opId || `op-${Date.now()}-${Math.random()}`;
+      const type = op?.type;
+      const resource = op?.resource || options?.resource || this._defaults?.resource || null;
+      const entityTypeFromOp = op?.entity?.type || op?.entityType || options?.entityType || null;
+      const entityId = op?.entity?.id !== undefined && op?.entity?.id !== null ? String(op.entity.id) : null;
+      const baseVersion = op?.baseVersion === undefined || op?.baseVersion === null ? null : String(op.baseVersion);
+
+      const effectiveResource = resource || (entityTypeFromOp ? String(entityTypeFromOp).toLowerCase() + 's' : 'resource');
+      const { entityType, keyField, versionField } = this._resourceConfig(effectiveResource, entityTypeFromOp);
+
+      try {
+        if (type === 'create') {
+          const url = joinUrl(this._baseUrl, this._resourceConfig(effectiveResource, entityTypeFromOp).basePath);
+          const data = clone(op?.data || {});
+          const res = await fetchImpl(url, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json', ...this._headers },
+            body: JSON.stringify(data),
+          });
+          const body = await parseJsonSafely(res);
+          if (!res?.ok) {
+            rejected.push({ opId, status: 'rejected', error: this._errorFromHttp(res, body) });
+            continue;
+          }
+          const etag = getHeader(res?.headers, this._concurrency.etagHeader);
+          const rec = this._normalizeRecord(body || data, { keyField, versionField, fallbackVersion: etag || '0' });
+          const serverId = rec?.[keyField] !== undefined && rec?.[keyField] !== null ? String(rec[keyField]) : null;
+          if (!entities[entityType]) entities[entityType] = [];
+          if (rec && typeof rec === 'object') entities[entityType].push(rec);
+          applied.push({ opId, status: 'applied', serverId: serverId || undefined });
+          continue;
+        }
+
+        if (type === 'update') {
+          if (!entityId) throw new Error('update requires entity.id');
+          const url = this._buildItemUrl({ resource: effectiveResource, id: entityId });
+          const payload = op?.patch ? clone(op.patch) : clone(op?.data || {});
+          const headers = { 'content-type': 'application/json', ...this._headers };
+          if (this._concurrency.mode === 'etag' && baseVersion !== null) {
+            headers[this._concurrency.ifMatchHeader] = baseVersion;
+          }
+          const res = await fetchImpl(url, {
+            method: 'PATCH',
+            headers,
+            body: JSON.stringify(payload),
+          });
+          if (res?.status === 409 || res?.status === 412) {
+            const latest = await this._fetchLatestForConflict({ resource: effectiveResource, entityType, keyField, versionField, id: entityId });
+            conflicts.push({
+              opId,
+              status: 'conflict',
+              latestVersion: latest.latestVersion,
+              server: latest.record,
+              local: op,
+              httpStatus: res?.status,
+            });
+            continue;
+          }
+          const body = await parseJsonSafely(res);
+          if (!res?.ok) {
+            rejected.push({ opId, status: 'rejected', error: this._errorFromHttp(res, body) });
+            continue;
+          }
+          const etag = getHeader(res?.headers, this._concurrency.etagHeader);
+          const rec = this._normalizeRecord(body || { ...payload, [keyField]: entityId }, { keyField, versionField, fallbackVersion: etag || baseVersion || '0' });
+          rec[keyField] = String(rec[keyField] ?? entityId);
+          if (!entities[entityType]) entities[entityType] = [];
+          entities[entityType].push(rec);
+          applied.push({ opId, status: 'applied' });
+          continue;
+        }
+
+        if (type === 'delete') {
+          if (!entityId) throw new Error('delete requires entity.id');
+          const url = this._buildItemUrl({ resource: effectiveResource, id: entityId });
+          const headers = { ...this._headers };
+          if (this._concurrency.mode === 'etag' && baseVersion !== null) {
+            headers[this._concurrency.ifMatchHeader] = baseVersion;
+          }
+          const res = await fetchImpl(url, { method: 'DELETE', headers });
+          if (res?.status === 409 || res?.status === 412) {
+            const latest = await this._fetchLatestForConflict({ resource: effectiveResource, entityType, keyField, versionField, id: entityId });
+            conflicts.push({
+              opId,
+              status: 'conflict',
+              latestVersion: latest.latestVersion,
+              server: latest.record,
+              local: op,
+              httpStatus: res?.status,
+            });
+            continue;
+          }
+          if (!res?.ok) {
+            const body = await parseJsonSafely(res);
+            rejected.push({ opId, status: 'rejected', error: this._errorFromHttp(res, body) });
+            continue;
+          }
+          applied.push({ opId, status: 'applied' });
+          continue;
+        }
+
+        rejected.push({ opId, status: 'rejected', error: { code: 'unsupported', message: `Unsupported op type: ${String(type)}` } });
+      } catch (e) {
+        // IMPORTANT: transport-level failures must throw so the store re-queues all ops.
+        // We only convert *our own* validation errors to rejected.
+        const msg = e?.message || String(e);
+        const isLocalValidation =
+          msg.includes('update requires entity.id') ||
+          msg.includes('delete requires entity.id') ||
+          msg.includes('Unsupported op type');
+        if (isLocalValidation) {
+          rejected.push({ opId, status: 'rejected', error: { code: 'exception', message: msg } });
+          continue;
+        }
+        throw e;
+      }
+    }
+
+    return { applied, rejected, conflicts, entities, invalidations: [], meta: { mutatedAt: Date.now() } };
+  }
+}
+

--- a/lib/blinx.datasource.js
+++ b/lib/blinx.datasource.js
@@ -491,6 +491,14 @@ export class BlinxRestDataSource extends BlinxDataSource {
     });
 
     const json = await parseJsonSafely(res);
+    if (!res?.ok) {
+      const errObj = this._errorFromHttp(res, json);
+      const e = new Error(errObj.message);
+      e.code = errObj.code;
+      e.httpStatus = errObj.httpStatus;
+      e.details = errObj;
+      throw e;
+    }
     const { items, meta } = coerceListPayload(json);
 
     const totalCountHeader = getHeader(res?.headers, 'x-total-count');
@@ -516,9 +524,16 @@ export class BlinxRestDataSource extends BlinxDataSource {
 
     items.forEach((raw, idx) => {
       const rec = this._normalizeRecord(raw, { keyField, versionField, fallbackVersion });
-      const id = rec?.[keyField] !== undefined && rec?.[keyField] !== null ? String(rec[keyField]) : String(idx);
-      if (rec && typeof rec === 'object') rec[keyField] = id;
-      entities[entityType].push(rec);
+      const id = (rec && typeof rec === 'object' && rec?.[keyField] !== undefined && rec?.[keyField] !== null)
+        ? String(rec[keyField])
+        : String(idx);
+      if (rec && typeof rec === 'object') {
+        rec[keyField] = id;
+        entities[entityType].push(rec);
+      } else {
+        // Defensive: if API returns primitives in the list, coerce them into a record shape.
+        entities[entityType].push({ [keyField]: id, value: rec, [versionField]: fallbackVersion });
+      }
       result.push({ type: entityType, id });
     });
 
@@ -536,7 +551,10 @@ export class BlinxRestDataSource extends BlinxDataSource {
     const res = await fetchImpl(url, { method: 'GET', headers: { ...this._headers } });
     const etag = getHeader(res?.headers, this._concurrency.etagHeader);
     const json = await parseJsonSafely(res);
-    const record = this._normalizeRecord(json, { keyField, versionField, fallbackVersion: etag || '0' });
+    const recordRaw = this._normalizeRecord(json, { keyField, versionField, fallbackVersion: etag || '0' });
+    const record = (recordRaw && typeof recordRaw === 'object')
+      ? recordRaw
+      : { [keyField]: String(id), value: recordRaw, [versionField]: etag || '0' };
     const latestVersion = record?.[versionField] !== undefined ? String(record[versionField]) : (etag ? String(etag) : null);
     return { record, latestVersion, httpStatus: res?.status };
   }
@@ -623,10 +641,15 @@ export class BlinxRestDataSource extends BlinxDataSource {
             continue;
           }
           const etag = getHeader(res?.headers, this._concurrency.etagHeader);
-          const rec = this._normalizeRecord(body || { ...payload, [keyField]: entityId }, { keyField, versionField, fallbackVersion: etag || baseVersion || '0' });
-          rec[keyField] = String(rec[keyField] ?? entityId);
+          const bodyObj = (body && typeof body === 'object') ? body : null;
+          const rec = this._normalizeRecord(bodyObj || { ...payload, [keyField]: entityId }, { keyField, versionField, fallbackVersion: etag || baseVersion || '0' });
+          // Defensive: if normalization still produced a primitive, coerce to object.
+          const recObj = (rec && typeof rec === 'object')
+            ? rec
+            : { [keyField]: String(entityId), value: rec, [versionField]: etag || baseVersion || '0' };
+          recObj[keyField] = String(recObj[keyField] ?? entityId);
           if (!entities[entityType]) entities[entityType] = [];
-          entities[entityType].push(rec);
+          entities[entityType].push(recObj);
           applied.push({ opId, status: 'applied' });
           continue;
         }

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -1,4 +1,4 @@
-import { BlinxArrayDataSource, BlinxDataSource } from './blinx.datasource.js';
+import { BlinxArrayDataSource, BlinxDataSource, BlinxRestDataSource } from './blinx.datasource.js';
 
 export const DataTypes = {
   string: 'string',
@@ -355,7 +355,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     if (nextCriteria) criteria = { ...criteria, ...clone(nextCriteria) };
     status = 'loading'; error = null;
     pageState = { ...pageState, cursor: defaultPage.after ?? null, page: defaultPage.page ?? 0, offset: defaultPage.offset ?? 0, pageIndex: 0 };
-    const res = await dataSource.query(buildQuerySpec(), {});
+    const res = await dataSource.query(buildQuerySpec(), { resource, entityType, keyField, versionField });
     // Materialize as page-local array
     const records = (res?.entities?.[entityType] || []).map(r => clone(r));
     current = records;
@@ -377,7 +377,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
       pageState = { ...pageState, cursor: next, pageIndex: (pageState.pageIndex || 0) + 1 };
     }
     status = 'loading'; error = null;
-    const res = await dataSource.query(buildQuerySpec(), {});
+    const res = await dataSource.query(buildQuerySpec(), { resource, entityType, keyField, versionField });
     const records = (res?.entities?.[entityType] || []).map(r => clone(r));
     current = records;
     original = clone(records);
@@ -398,7 +398,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
       pageState = { ...pageState, cursor: prev, pageIndex: Math.max(0, (pageState.pageIndex || 0) - 1) };
     }
     status = 'loading'; error = null;
-    const res = await dataSource.query(buildQuerySpec(), {});
+    const res = await dataSource.query(buildQuerySpec(), { resource, entityType, keyField, versionField });
     const records = (res?.entities?.[entityType] || []).map(r => clone(r));
     current = records;
     original = clone(records);
@@ -424,7 +424,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
 
     let res;
     try {
-      res = await dataSource.mutate(ops, {});
+      res = await dataSource.mutate(ops, { resource, entityType, keyField, versionField });
     } catch (e) {
       // Transport-level failure: restore all pending ops so nothing is lost.
       pendingOps.unshift(...ops);
@@ -448,6 +448,22 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
       status = 'error';
       error = { conflicts, rejected };
       return res;
+    }
+    // Reconcile create ops with server-assigned IDs (if provided).
+    // Store generates temporary IDs; data sources may return `applied[].serverId`.
+    const appliedById = new Map((applied || []).filter(Boolean).map(a => [String(a?.opId), a]));
+    for (const op of ops) {
+      if (op?.type !== 'create') continue;
+      const a = appliedById.get(String(op?.opId));
+      const serverId = a?.serverId !== undefined && a?.serverId !== null ? String(a.serverId) : null;
+      if (!serverId) continue;
+      const clientId = op?.data?.[keyField] !== undefined && op?.data?.[keyField] !== null ? String(op.data[keyField]) : null;
+      if (!clientId) continue;
+      // Update the in-memory current record id so canonical entity replacement can succeed.
+      const idx = current.findIndex(r => String(r?.[keyField]) === clientId);
+      if (idx >= 0 && current[idx] && typeof current[idx] === 'object') {
+        current[idx][keyField] = serverId;
+      }
     }
     // Apply canonical entities (if provided) and snapshot.
     const canonical = res?.entities?.[entityType] || null;
@@ -562,4 +578,4 @@ export function blinxStore(arg1, arg2) {
 export { blinxStore as createBlinxStore };
 
 // Re-export data source types for convenience
-export { BlinxDataSource, BlinxArrayDataSource };
+export { BlinxDataSource, BlinxArrayDataSource, BlinxRestDataSource };


### PR DESCRIPTION
Implement `BlinxRestDataSource` to enable Blinx for real-world client-server applications with optimistic concurrency.

This PR introduces `BlinxRestDataSource`, which integrates with `blinxStore` to provide HTTP-backed data operations. It maps `baseVersion` to HTTP `If-Match` headers for optimistic concurrency, translates `409 Conflict` and `412 Precondition Failed` responses into structured `conflicts[]` payloads (including fetching the latest server record), and ensures transport-level errors throw to trigger full re-queueing by the store. Additionally, `blinxStore` now reconciles client-generated temporary IDs with server-assigned IDs for create operations and passes view context to datasource calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-7074d3fb-9641-4b6c-a948-18518b596416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7074d3fb-9641-4b6c-a948-18518b596416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `BlinxRestDataSource` with ETag-based optimistic concurrency and update store to pass view context and reconcile server-assigned IDs.
> 
> - **Data Source (`lib/blinx.datasource.js`)**
>   - **New `BlinxRestDataSource`**: HTTP adapter implementing `query()` and `mutate()` with URL building, filter/sort/paging, and entity normalization.
>   - **Optimistic Concurrency**: Maps `baseVersion` to `If-Match`; reads `ETag`; handles `409/412` as `conflicts[]` (fetches latest record); throws on transport errors.
>   - **HTTP Utilities**: Header helpers, safe JSON parsing, query param encoding, list payload coercion; total count from `x-total-count` or body.
> - **Store (`lib/blinx.store.js`)**
>   - Passes `{ resource, entityType, keyField, versionField }` to `dataSource.query/mutate`.
>   - **Create ID Reconciliation**: Updates local temp IDs with `applied.serverId` and applies canonical entities after save.
>   - Re-exports `BlinxRestDataSource` and updates imports.
> - **Tests**
>   - Add REST datasource and store integration tests in `__tests__/blinx.datasource.rest.test.js` and `__tests__/blinx.store.rest.create-and-requeue.test.js` covering query URL/paging, ETag/If-Match, conflict handling, mixed results, re-queue on transport failure, and server-assigned IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6e353b0857778eb03609b228ef2d992fcd71b2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->