### PR TITLE
Blinx store collection strategy

### DIFF
--- a/__tests__/blinx.declarative-views.integration.test.js
+++ b/__tests__/blinx.declarative-views.integration.test.js
@@ -1,0 +1,84 @@
+/** @jest-environment jsdom */
+
+import { blinxStore } from '../lib/blinx.store.js';
+import { blinxCollection } from '../lib/blinx.collection.js';
+import { blinxForm } from '../lib/blinx.form.js';
+
+import { ProductModel, ProductDataViews, ProductUIViews } from '../test-fixtures/models/product/index.js';
+
+describe('Declarative data views + UI views (integration)', () => {
+  test('components can resolve ui view by key and update when active data view changes', async () => {
+    const queryCalls = [];
+
+    const dataSource = {
+      init() {},
+      async query(spec) {
+        queryCalls.push(spec.resource);
+        if (spec.resource === 'products') {
+          return {
+            entities: { Product: [{ id: 'p1', name: 'Catalog A', price: 1, version: '1' }] },
+            result: [{ type: 'Product', id: 'p1' }],
+            pageInfo: { totalCount: 1 },
+          };
+        }
+        if (spec.resource === 'products-featured') {
+          return {
+            entities: { Product: [{ id: 'p9', name: 'Featured Z', price: 99, version: '1' }] },
+            result: [{ type: 'Product', id: 'p9' }],
+            pageInfo: { totalCount: 1 },
+          };
+        }
+        return { entities: { Product: [] }, result: [], pageInfo: { totalCount: 0 } };
+      },
+      async mutate() {
+        return { applied: [], rejected: [], conflicts: [], entities: {} };
+      },
+    };
+
+    const store = blinxStore({
+      model: ProductModel,
+      dataSource,
+      views: ProductDataViews,
+      defaultView: 'catalog',
+      uiViews: ProductUIViews,
+    });
+
+    // Load default (catalog)
+    await store.loadFirst();
+
+    const listRoot = document.createElement('div');
+    const formRoot = document.createElement('div');
+
+    blinxCollection({
+      root: listRoot,
+      store,
+      dataView: 'active',
+      view: 'list',
+      paging: { pageSize: 20 },
+    });
+
+    blinxForm({
+      root: formRoot,
+      store,
+      dataView: 'active',
+      view: 'edit',
+      recordIndex: 0,
+    });
+
+    // Assert initial catalog render
+    expect(listRoot.querySelectorAll('tbody tr').length).toBe(1);
+    expect(listRoot.textContent).toContain('Catalog A');
+    expect(formRoot.querySelector('input')?.value).toBe('Catalog A');
+
+    // Switch active view => components should refresh via viewChanged + subsequent loadFirst/reset
+    store.setActiveView('featured');
+    await store.loadFirst();
+    // blinxCollection/blinxForm schedule reset refresh via setTimeout(0)
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(listRoot.textContent).toContain('Featured Z');
+    expect(formRoot.querySelector('input')?.value).toBe('Featured Z');
+    expect(queryCalls).toEqual(expect.arrayContaining(['products', 'products-featured']));
+  });
+});
+

--- a/__tests__/blinx.store.manager.test.js
+++ b/__tests__/blinx.store.manager.test.js
@@ -1,0 +1,63 @@
+import { blinxStore, EventTypes } from '../lib/blinx.store.js';
+
+describe('blinxStore (remote) manager/proxy behavior', () => {
+  test('proxies store operations to active view and emits viewChanged', async () => {
+    const calls = [];
+
+    const dataSource = {
+      init() {},
+      async query(spec) {
+        calls.push(spec.resource);
+        if (spec.resource === 'a') {
+          return {
+            entities: { Item: [{ id: '1', name: 'A', version: '1' }] },
+            result: [{ type: 'Item', id: '1' }],
+            pageInfo: { totalCount: 1 },
+          };
+        }
+        if (spec.resource === 'b') {
+          return {
+            entities: { Item: [{ id: '2', name: 'B', version: '1' }] },
+            result: [{ type: 'Item', id: '2' }],
+            pageInfo: { totalCount: 1 },
+          };
+        }
+        return { entities: { Item: [] }, result: [], pageInfo: { totalCount: 0 } };
+      },
+      async mutate() {
+        return { applied: [], rejected: [], conflicts: [], entities: {} };
+      },
+    };
+
+    const store = blinxStore({
+      model: { fields: { id: {}, name: {}, version: {} } },
+      dataSource,
+      defaultView: 'viewA',
+      views: {
+        viewA: { resource: 'a', entityType: 'Item', keyField: 'id', versionField: 'version', defaultPage: { mode: 'page', page: 0, limit: 10 } },
+        viewB: { resource: 'b', entityType: 'Item', keyField: 'id', versionField: 'version', defaultPage: { mode: 'page', page: 0, limit: 10 } },
+      }
+    });
+
+    const events = [];
+    store.subscribe(ev => events.push(ev));
+
+    expect(store.getActiveView()).toBe('viewA');
+    await store.loadFirst();
+    expect(store.getRecord(0)).toEqual(expect.objectContaining({ name: 'A' }));
+
+    store.setActiveView('viewB');
+    const vc = events.find(e => e.path?.[0] === EventTypes.viewChanged);
+    expect(vc).toBeDefined();
+    expect(vc.value).toEqual({ from: 'viewA', to: 'viewB' });
+
+    await store.loadFirst();
+    expect(store.getRecord(0)).toEqual(expect.objectContaining({ name: 'B' }));
+    expect(calls).toEqual(expect.arrayContaining(['a', 'b']));
+
+    // Still supports retrieving a concrete view-store
+    const viewAStore = store.collection('viewA');
+    expect(typeof viewAStore.loadFirst).toBe('function');
+  });
+});
+

--- a/__tests__/blinx.store.uiviews.no-mutation.test.js
+++ b/__tests__/blinx.store.uiviews.no-mutation.test.js
@@ -1,0 +1,60 @@
+/** @jest-environment jsdom */
+
+import { blinxStore } from '../lib/blinx.store.js';
+import { BlinxArrayDataSource } from '../lib/blinx.store.js';
+import { blinxCollection } from '../lib/blinx.collection.js';
+
+describe('blinxStore uiViews are store-scoped (no model mutation)', () => {
+  test('two stores can share the same model object but use different uiViews', async () => {
+    const sharedModel = {
+      fields: {
+        id: { type: 'number' },
+        name: { type: 'string' },
+        version: { type: 'string' },
+      }
+    };
+
+    const uiViewsA = {
+      list: { layout: 'table', columns: [{ field: 'name', label: 'Name (A)' }] }
+    };
+    const uiViewsB = {
+      list: { layout: 'table', columns: [{ field: 'name', label: 'Name (B)' }] }
+    };
+
+    const ds = new BlinxArrayDataSource([{ id: 1, name: 'X', version: '1' }], { entityType: 'Item', keyField: 'id', versionField: 'version' });
+
+    const storeA = blinxStore({
+      model: sharedModel,
+      dataSource: ds,
+      view: { name: 'items', resource: 'items', entityType: 'Item', keyField: 'id', versionField: 'version', defaultPage: { mode: 'page', page: 0, limit: 10 } },
+      uiViews: uiViewsA,
+    });
+
+    const storeB = blinxStore({
+      model: sharedModel,
+      dataSource: ds,
+      view: { name: 'items', resource: 'items', entityType: 'Item', keyField: 'id', versionField: 'version', defaultPage: { mode: 'page', page: 0, limit: 10 } },
+      uiViews: uiViewsB,
+    });
+
+    // Ensure the model object was not mutated.
+    expect(sharedModel.uiViews).toBeUndefined();
+    expect(storeA.getUIViews()).toBe(uiViewsA);
+    expect(storeB.getUIViews()).toBe(uiViewsB);
+
+    await storeA.loadFirst();
+    await storeB.loadFirst();
+
+    const rootA = document.createElement('div');
+    const rootB = document.createElement('div');
+
+    blinxCollection({ root: rootA, store: storeA, dataView: 'active', view: 'list' });
+    blinxCollection({ root: rootB, store: storeB, dataView: 'active', view: 'list' });
+
+    const thA = rootA.querySelector('thead th:nth-child(2)')?.textContent; // 1st is 'Sel'
+    const thB = rootB.querySelector('thead th:nth-child(2)')?.textContent;
+    expect(thA).toBe('Name (A)');
+    expect(thB).toBe('Name (B)');
+  });
+});
+

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -221,9 +221,7 @@ export function blinxCollection({
 
   // Resolve declarative UI view by key (if provided as string).
   if (typeof view === 'string') {
-    const uiViews = (store && typeof store.getUIViews === 'function')
-      ? store.getUIViews()
-      : (store && typeof store.getModel === 'function' ? store.getModel()?.uiViews : null);
+    const uiViews = (store && typeof store.getUIViews === 'function') ? store.getUIViews() : null;
     const resolved = uiViews && typeof uiViews === 'object' ? uiViews[view] : null;
     if (!resolved) throw new Error(`blinxCollection: unknown ui view "${String(view)}".`);
     view = resolved;

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -199,6 +199,10 @@ export function blinxCollection({
   root,
   view,
   store,
+  // Optional: declarative data-view selection when a multi-view store manager is provided.
+  // - "active": bind to the manager's active view (proxy behavior).
+  // - any other string: resolves to store.view(name) / store.collection(name).
+  dataView,
   paging = {},
   selection = { mode: 'multi' },
   actions = { create: true, deleteSelected: true },
@@ -206,6 +210,25 @@ export function blinxCollection({
   layouts = {},
   onItemClick,
 } = {}) {
+  // Resolve declarative data view (if requested).
+  if (dataView && typeof dataView === 'string') {
+    if (dataView !== 'active') {
+      if (store && typeof store.view === 'function') store = store.view(dataView);
+      else if (store && typeof store.collection === 'function') store = store.collection(dataView);
+      else throw new Error('blinxCollection: dataView requires a multi-view store (with view()/collection()).');
+    }
+  }
+
+  // Resolve declarative UI view by key (if provided as string).
+  if (typeof view === 'string') {
+    const uiViews = (store && typeof store.getUIViews === 'function')
+      ? store.getUIViews()
+      : (store && typeof store.getModel === 'function' ? store.getModel()?.uiViews : null);
+    const resolved = uiViews && typeof uiViews === 'object' ? uiViews[view] : null;
+    if (!resolved) throw new Error(`blinxCollection: unknown ui view "${String(view)}".`);
+    view = resolved;
+  }
+
   if (!store || typeof store.getModel !== 'function') {
     throw new Error('blinxCollection requires a store that exposes getModel().');
   }

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -57,9 +57,7 @@ export function blinxForm({
 
   // Resolve declarative UI view by key (if provided as string).
   if (typeof view === 'string') {
-    const uiViews = (store && typeof store.getUIViews === 'function')
-      ? store.getUIViews()
-      : (store && typeof store.getModel === 'function' ? store.getModel()?.uiViews : null);
+    const uiViews = (store && typeof store.getUIViews === 'function') ? store.getUIViews() : null;
     const resolved = uiViews && typeof uiViews === 'object' ? uiViews[view] : null;
     if (!resolved) throw new Error(`blinxForm: unknown ui view "${String(view)}".`);
     view = resolved;

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -30,6 +30,10 @@ function bindClick(controlEl, role, handler) {
 
 export function blinxForm({
   root, view, store,
+  // Optional: declarative data-view selection when a multi-view store manager is provided.
+  // - "active": bind to the manager's active view (proxy behavior).
+  // - any other string: resolves to store.view(name) / store.collection(name).
+  dataView,
   recordIndex = 0,
   controls = {
     saveButtonId: null,
@@ -42,6 +46,25 @@ export function blinxForm({
     saveStatusId: null,
   }
 }) {
+  // Resolve declarative data view (if requested).
+  if (dataView && typeof dataView === 'string') {
+    if (dataView !== 'active') {
+      if (store && typeof store.view === 'function') store = store.view(dataView);
+      else if (store && typeof store.collection === 'function') store = store.collection(dataView);
+      else throw new Error('blinxForm: dataView requires a multi-view store (with view()/collection()).');
+    }
+  }
+
+  // Resolve declarative UI view by key (if provided as string).
+  if (typeof view === 'string') {
+    const uiViews = (store && typeof store.getUIViews === 'function')
+      ? store.getUIViews()
+      : (store && typeof store.getModel === 'function' ? store.getModel()?.uiViews : null);
+    const resolved = uiViews && typeof uiViews === 'object' ? uiViews[view] : null;
+    if (!resolved) throw new Error(`blinxForm: unknown ui view "${String(view)}".`);
+    view = resolved;
+  }
+
   if (!store || typeof store.getModel !== 'function') {
     throw new Error('blinxForm requires a store that exposes getModel().');
   }
@@ -90,6 +113,7 @@ export function blinxForm({
     EventTypes.update,
     EventTypes.commit,
     EventTypes.reset,
+    EventTypes.viewChanged,
   ]);
 
   const externalStatusMessages = {
@@ -98,6 +122,7 @@ export function blinxForm({
     [EventTypes.update]: 'Record updated elsewhere; refreshed view.',
     [EventTypes.commit]: 'Changes committed elsewhere; refreshed view.',
     [EventTypes.reset]: 'Store reset elsewhere; refreshed view.',
+    [EventTypes.viewChanged]: 'View changed; refreshed view.',
   };
 
   const dom = {

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -15,6 +15,9 @@ export const EventTypes = {
   update: 'update',
   commit: 'commit',
   reset: 'reset',
+  // Manager-level / view-level lifecycle events (emitted by the multi-view store manager).
+  viewChanged: 'viewChanged',
+  criteriaChanged: 'criteriaChanged',
 };
 
 const clone = value => JSON.parse(JSON.stringify(value));
@@ -538,6 +541,9 @@ export function blinxStore(arg1, arg2) {
   }
 
   const views = cfg.views || {};
+  // Optional UI view registry co-located with the model.
+  // This enables declarative `view: "list"` usage in UI components.
+  if (cfg.uiViews && !model.uiViews) model.uiViews = cfg.uiViews;
   const defaultView = cfg.defaultView || Object.keys(views)[0] || 'default';
   const defaultViewConfig = views[defaultView] || { name: defaultView, entityType: 'Record', resource: defaultView };
 
@@ -556,12 +562,11 @@ export function blinxStore(arg1, arg2) {
     });
   }
 
-  // The returned store is the default view controller, with `collection(name)` to access others.
-  const defaultStore = createRemoteViewStore({ model, dataSource: ds, viewName: defaultView, viewConfig: { ...defaultViewConfig, name: defaultView } });
+  // Multi-view manager: exposes a single-model event bus + view selection,
+  // while remaining drop-in compatible with a view store by proxying operations to the active view.
+  const viewStores = new Map();
 
-  const viewStores = new Map([[defaultView, defaultStore]]);
-
-  defaultStore.collection = (name = defaultView) => {
+  function getOrCreateViewStore(name) {
     const key = name || defaultView;
     if (viewStores.has(key)) return viewStores.get(key);
     const vc = views[key];
@@ -569,9 +574,102 @@ export function blinxStore(arg1, arg2) {
     const vs = createRemoteViewStore({ model, dataSource: ds, viewName: key, viewConfig: { ...vc, name: key } });
     viewStores.set(key, vs);
     return vs;
+  }
+
+  // Eagerly create default view store (preserves historic behavior: store methods work immediately).
+  const defaultStore = createRemoteViewStore({ model, dataSource: ds, viewName: defaultView, viewConfig: { ...defaultViewConfig, name: defaultView } });
+  viewStores.set(defaultView, defaultStore);
+
+  const subs = new Set();
+  let activeView = defaultView;
+  let activeUnsubscribe = null;
+  let managerApi;
+
+  function notify(path, value) {
+    subs.forEach(fn => fn({ path, value, data: managerApi.toJSON(), store: managerApi }));
+  }
+
+  function attachActiveSubscription() {
+    if (typeof activeUnsubscribe === 'function') activeUnsubscribe();
+    const vs = getOrCreateViewStore(activeView);
+    activeUnsubscribe = vs.subscribe(ev => {
+      // Forward view events through the manager. Use the manager as `store` so non-UI listeners
+      // can treat it as the model-scoped event bus.
+      const payload = ev && typeof ev === 'object'
+        ? { ...ev, store: managerApi, view: activeView }
+        : { path: [EventTypes.update], value: null, data: managerApi.toJSON(), store: managerApi, view: activeView };
+      subs.forEach(fn => fn(payload));
+    });
+  }
+
+  function activeStore() {
+    return getOrCreateViewStore(activeView);
+  }
+
+  function proxy(method, ...args) {
+    const vs = activeStore();
+    if (!vs || typeof vs[method] !== 'function') {
+      throw new Error(`blinxStore: active view store does not implement "${String(method)}".`);
+    }
+    return vs[method](...args);
+  }
+
+  managerApi = {
+    // ---- View management ----
+    collection(name) {
+      // Back-compat: when called without a name, return the active view store.
+      if (name === undefined || name === null) return activeStore();
+      return getOrCreateViewStore(name);
+    },
+    // Preferred alias (clearer semantics)
+    view(name) { return managerApi.collection(name); },
+    getViews: () => ({ ...views }),
+    getUIViews: () => (model && model.uiViews) ? model.uiViews : {},
+    getActiveView: () => activeView,
+    setActiveView(name) {
+      const next = name || defaultView;
+      if (next === activeView) return activeView;
+      // Validate (will throw for unknown views)
+      getOrCreateViewStore(next);
+      const prev = activeView;
+      activeView = next;
+      attachActiveSubscription();
+      notify([EventTypes.viewChanged, next], { from: prev, to: next });
+      return activeView;
+    },
+    active: () => activeStore(),
+
+    // ---- Event bus ----
+    subscribe(fn) { subs.add(fn); return () => subs.delete(fn); },
+
+    // ---- View-store compatible API (proxied to active view) ----
+    getModel: () => model,
+    getRecord: (idx) => proxy('getRecord', idx),
+    getLength: () => proxy('getLength'),
+    setField: (idx, field, value) => proxy('setField', idx, field, value),
+    addRecord: (record, atIndex) => proxy('addRecord', record, atIndex),
+    removeRecords: (indexes) => proxy('removeRecords', indexes),
+    updateIndex: (index) => proxy('updateIndex', index),
+    update: (index, record) => proxy('update', index, record),
+    toJSON: () => proxy('toJSON'),
+    diff: () => proxy('diff'),
+    commit: () => proxy('commit'),
+    reset: () => proxy('reset'),
+
+    // Remote/view-oriented API
+    loadFirst: (criteria) => proxy('loadFirst', criteria),
+    pageNext: () => proxy('pageNext'),
+    pagePrev: () => proxy('pagePrev'),
+    search: (criteria) => proxy('search', criteria),
+    save: () => proxy('save'),
+    getStatus: () => proxy('getStatus'),
+    getPagingState: () => proxy('getPagingState'),
   };
 
-  return defaultStore;
+  // Initialize subscription to the default view for manager-level events.
+  attachActiveSubscription();
+
+  return managerApi;
 }
 
 // Backwards-compatible alias (deprecated)

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -541,9 +541,9 @@ export function blinxStore(arg1, arg2) {
   }
 
   const views = cfg.views || {};
-  // Optional UI view registry co-located with the model.
-  // This enables declarative `view: "list"` usage in UI components.
-  if (cfg.uiViews && !model.uiViews) model.uiViews = cfg.uiViews;
+  // UI view registry is store-scoped; DO NOT mutate the user-provided model object.
+  // `cfg.uiViews` takes precedence over `model.uiViews` (if callers attach it themselves).
+  const uiViews = cfg.uiViews || model.uiViews || {};
   const defaultView = cfg.defaultView || Object.keys(views)[0] || 'default';
   const defaultViewConfig = views[defaultView] || { name: defaultView, entityType: 'Record', resource: defaultView };
 
@@ -624,7 +624,7 @@ export function blinxStore(arg1, arg2) {
     // Preferred alias (clearer semantics)
     view(name) { return managerApi.collection(name); },
     getViews: () => ({ ...views }),
-    getUIViews: () => (model && model.uiViews) ? model.uiViews : {},
+    getUIViews: () => uiViews,
     getActiveView: () => activeView,
     setActiveView(name) {
       const next = name || defaultView;

--- a/test-fixtures/models/product/dataViews.js
+++ b/test-fixtures/models/product/dataViews.js
@@ -1,0 +1,17 @@
+export const ProductDataViews = {
+  catalog: {
+    resource: 'products',
+    entityType: 'Product',
+    keyField: 'id',
+    versionField: 'version',
+    defaultPage: { mode: 'page', page: 0, limit: 10 },
+  },
+  featured: {
+    resource: 'products-featured',
+    entityType: 'Product',
+    keyField: 'id',
+    versionField: 'version',
+    defaultPage: { mode: 'page', page: 0, limit: 10 },
+  },
+};
+

--- a/test-fixtures/models/product/index.js
+++ b/test-fixtures/models/product/index.js
@@ -1,0 +1,4 @@
+export { ProductModel } from './model.js';
+export { ProductDataViews } from './dataViews.js';
+export { ProductUIViews } from './uiViews.js';
+

--- a/test-fixtures/models/product/model.js
+++ b/test-fixtures/models/product/model.js
@@ -1,0 +1,10 @@
+export const ProductModel = {
+  name: 'Product',
+  fields: {
+    id: { type: 'string' },
+    name: { type: 'string' },
+    price: { type: 'number' },
+    version: { type: 'string' },
+  }
+};
+

--- a/test-fixtures/models/product/uiViews.js
+++ b/test-fixtures/models/product/uiViews.js
@@ -1,0 +1,15 @@
+export const ProductUIViews = {
+  list: {
+    layout: 'table',
+    columns: [
+      { field: 'name', label: 'Name' },
+      { field: 'price', label: 'Price' },
+    ],
+  },
+  edit: {
+    sections: [
+      { title: 'Basics', columns: 2, fields: ['name', 'price'] },
+    ],
+  },
+};
+


### PR DESCRIPTION
Introduce `blinxStore` as a multi-view manager and enable declarative `dataView` and `uiView` binding for `blinxCollection` and `blinxForm`.

This change properly utilizes the `blinxStore.collection` concept, separating data view configuration from UI presentation, and allows components to declaratively bind to data views (including an "active" view) and UI view presets, with automatic re-rendering when the active data view changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-78d4ec74-5b65-45fe-a806-9f05ce351566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-78d4ec74-5b65-45fe-a806-9f05ce351566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a multi-view `blinxStore` that proxies to the active view and enables declarative `dataView` and UI view resolution in `blinxCollection`/`blinxForm`, with auto-refresh on `viewChanged`.
> 
> - **Store (multi-view manager)**
>   - Introduces manager around per-view stores; proxies standard CRUD/paging methods to the active view.
>   - New API: `view(name)`/`collection(name)`, `getActiveView()`, `setActiveView()`, `getViews()`, `getUIViews()`; forwards events via a single bus.
>   - Emits `EventTypes.viewChanged` (and defines `criteriaChanged`); default view store created eagerly.
>   - Allows co-locating UI view registry via `uiViews` on model/config.
> - **UI Components**
>   - `blinxCollection`/`blinxForm`: support `dataView` ('active' or named) and resolve UI `view` by key from `getUIViews()`/model.
>   - Refresh on `viewChanged`; improved external status messaging; validation of unknown UI views.
> - **Tests & Fixtures**
>   - Adds manager proxy and integration tests for declarative views.
>   - Introduces `Product` model with `ProductDataViews` and `ProductUIViews` for testing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f8bffe193d8a585d1b4f950ea1a6eac2b3fc019. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->