### PR TITLE
Declarative form controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This layering keeps validation, diffing, and messaging logic reusable while adap
 - Sections render into a `DocumentFragment`, then flush to the DOM in one pass to minimize layout thrash.
 - Fields delegate to the active adapter through `ui.createField(...)`, which returns `{ el, ... }` so widgets can manage their own lifecycle.
 - Navigation (`Next/Prev`) is purely index-driven; the form rebinds itself whenever the selected record changes.
-- Indicator and status nodes stay optional and are wired up through injected `controls`, letting integrators map them to any markup.
+- Controls can be declared on the UI view (`view.controls`) or passed to `blinxForm({ controls })`. If controls are omitted, Blinx auto-renders an opinionated default toolbar.
 - Interceptors wrap every command, receiving a `processor` object with state, DOM references, and an idempotent `proceed()` so middleware chains cannot double-run defaults.
 
 ### Default Form Controls
@@ -66,7 +66,7 @@ This layering keeps validation, diffing, and messaging logic reusable while adap
 
 ## Table Rendering
 
-- Client-side pagination (default page size 20) maintains a shared `page` pointer and updates Prev/Next controls.
+- Client-side pagination (default page size 20) maintains a shared `page` pointer and updates Prev/Next controls (when declared, or when controls are omitted and auto-rendered).
 - Checkbox selection tracks row indexes inside a `Set`. Interceptors can read `processor.state.selected` before destructive actions.
 - `ui.formatCell(value, fieldDef)` lets adapters decide how to visualize primitives (chips, currency, badges, etc.).
 - The table subscribes to store events and rebuilds the visible page whenever the dataset mutates.

--- a/__tests__/blinx.collection.test.js
+++ b/__tests__/blinx.collection.test.js
@@ -123,9 +123,9 @@ describe('blinxCollection', () => {
       view: { layout: 'table', columns: [{ field: 'name', label: 'Name' }] },
       paging: { pageSize: 20 },
       controls: {
-        createButtonId: 'create',
-        deleteSelectedButtonId: 'del',
-        statusId: 'status',
+        createButton: 'create',
+        deleteSelectedButton: 'del',
+        status: 'status',
       }
     });
 

--- a/__tests__/blinx.collection.test.js
+++ b/__tests__/blinx.collection.test.js
@@ -153,5 +153,26 @@ describe('blinxCollection', () => {
     await Promise.resolve();
     expect(store.getLength()).toBe(1);
   });
+
+  test('controls: {} suppresses the default toolbar (but still renders collection content)', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }, { name: 'B' }], model);
+    const root = document.createElement('div');
+
+    blinxCollection({
+      root,
+      store,
+      view: { layout: 'table', columns: [{ field: 'name', label: 'Name' }] },
+      paging: { pageSize: 20 },
+      controls: {},
+    });
+
+    expect(root.querySelector('.blinx-controls')).toBeNull();
+    expect(root.querySelector('table')).not.toBeNull();
+    expect(root.querySelectorAll('tbody tr').length).toBe(2);
+    expect(root.textContent).not.toContain('Prev');
+    expect(root.textContent).not.toContain('Next');
+    expect(root.textContent).not.toContain('Page:');
+  });
 });
 

--- a/__tests__/blinx.collection.test.js
+++ b/__tests__/blinx.collection.test.js
@@ -174,5 +174,36 @@ describe('blinxCollection', () => {
     expect(root.textContent).not.toContain('Next');
     expect(root.textContent).not.toContain('Page:');
   });
+
+  test('toolbar renders after content in both auto and declarative modes', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }, { name: 'B' }], model);
+
+    // Auto mode: controls omitted => default toolbar created.
+    const rootAuto = document.createElement('div');
+    blinxCollection({
+      root: rootAuto,
+      store,
+      view: { layout: 'table', columns: [{ field: 'name', label: 'Name' }] },
+      paging: { pageSize: 20 },
+    });
+    expect(rootAuto.firstElementChild?.classList.contains('blinx-collection__content')).toBe(true);
+    expect(rootAuto.lastElementChild?.classList.contains('blinx-controls')).toBe(true);
+
+    // Declarative mode: some controls declared => toolbar created, should still be after content.
+    const rootDecl = document.createElement('div');
+    blinxCollection({
+      root: rootDecl,
+      store,
+      view: {
+        layout: 'table',
+        columns: [{ field: 'name', label: 'Name' }],
+        controls: { prevButton: true },
+      },
+      paging: { pageSize: 20 },
+    });
+    expect(rootDecl.firstElementChild?.classList.contains('blinx-collection__content')).toBe(true);
+    expect(rootDecl.lastElementChild?.classList.contains('blinx-controls')).toBe(true);
+  });
 });
 

--- a/__tests__/blinx.controls.test.js
+++ b/__tests__/blinx.controls.test.js
@@ -1,0 +1,63 @@
+/** @jest-environment jsdom */
+
+import {
+  normalizeControlSpecEntry,
+  resolveElementByIdWithinRoot,
+  applyControlPresentation,
+} from '../lib/blinx.controls.js';
+
+describe('blinx.controls micro-lib', () => {
+  test('normalizeControlSpecEntry supports shorthand forms', () => {
+    expect(normalizeControlSpecEntry('x')).toEqual({ domId: 'x' });
+    expect(normalizeControlSpecEntry(true)).toEqual({ visible: true, disabled: false });
+    expect(normalizeControlSpecEntry(false)).toEqual({ visible: false, disabled: true });
+    expect(normalizeControlSpecEntry({ domId: 'a', label: 'Save' })).toEqual({ domId: 'a', label: 'Save' });
+    expect(normalizeControlSpecEntry(undefined)).toBeNull();
+    expect(normalizeControlSpecEntry(null)).toBeNull();
+  });
+
+  test('resolveElementByIdWithinRoot prefers root scope, then falls back to document', () => {
+    document.body.innerHTML = '';
+
+    const root = document.createElement('div');
+    const inRoot = document.createElement('button');
+    inRoot.id = 'in-root';
+    root.appendChild(inRoot);
+    document.body.appendChild(root);
+
+    const inDoc = document.createElement('button');
+    inDoc.id = 'in-doc';
+    document.body.appendChild(inDoc);
+
+    expect(resolveElementByIdWithinRoot(root, 'in-root')).toBe(inRoot);
+    expect(resolveElementByIdWithinRoot(root, 'in-doc')).toBe(inDoc);
+    expect(resolveElementByIdWithinRoot(root, 'missing')).toBeNull();
+    expect(resolveElementByIdWithinRoot(null, 'in-doc')).toBe(inDoc);
+  });
+
+  test('applyControlPresentation updates visibility, disabled state, css, and label', () => {
+    const btn = document.createElement('button');
+    btn.className = 'a';
+    btn.textContent = 'Old';
+
+    applyControlPresentation(btn, {
+      visible: false,
+      disabled: true,
+      css: 'b',
+      label: 'New',
+    });
+
+    expect(btn.hidden).toBe(true);
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
+    expect(btn.className).toContain('a');
+    expect(btn.className).toContain('b');
+    expect(btn.textContent).toBe('New');
+
+    // Should be safe on non-interactive elements too.
+    const span = document.createElement('span');
+    applyControlPresentation(span, { disabled: true });
+    expect(span.getAttribute('aria-disabled')).toBe('true');
+  });
+});
+

--- a/__tests__/blinx.form.test.js
+++ b/__tests__/blinx.form.test.js
@@ -294,4 +294,21 @@ describe('blinxForm', () => {
     expect(getText('status')).toBe('No changes to save.');
     expect(getText('indicator')).toBe('Record 1 of 1');
   });
+
+  test('controls: {} suppresses the default toolbar (but still renders form content)', () => {
+    const model = {
+      fields: { name: { type: 'string', required: true, length: { min: 2 } } }
+    };
+    const store = blinxStore([{ name: 'AA' }], model);
+    const view = { sections: [{ title: 'Main', columns: 2, fields: ['name'] }] };
+    const root = document.createElement('div');
+
+    blinxForm({ root, view, store, recordIndex: 0, controls: {} });
+
+    // Explicit empty controls means "no auto controls".
+    expect(root.querySelector('.blinx-controls')).toBeNull();
+    // But content should still render.
+    expect(root.querySelector('input, textarea, select')).not.toBeNull();
+    expect(root.querySelectorAll('button').length).toBe(0);
+  });
 });

--- a/__tests__/blinx.form.test.js
+++ b/__tests__/blinx.form.test.js
@@ -6,7 +6,9 @@ import { blinxForm } from '../lib/blinx.form.js';
 function setupDomControls(ids) {
   document.body.innerHTML = '';
   for (const [key, id] of Object.entries(ids)) {
-    const el = (key.includes('Indicator') || key.includes('Status')) ? document.createElement('div') : document.createElement('button');
+    const el = (key.includes('indicator') || key.includes('status') || key.includes('Indicator') || key.includes('Status'))
+      ? document.createElement('div')
+      : document.createElement('button');
     el.id = id;
     document.body.appendChild(el);
   }
@@ -45,14 +47,14 @@ describe('blinxForm', () => {
     const root = document.createElement('div');
 
     setupDomControls({
-      saveButtonId: 'save',
-      resetButtonId: 'reset',
-      nextButtonId: 'next',
-      prevButtonId: 'prev',
-      createButtonId: 'create',
-      deleteButtonId: 'delete',
-      recordIndicatorId: 'indicator',
-      saveStatusId: 'status',
+      save: 'save',
+      reset: 'reset',
+      next: 'next',
+      prev: 'prev',
+      create: 'create',
+      delete: 'delete',
+      indicator: 'indicator',
+      status: 'status',
     });
 
     blinxForm({
@@ -61,15 +63,15 @@ describe('blinxForm', () => {
       store,
       recordIndex: 0,
       controls: {
-        saveButtonId: 'save',
-        resetButtonId: 'reset',
-        nextButtonId: 'next',
-        prevButtonId: 'prev',
-        createButtonId: 'create',
-        deleteButtonId: 'delete',
-        recordIndicatorId: 'indicator',
-        saveStatusId: 'status',
-      }
+        saveButton: 'save',
+        resetButton: 'reset',
+        nextButton: 'next',
+        prevButton: 'prev',
+        createButton: 'create',
+        deleteButton: 'delete',
+        recordIndicator: 'indicator',
+        saveStatus: 'status',
+      },
     });
 
     expect(getText('indicator')).toBe('Record 1 of 1');
@@ -106,9 +108,9 @@ describe('blinxForm', () => {
     const view = { sections: [{ title: 'Main', columns: 2, fields: ['name', 'price'] }] };
 
     setupDomControls({
-      saveButtonId: 'save',
-      saveStatusId: 'status',
-      recordIndicatorId: 'indicator',
+      save: 'save',
+      status: 'status',
+      indicator: 'indicator',
     });
 
     const root = document.createElement('div');
@@ -122,10 +124,10 @@ describe('blinxForm', () => {
       view,
       store: storeInvalid,
       controls: {
-        saveButtonId: 'save',
-        saveStatusId: 'status',
-        recordIndicatorId: 'indicator',
-      }
+        saveButton: 'save',
+        saveStatus: 'status',
+        recordIndicator: 'indicator',
+      },
     });
 
     document.getElementById('save').click();
@@ -143,10 +145,10 @@ describe('blinxForm', () => {
       view,
       store: storeNoChanges,
       controls: {
-        saveButtonId: 'save',
-        saveStatusId: 'status',
-        recordIndicatorId: 'indicator',
-      }
+        saveButton: 'save',
+        saveStatus: 'status',
+        recordIndicator: 'indicator',
+      },
     });
 
     document.getElementById('save').click();
@@ -176,8 +178,8 @@ describe('blinxForm', () => {
     const view = { sections: [{ title: 'Main', columns: 2, fields: ['name'] }] };
 
     setupDomControls({
-      saveStatusId: 'status',
-      recordIndicatorId: 'indicator',
+      status: 'status',
+      indicator: 'indicator',
     });
 
     const root = document.createElement('div');
@@ -187,9 +189,9 @@ describe('blinxForm', () => {
       view,
       store,
       controls: {
-        saveStatusId: 'status',
-        recordIndicatorId: 'indicator',
-      }
+        saveStatus: 'status',
+        recordIndicator: 'indicator',
+      },
     });
 
     store.updateIndex(0);

--- a/__tests__/blinx.form.test.js
+++ b/__tests__/blinx.form.test.js
@@ -202,4 +202,94 @@ describe('blinxForm', () => {
 
     jest.useRealTimers();
   });
+
+  test('when controls are omitted, renders an opinionated default toolbar inside root', async () => {
+    const model = {
+      fields: {
+        name: { type: 'string', required: true, length: { min: 2, max: 50 } },
+        price: { type: 'number', required: true, min: 0 },
+      }
+    };
+    const store = blinxStore([{ name: 'AA', price: 1 }], model);
+    const view = { sections: [{ title: 'Main', columns: 2, fields: ['name', 'price'] }] };
+    const root = document.createElement('div');
+
+    blinxForm({ root, view, store, recordIndex: 0 });
+
+    const toolbar = root.querySelector('.blinx-controls');
+    expect(toolbar).not.toBeNull();
+    expect(toolbar.querySelectorAll('button').length).toBe(6);
+
+    const indicator = Array.from(toolbar.querySelectorAll('span')).find(s => s.textContent.includes('Record') || s.textContent.includes('No records')) || null;
+    expect(indicator).not.toBeNull();
+
+    const btn = (label) => Array.from(toolbar.querySelectorAll('button')).find(b => b.textContent === label);
+    btn('Create').click();
+    await Promise.resolve();
+
+    expect(store.getLength()).toBe(2);
+    expect(toolbar.textContent).toContain('New record created.');
+
+    btn('Delete').click();
+    await Promise.resolve();
+
+    expect(store.getLength()).toBe(1);
+    expect(toolbar.textContent).toContain('Record deleted.');
+  });
+
+  test('declarative view.controls renders only explicitly mentioned controls', () => {
+    const model = {
+      fields: { name: { type: 'string', required: true, length: { min: 2 } } }
+    };
+    const store = blinxStore([{ name: 'AA' }], model);
+    const view = {
+      sections: [{ title: 'Main', columns: 2, fields: ['name'] }],
+      controls: {
+        saveButton: true,
+        saveStatus: true,
+      },
+    };
+    const root = document.createElement('div');
+
+    blinxForm({ root, view, store, recordIndex: 0 });
+
+    const toolbar = root.querySelector('.blinx-controls');
+    expect(toolbar).not.toBeNull();
+    expect(Array.from(toolbar.querySelectorAll('button')).map(b => b.textContent)).toEqual(['Save']);
+    // Status is declared, indicator is not.
+    expect(toolbar.querySelectorAll('span').length).toBe(1);
+  });
+
+  test('declarative view.controls can bind to external DOM elements by id (no controls option required)', async () => {
+    document.body.innerHTML = '';
+    const save = document.createElement('button'); save.id = 'save';
+    const status = document.createElement('div'); status.id = 'status';
+    const indicator = document.createElement('div'); indicator.id = 'indicator';
+    document.body.append(save, status, indicator);
+
+    const model = {
+      fields: { name: { type: 'string', required: true, length: { min: 2 } } }
+    };
+    const store = blinxStore([{ name: 'AA' }], model);
+    const view = {
+      sections: [{ title: 'Main', columns: 2, fields: ['name'] }],
+      controls: {
+        saveButton: 'save',
+        saveStatus: 'status',
+        recordIndicator: 'indicator',
+      },
+    };
+    const root = document.createElement('div');
+
+    blinxForm({ root, view, store, recordIndex: 0 });
+
+    // No internal toolbar should be created since controls were bound externally.
+    expect(root.querySelector('.blinx-controls')).toBeNull();
+
+    document.getElementById('save').click();
+    await Promise.resolve();
+
+    expect(getText('status')).toBe('No changes to save.');
+    expect(getText('indicator')).toBe('Record 1 of 1');
+  });
 });

--- a/__tests__/blinx.table.test.js
+++ b/__tests__/blinx.table.test.js
@@ -172,4 +172,22 @@ describe('blinxTable', () => {
 
     jest.useRealTimers();
   });
+
+  test('controls: {} suppresses the default toolbar (but still renders table rows)', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }, { name: 'B' }], model);
+    const root = document.createElement('div');
+
+    blinxTable({
+      root,
+      view: { columns: [{ field: 'name', label: 'Name' }] },
+      store,
+      pageSize: 20,
+      controls: {},
+    });
+
+    expect(root.querySelector('.blinx-controls')).toBeNull();
+    expect(root.querySelector('table')).not.toBeNull();
+    expect(root.querySelectorAll('tbody tr').length).toBe(2);
+  });
 });

--- a/__tests__/blinx.table.test.js
+++ b/__tests__/blinx.table.test.js
@@ -85,9 +85,9 @@ describe('blinxTable', () => {
       store,
       pageSize: 20,
       controls: {
-        createButtonId: 'create',
-        deleteSelectedButtonId: 'del',
-        statusId: 'status',
+        createButton: 'create',
+        deleteSelectedButton: 'del',
+        status: 'status',
       }
     });
 
@@ -127,8 +127,8 @@ describe('blinxTable', () => {
       store,
       pageSize: 20,
       controls: {
-        createButtonId: 'create',
-        statusId: 'status',
+        createButton: 'create',
+        status: 'status',
       }
     });
 
@@ -159,7 +159,7 @@ describe('blinxTable', () => {
       store,
       pageSize: 20,
       controls: {
-        statusId: 'status',
+        status: 'status',
       }
     });
 

--- a/demo/basic-model/basic-model.html
+++ b/demo/basic-model/basic-model.html
@@ -52,11 +52,6 @@
       store,
       pageSize: 10,
       onRowClick: (rowIndex) => formApi.setRecordIndex(rowIndex),
-      controls: {
-        createButtonId: 'tbl-create',
-        deleteSelectedButtonId: 'tbl-delete-selected',
-        statusId: 'tbl-status',
-      }
     });
   </script>
 </body>

--- a/demo/basic-model/basic-model.html
+++ b/demo/basic-model/basic-model.html
@@ -44,16 +44,6 @@
       view: productFormView,
       store,
       recordIndex: 0,
-      controls: {
-        saveButtonId: 'btn-save',
-        resetButtonId: 'btn-reset',
-        nextButtonId: 'btn-next',
-        prevButtonId: 'btn-prev',
-        createButtonId: 'btn-create',
-        deleteButtonId: 'btn-delete',
-        recordIndicatorId: 'record-indicator',
-        saveStatusId: 'save-status',
-      }
     });
 
     const { tableApi } = blinxTable({

--- a/demo/basic-model/model/product.model.js
+++ b/demo/basic-model/model/product.model.js
@@ -17,6 +17,17 @@ export const productModel = {
 
 export const productFormView = {
   sections: [{ title: 'General', columns: 2, fields: ['id', 'name', 'price', 'active', 'category', 'releaseDate', 'tags'] }],
+  // Declarative controls: bind to DOM by id (no boilerplate in blinxForm call)
+  controls: {
+    saveButton: 'btn-save',
+    resetButton: 'btn-reset',
+    nextButton: 'btn-next',
+    prevButton: 'btn-prev',
+    createButton: 'btn-create',
+    deleteButton: 'btn-delete',
+    recordIndicator: 'record-indicator',
+    saveStatus: 'save-status',
+  },
 };
 
 export const productTableView = {

--- a/demo/basic-model/model/product.model.js
+++ b/demo/basic-model/model/product.model.js
@@ -40,6 +40,10 @@ export const productTableView = {
     { field: 'releaseDate', label: 'Release Date' },
   ],
   controls: {
+    // Pager is intentionally auto-rendered inside #table-container (used by E2E).
+    prevButton: true,
+    nextButton: true,
+    pageLabel: true,
     createButton: 'tbl-create',
     deleteSelectedButton: 'tbl-delete-selected',
     status: 'tbl-status',

--- a/demo/basic-model/model/product.model.js
+++ b/demo/basic-model/model/product.model.js
@@ -39,6 +39,11 @@ export const productTableView = {
     { field: 'category', label: 'Category' },
     { field: 'releaseDate', label: 'Release Date' },
   ],
+  controls: {
+    createButton: 'tbl-create',
+    deleteSelectedButton: 'tbl-delete-selected',
+    status: 'tbl-status',
+  },
 };
 
 export const initialDataset = [

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -3,15 +3,79 @@ import { RegisteredUI } from './blinx.registered-ui.js';
 
 const ROOT_CLEANUP = Symbol('blinxCollectionCleanup');
 
-function getDomControls(controls = {}) {
-  return {
-    createBtn: controls.createButtonId ? document.getElementById(controls.createButtonId) : null,
-    deleteSelectedBtn: controls.deleteSelectedButtonId ? document.getElementById(controls.deleteSelectedButtonId) : null,
-    status: controls.statusId ? document.getElementById(controls.statusId) : null,
-    prevBtn: controls.prevButtonId ? document.getElementById(controls.prevButtonId) : null,
-    nextBtn: controls.nextButtonId ? document.getElementById(controls.nextButtonId) : null,
-    pageLabel: controls.pageLabelId ? document.getElementById(controls.pageLabelId) : null,
-  };
+const BUILTIN_CONTROL_KEYS = [
+  'createButton',
+  'deleteSelectedButton',
+  'status',
+  'prevButton',
+  'nextButton',
+  'pageLabel',
+];
+
+function assertNoLegacyControlIds(obj, source = 'controls') {
+  if (!obj || typeof obj !== 'object') return;
+  const legacyKeys = [
+    'createButtonId',
+    'deleteSelectedButtonId',
+    'statusId',
+    'prevButtonId',
+    'nextButtonId',
+    'pageLabelId',
+  ].filter(k => Object.prototype.hasOwnProperty.call(obj, k));
+  if (legacyKeys.length > 0) {
+    throw new Error(
+      `blinxCollection: legacy control id keys are no longer supported (${legacyKeys.join(', ')}). `
+      + `Use ${source}.{ createButton, deleteSelectedButton, status, prevButton, nextButton, pageLabel } `
+      + 'with shorthand: true | false | "domId" | { domId, label, visible, disabled, css, action }.'
+    );
+  }
+}
+
+function normalizeControlSpecEntry(entry) {
+  if (typeof entry === 'string') return { domId: entry };
+  if (entry === true) return { visible: true, disabled: false };
+  if (entry === false) return { visible: false, disabled: true };
+  if (entry && typeof entry === 'object') return { ...entry };
+  return null;
+}
+
+function resolveElementByIdWithinRoot(root, id) {
+  if (!id) return null;
+  if (root && typeof root.querySelector === 'function') {
+    try {
+      const escaped = (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') ? CSS.escape(id) : id;
+      const within = root.querySelector(`#${escaped}`);
+      if (within) return within;
+    } catch { /* ignore */ }
+  }
+  return document.getElementById(id);
+}
+
+function applyControlPresentation(el, spec) {
+  if (!el || !spec) return;
+  if (typeof spec.visible === 'boolean') el.hidden = !spec.visible;
+  if (typeof spec.disabled === 'boolean') {
+    if ('disabled' in el) el.disabled = !!spec.disabled;
+    el.setAttribute('aria-disabled', spec.disabled ? 'true' : 'false');
+  }
+  if (typeof spec.css === 'string' && spec.css.trim()) {
+    el.className = `${el.className || ''} ${spec.css}`.trim();
+  }
+  if (typeof spec.label === 'string') {
+    if (el.tagName === 'BUTTON') el.textContent = spec.label;
+  }
+}
+
+function defaultBuiltinControlMeta(key) {
+  switch (key) {
+    case 'createButton': return { label: 'Create', css: 'btn' };
+    case 'deleteSelectedButton': return { label: 'Delete Selected', css: 'btn' };
+    case 'prevButton': return { label: 'Prev', css: 'btn' };
+    case 'nextButton': return { label: 'Next', css: 'btn' };
+    case 'pageLabel': return { label: '', css: '' };
+    case 'status': return { label: '', css: '' };
+    default: return { label: '', css: '' };
+  }
 }
 
 function setStatus(dom, msg, color = '#4a5568') {
@@ -20,15 +84,34 @@ function setStatus(dom, msg, color = '#4a5568') {
   dom.status.style.color = color;
 }
 
-function createInternalPager(root) {
+function createDefaultToolbar(root, { includeActions = true, includePager = true } = {}) {
   const toolbar = document.createElement('div');
-  toolbar.className = 'flex';
-  const prevBtn = document.createElement('button'); prevBtn.className = 'btn'; prevBtn.textContent = 'Prev';
-  const nextBtn = document.createElement('button'); nextBtn.className = 'btn'; nextBtn.textContent = 'Next';
+  toolbar.className = 'flex blinx-controls';
+  const createBtn = document.createElement('button'); createBtn.type = 'button';
+  const deleteSelectedBtn = document.createElement('button'); deleteSelectedBtn.type = 'button';
+  const prevBtn = document.createElement('button'); prevBtn.type = 'button';
+  const nextBtn = document.createElement('button'); nextBtn.type = 'button';
   const pageLabel = document.createElement('span'); pageLabel.textContent = 'Page: 1';
-  toolbar.append(prevBtn, nextBtn, pageLabel);
+  const status = document.createElement('span');
+
+  const meta = {
+    createButton: defaultBuiltinControlMeta('createButton'),
+    deleteSelectedButton: defaultBuiltinControlMeta('deleteSelectedButton'),
+    prevButton: defaultBuiltinControlMeta('prevButton'),
+    nextButton: defaultBuiltinControlMeta('nextButton'),
+  };
+  createBtn.textContent = meta.createButton.label; createBtn.className = meta.createButton.css;
+  deleteSelectedBtn.textContent = meta.deleteSelectedButton.label; deleteSelectedBtn.className = meta.deleteSelectedButton.css;
+  prevBtn.textContent = meta.prevButton.label; prevBtn.className = meta.prevButton.css;
+  nextBtn.textContent = meta.nextButton.label; nextBtn.className = meta.nextButton.css;
+
+  const nodes = [];
+  if (includeActions) nodes.push(createBtn, deleteSelectedBtn);
+  if (includePager) nodes.push(prevBtn, nextBtn, pageLabel);
+  nodes.push(status);
+  toolbar.append(...nodes);
   root.appendChild(toolbar);
-  return { prevBtn, nextBtn, pageLabel, toolbar };
+  return { toolbar, createBtn, deleteSelectedBtn, prevBtn, nextBtn, pageLabel, status };
 }
 
 function defaultExternalStatusMessages(layout) {
@@ -206,7 +289,7 @@ export function blinxCollection({
   paging = {},
   selection = { mode: 'multi' },
   actions = { create: true, deleteSelected: true },
-  controls = {},
+  controls,
   layouts = {},
   onItemClick,
 } = {}) {
@@ -267,6 +350,9 @@ export function blinxCollection({
   }
 
   root.innerHTML = '';
+  const contentRoot = document.createElement('div');
+  contentRoot.className = 'blinx-collection__content';
+  root.appendChild(contentRoot);
 
   const layoutKey = typeof view.layout === 'string' ? view.layout : (view.layout ? 'custom' : 'table');
   const builtins = {
@@ -286,8 +372,105 @@ export function blinxCollection({
   let pendingResetSync = null;
   const cleanupFns = [];
 
-  const dom = getDomControls(controls);
-  let internalPager = null;
+  // Resolve controls:
+  // - Declarative view controls: view.controls (or explicit `controls` param)
+  // - Omitted controls => auto-render a default toolbar (actions + pager + status)
+  const explicitControlsProvided = Object.prototype.hasOwnProperty.call(arguments?.[0] || {}, 'controls');
+  const viewControlsSpec = view && typeof view === 'object' ? view.controls : undefined;
+  const resolvedControlsSpec = explicitControlsProvided ? controls : viewControlsSpec;
+  assertNoLegacyControlIds(resolvedControlsSpec, explicitControlsProvided ? 'controls' : 'view.controls');
+
+  const dom = {
+    createBtn: null,
+    deleteSelectedBtn: null,
+    status: null,
+    prevBtn: null,
+    nextBtn: null,
+    pageLabel: null,
+    custom: {},
+  };
+  let internalToolbar = null;
+
+  function ensureToolbar() {
+    if (internalToolbar) return internalToolbar;
+    internalToolbar = document.createElement('div');
+    internalToolbar.className = 'flex blinx-controls';
+    root.insertBefore(internalToolbar, contentRoot);
+    cleanupFns.push(() => {
+      try { internalToolbar?.remove(); } catch { /* ignore */ }
+      internalToolbar = null;
+    });
+    return internalToolbar;
+  }
+
+  function ensureBuiltin(key) {
+    if (!resolvedControlsSpec || typeof resolvedControlsSpec !== 'object') return null;
+    const entry = normalizeControlSpecEntry(resolvedControlsSpec[key]);
+    if (!entry) return null; // not declared
+    const meta = { ...defaultBuiltinControlMeta(key), ...entry };
+    meta.visible = (typeof meta.visible === 'boolean') ? meta.visible : true;
+    meta.disabled = (typeof meta.disabled === 'boolean') ? meta.disabled : false;
+
+    if (typeof meta.domId === 'string' && meta.domId) {
+      const existing = resolveElementByIdWithinRoot(root, meta.domId);
+      applyControlPresentation(existing, meta);
+      return existing;
+    }
+
+    let el;
+    if (key === 'status' || key === 'pageLabel') el = document.createElement('span');
+    else { el = document.createElement('button'); el.type = 'button'; }
+    if (meta.label && el.tagName === 'BUTTON') el.textContent = meta.label;
+    applyControlPresentation(el, meta);
+    ensureToolbar().appendChild(el);
+    return el;
+  }
+
+  if (resolvedControlsSpec === false || resolvedControlsSpec === null) {
+    // Explicitly disable controls.
+  } else if (!explicitControlsProvided && resolvedControlsSpec === undefined) {
+    // Auto-render defaults when controls are omitted everywhere.
+    const includeActions = !!actions?.create || !!actions?.deleteSelected;
+    const includePager = true;
+    const t = createDefaultToolbar(root, { includeActions, includePager });
+    cleanupFns.push(() => { try { t?.toolbar?.remove(); } catch { /* ignore */ } });
+    dom.createBtn = t.createBtn;
+    dom.deleteSelectedBtn = t.deleteSelectedBtn;
+    dom.prevBtn = t.prevBtn;
+    dom.nextBtn = t.nextBtn;
+    dom.pageLabel = t.pageLabel;
+    dom.status = t.status;
+  } else if (resolvedControlsSpec && typeof resolvedControlsSpec === 'object') {
+    // Render/bind only explicitly declared controls.
+    dom.createBtn = ensureBuiltin('createButton');
+    dom.deleteSelectedBtn = ensureBuiltin('deleteSelectedButton');
+    dom.prevBtn = ensureBuiltin('prevButton');
+    dom.nextBtn = ensureBuiltin('nextButton');
+    dom.pageLabel = ensureBuiltin('pageLabel');
+    dom.status = ensureBuiltin('status');
+
+    for (const [key, raw] of Object.entries(resolvedControlsSpec)) {
+      if (BUILTIN_CONTROL_KEYS.includes(key)) continue;
+      const entry = normalizeControlSpecEntry(raw);
+      if (!entry) continue;
+      const meta = { label: key, ...entry };
+      meta.visible = (typeof meta.visible === 'boolean') ? meta.visible : true;
+      meta.disabled = (typeof meta.disabled === 'boolean') ? meta.disabled : false;
+
+      let el = null;
+      if (typeof meta.domId === 'string' && meta.domId) {
+        el = resolveElementByIdWithinRoot(root, meta.domId);
+        applyControlPresentation(el, meta);
+      } else {
+        el = document.createElement('button');
+        el.type = 'button';
+        el.textContent = meta.label || key;
+        applyControlPresentation(el, meta);
+        ensureToolbar().appendChild(el);
+      }
+      if (el) dom.custom[key] = { el, spec: meta };
+    }
+  }
   const trackedStoreEvents = new Set([
     EventTypes.add,
     EventTypes.remove,
@@ -352,7 +535,7 @@ export function blinxCollection({
   }
 
   function updatePagerLabel() {
-    const labelEl = dom.pageLabel || internalPager?.pageLabel;
+    const labelEl = dom.pageLabel;
     if (!labelEl) return;
     if (typeof store.getPagingState === 'function') {
       const s = store.getPagingState();
@@ -441,8 +624,8 @@ export function blinxCollection({
   }
 
   function bindPagerButtons() {
-    const prevEl = dom.prevBtn || internalPager?.prevBtn;
-    const nextEl = dom.nextBtn || internalPager?.nextBtn;
+    const prevEl = dom.prevBtn;
+    const nextEl = dom.nextBtn;
     if (prevEl) {
       const onPrev = async () => {
         if (typeof store.pagePrev === 'function') {
@@ -485,14 +668,7 @@ export function blinxCollection({
     }
   }
 
-  // If external pager controls are not provided, mount internal pager by default.
-  if (!dom.prevBtn && !dom.nextBtn && !dom.pageLabel) {
-    internalPager = createInternalPager(root);
-    cleanupFns.push(() => {
-      try { internalPager?.toolbar?.remove(); } catch { /* ignore */ }
-      internalPager = null;
-    });
-  }
+  // Note: pager is rendered/bound only when declared or when controls are omitted (auto default).
 
   const controller = {
     getState: () => {
@@ -520,7 +696,7 @@ export function blinxCollection({
   };
 
   const layoutApi = layout.mount({
-    root,
+    root: contentRoot,
     model,
     view,
     ui: getUI(defaultRendererName),
@@ -534,8 +710,33 @@ export function blinxCollection({
   }
   cleanupFns.push(() => { try { layoutApi.destroy && layoutApi.destroy(); } catch { /* ignore */ } });
 
+  const api = {
+    onCreate: fn => listeners.create.push(fn),
+    onDeleteSelected: fn => listeners.deleteSelected.push(fn),
+    setPage: controller.setPage,
+    getState: controller.getState,
+    destroy: () => destroy(),
+  };
+
   bindPagerButtons();
   bindActionButtons();
+
+  // Bind custom control actions (if any)
+  for (const [name, { el, spec }] of Object.entries(dom.custom || {})) {
+    const action = spec?.action;
+    if (!el || typeof action !== 'function') continue;
+    const onClick = async () => {
+      const ctx = {
+        api,
+        store,
+        getState: () => controller.getState(),
+        setStatus: (msg, color) => setStatus(dom, msg, color),
+      };
+      await action(ctx);
+    };
+    el.addEventListener('click', onClick);
+    cleanupFns.push(() => el.removeEventListener('click', onClick));
+  }
 
   const unsubscribe = store.subscribe(ev => {
     if (internalChangeDepth > 0) return;
@@ -568,15 +769,7 @@ export function blinxCollection({
   }
   root[ROOT_CLEANUP] = destroy;
 
-  return {
-    api: {
-      onCreate: fn => listeners.create.push(fn),
-      onDeleteSelected: fn => listeners.deleteSelected.push(fn),
-      setPage: controller.setPage,
-      getState: controller.getState,
-      destroy,
-    }
-  };
+  return { api };
 }
 
 // Backwards-compatible alias (deprecated)

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -1,5 +1,10 @@
 import { EventTypes } from './blinx.store.js';
 import { RegisteredUI } from './blinx.registered-ui.js';
+import {
+  normalizeControlSpecEntry,
+  resolveElementByIdWithinRoot,
+  applyControlPresentation,
+} from './blinx.controls.js';
 
 const ROOT_CLEANUP = Symbol('blinxCollectionCleanup');
 
@@ -11,60 +16,6 @@ const BUILTIN_CONTROL_KEYS = [
   'nextButton',
   'pageLabel',
 ];
-
-function assertNoLegacyControlIds(obj, source = 'controls') {
-  if (!obj || typeof obj !== 'object') return;
-  const legacyKeys = [
-    'createButtonId',
-    'deleteSelectedButtonId',
-    'statusId',
-    'prevButtonId',
-    'nextButtonId',
-    'pageLabelId',
-  ].filter(k => Object.prototype.hasOwnProperty.call(obj, k));
-  if (legacyKeys.length > 0) {
-    throw new Error(
-      `blinxCollection: legacy control id keys are no longer supported (${legacyKeys.join(', ')}). `
-      + `Use ${source}.{ createButton, deleteSelectedButton, status, prevButton, nextButton, pageLabel } `
-      + 'with shorthand: true | false | "domId" | { domId, label, visible, disabled, css, action }.'
-    );
-  }
-}
-
-function normalizeControlSpecEntry(entry) {
-  if (typeof entry === 'string') return { domId: entry };
-  if (entry === true) return { visible: true, disabled: false };
-  if (entry === false) return { visible: false, disabled: true };
-  if (entry && typeof entry === 'object') return { ...entry };
-  return null;
-}
-
-function resolveElementByIdWithinRoot(root, id) {
-  if (!id) return null;
-  if (root && typeof root.querySelector === 'function') {
-    try {
-      const escaped = (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') ? CSS.escape(id) : id;
-      const within = root.querySelector(`#${escaped}`);
-      if (within) return within;
-    } catch { /* ignore */ }
-  }
-  return document.getElementById(id);
-}
-
-function applyControlPresentation(el, spec) {
-  if (!el || !spec) return;
-  if (typeof spec.visible === 'boolean') el.hidden = !spec.visible;
-  if (typeof spec.disabled === 'boolean') {
-    if ('disabled' in el) el.disabled = !!spec.disabled;
-    el.setAttribute('aria-disabled', spec.disabled ? 'true' : 'false');
-  }
-  if (typeof spec.css === 'string' && spec.css.trim()) {
-    el.className = `${el.className || ''} ${spec.css}`.trim();
-  }
-  if (typeof spec.label === 'string') {
-    if (el.tagName === 'BUTTON') el.textContent = spec.label;
-  }
-}
 
 function defaultBuiltinControlMeta(key) {
   switch (key) {
@@ -378,7 +329,6 @@ export function blinxCollection({
   const explicitControlsProvided = Object.prototype.hasOwnProperty.call(arguments?.[0] || {}, 'controls');
   const viewControlsSpec = view && typeof view === 'object' ? view.controls : undefined;
   const resolvedControlsSpec = explicitControlsProvided ? controls : viewControlsSpec;
-  assertNoLegacyControlIds(resolvedControlsSpec, explicitControlsProvided ? 'controls' : 'view.controls');
 
   const dom = {
     createBtn: null,
@@ -395,7 +345,8 @@ export function blinxCollection({
     if (internalToolbar) return internalToolbar;
     internalToolbar = document.createElement('div');
     internalToolbar.className = 'flex blinx-controls';
-    root.insertBefore(internalToolbar, contentRoot);
+    // Keep placement consistent with auto-rendered toolbar: after content.
+    root.appendChild(internalToolbar);
     cleanupFns.push(() => {
       try { internalToolbar?.remove(); } catch { /* ignore */ }
       internalToolbar = null;

--- a/lib/blinx.controls.js
+++ b/lib/blinx.controls.js
@@ -1,0 +1,49 @@
+// Internal helpers for declarative controls (shared across adapters).
+
+export function normalizeControlSpecEntry(entry) {
+  // Shorthand forms:
+  // - string: domId
+  // - true: visible + auto-render
+  // - false: hidden
+  if (typeof entry === 'string') return { domId: entry };
+  if (entry === true) return { visible: true, disabled: false };
+  if (entry === false) return { visible: false, disabled: true };
+  if (entry && typeof entry === 'object') return { ...entry };
+  // undefined/null => treat as omitted (not declared)
+  return null;
+}
+
+export function resolveElementByIdWithinRoot(root, id) {
+  if (!id) return null;
+  // Prefer scoping to root (important for nested renderers); fall back to global.
+  if (root && typeof root.querySelector === 'function') {
+    try {
+      // CSS.escape is not guaranteed in all runtimes; best-effort.
+      const escaped = (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') ? CSS.escape(id) : id;
+      const within = root.querySelector(`#${escaped}`);
+      if (within) return within;
+    } catch { /* ignore */ }
+  }
+  return document.getElementById(id);
+}
+
+export function applyControlPresentation(el, spec) {
+  if (!el || !spec) return;
+  if (typeof spec.visible === 'boolean') {
+    // Use hidden for accessibility & easy toggling.
+    el.hidden = !spec.visible;
+  }
+  if (typeof spec.disabled === 'boolean') {
+    // Only meaningful for interactive controls.
+    if ('disabled' in el) el.disabled = !!spec.disabled;
+    el.setAttribute('aria-disabled', spec.disabled ? 'true' : 'false');
+  }
+  if (typeof spec.css === 'string' && spec.css.trim()) {
+    el.className = `${el.className || ''} ${spec.css}`.trim();
+  }
+  if (typeof spec.label === 'string') {
+    // For buttons, update label.
+    if (el.tagName === 'BUTTON') el.textContent = spec.label;
+  }
+}
+

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -19,16 +19,25 @@ const BUILTIN_CONTROL_KEYS = [
   'saveStatus',
 ];
 
-function hasLegacyControlIds(obj) {
-  if (!obj || typeof obj !== 'object') return false;
-  return Object.prototype.hasOwnProperty.call(obj, 'saveButtonId')
-    || Object.prototype.hasOwnProperty.call(obj, 'resetButtonId')
-    || Object.prototype.hasOwnProperty.call(obj, 'nextButtonId')
-    || Object.prototype.hasOwnProperty.call(obj, 'prevButtonId')
-    || Object.prototype.hasOwnProperty.call(obj, 'createButtonId')
-    || Object.prototype.hasOwnProperty.call(obj, 'deleteButtonId')
-    || Object.prototype.hasOwnProperty.call(obj, 'recordIndicatorId')
-    || Object.prototype.hasOwnProperty.call(obj, 'saveStatusId');
+function assertNoLegacyControlIds(obj, source = 'controls') {
+  if (!obj || typeof obj !== 'object') return;
+  const legacyKeys = [
+    'saveButtonId',
+    'resetButtonId',
+    'nextButtonId',
+    'prevButtonId',
+    'createButtonId',
+    'deleteButtonId',
+    'recordIndicatorId',
+    'saveStatusId',
+  ].filter(k => Object.prototype.hasOwnProperty.call(obj, k));
+  if (legacyKeys.length > 0) {
+    throw new Error(
+      `blinxForm: legacy control id keys are no longer supported (${legacyKeys.join(', ')}). `
+      + `Use ${source}.{ saveButton, resetButton, nextButton, prevButton, createButton, deleteButton, recordIndicator, saveStatus } `
+      + 'with shorthand: true | false | "domId" | { domId, label, visible, disabled, css, action }.'
+    );
+  }
 }
 
 function normalizeControlSpecEntry(entry) {
@@ -236,12 +245,12 @@ export function blinxForm({
   };
 
   // Resolve controls:
-  // - Legacy external ids: { saveButtonId: '...', ... }
   // - Declarative view controls: view.controls (or explicit `controls` param)
   // - Omitted controls => auto-render a default toolbar
   const explicitControlsProvided = Object.prototype.hasOwnProperty.call(arguments?.[0] || {}, 'controls');
   const viewControlsSpec = view && typeof view === 'object' ? view.controls : undefined;
   const resolvedControlsSpec = explicitControlsProvided ? controls : viewControlsSpec;
+  assertNoLegacyControlIds(resolvedControlsSpec, explicitControlsProvided ? 'controls' : 'view.controls');
 
   const dom = {
     saveBtn: null,
@@ -274,16 +283,6 @@ export function blinxForm({
     dom.deleteBtn = internalToolbar.deleteBtn;
     dom.indicator = internalToolbar.indicator;
     dom.status = internalToolbar.status;
-  } else if (hasLegacyControlIds(resolvedControlsSpec)) {
-    const legacy = resolvedControlsSpec || {};
-    dom.saveBtn = legacy.saveButtonId ? resolveElementByIdWithinRoot(root, legacy.saveButtonId) : null;
-    dom.resetBtn = legacy.resetButtonId ? resolveElementByIdWithinRoot(root, legacy.resetButtonId) : null;
-    dom.nextBtn = legacy.nextButtonId ? resolveElementByIdWithinRoot(root, legacy.nextButtonId) : null;
-    dom.prevBtn = legacy.prevButtonId ? resolveElementByIdWithinRoot(root, legacy.prevButtonId) : null;
-    dom.createBtn = legacy.createButtonId ? resolveElementByIdWithinRoot(root, legacy.createButtonId) : null;
-    dom.deleteBtn = legacy.deleteButtonId ? resolveElementByIdWithinRoot(root, legacy.deleteButtonId) : null;
-    dom.indicator = legacy.recordIndicatorId ? resolveElementByIdWithinRoot(root, legacy.recordIndicatorId) : null;
-    dom.status = legacy.saveStatusId ? resolveElementByIdWithinRoot(root, legacy.saveStatusId) : null;
   } else if (resolvedControlsSpec && typeof resolvedControlsSpec === 'object') {
     // Declarative controls: only render/bind what is explicitly mentioned.
     const specObj = resolvedControlsSpec;

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -8,6 +8,123 @@ import { RegisteredUI } from './blinx.registered-ui.js';
 const CONTROL_CLICK_BINDINGS = new WeakMap();
 const ROOT_CLEANUP = Symbol('blinxFormCleanup');
 
+const BUILTIN_CONTROL_KEYS = [
+  'saveButton',
+  'resetButton',
+  'nextButton',
+  'prevButton',
+  'createButton',
+  'deleteButton',
+  'recordIndicator',
+  'saveStatus',
+];
+
+function hasLegacyControlIds(obj) {
+  if (!obj || typeof obj !== 'object') return false;
+  return Object.prototype.hasOwnProperty.call(obj, 'saveButtonId')
+    || Object.prototype.hasOwnProperty.call(obj, 'resetButtonId')
+    || Object.prototype.hasOwnProperty.call(obj, 'nextButtonId')
+    || Object.prototype.hasOwnProperty.call(obj, 'prevButtonId')
+    || Object.prototype.hasOwnProperty.call(obj, 'createButtonId')
+    || Object.prototype.hasOwnProperty.call(obj, 'deleteButtonId')
+    || Object.prototype.hasOwnProperty.call(obj, 'recordIndicatorId')
+    || Object.prototype.hasOwnProperty.call(obj, 'saveStatusId');
+}
+
+function normalizeControlSpecEntry(entry) {
+  // Shorthand forms:
+  // - string: domId
+  // - true: visible + auto-render
+  // - false: hidden
+  if (typeof entry === 'string') return { domId: entry };
+  if (entry === true) return { visible: true, disabled: false };
+  if (entry === false) return { visible: false, disabled: true };
+  if (entry && typeof entry === 'object') return { ...entry };
+  // undefined/null => treat as omitted (not declared)
+  return null;
+}
+
+function resolveElementByIdWithinRoot(root, id) {
+  if (!id) return null;
+  // Prefer scoping to root (important for nested renderers); fall back to global.
+  if (root && typeof root.querySelector === 'function') {
+    try {
+      // CSS.escape is not guaranteed in all runtimes; best-effort.
+      const escaped = (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') ? CSS.escape(id) : id;
+      const within = root.querySelector(`#${escaped}`);
+      if (within) return within;
+    } catch { /* ignore */ }
+  }
+  return document.getElementById(id);
+}
+
+function applyControlPresentation(el, spec) {
+  if (!el || !spec) return;
+  if (typeof spec.visible === 'boolean') {
+    // Use hidden for accessibility & easy toggling.
+    el.hidden = !spec.visible;
+  }
+  if (typeof spec.disabled === 'boolean') {
+    // Only meaningful for interactive controls.
+    if ('disabled' in el) el.disabled = !!spec.disabled;
+    el.setAttribute('aria-disabled', spec.disabled ? 'true' : 'false');
+  }
+  if (typeof spec.css === 'string' && spec.css.trim()) {
+    el.className = `${el.className || ''} ${spec.css}`.trim();
+  }
+  if (typeof spec.label === 'string') {
+    // For buttons, update label.
+    if (el.tagName === 'BUTTON') el.textContent = spec.label;
+  }
+}
+
+function defaultBuiltinControlMeta(key) {
+  switch (key) {
+    case 'prevButton': return { label: 'Previous', css: 'btn' };
+    case 'nextButton': return { label: 'Next', css: 'btn' };
+    case 'saveButton': return { label: 'Save', css: 'btn btn-primary' };
+    case 'resetButton': return { label: 'Reset', css: 'btn' };
+    case 'createButton': return { label: 'Create', css: 'btn' };
+    case 'deleteButton': return { label: 'Delete', css: 'btn' };
+    case 'recordIndicator': return { label: '', css: '' };
+    case 'saveStatus': return { label: '', css: '' };
+    default: return { label: '', css: '' };
+  }
+}
+
+function createDefaultToolbar(root) {
+  const toolbar = document.createElement('div');
+  toolbar.className = 'flex blinx-controls';
+  // Order mirrors demo/basic-model.html
+  const prevBtn = document.createElement('button'); prevBtn.type = 'button';
+  const nextBtn = document.createElement('button'); nextBtn.type = 'button';
+  const indicator = document.createElement('span');
+  const saveBtn = document.createElement('button'); saveBtn.type = 'button';
+  const resetBtn = document.createElement('button'); resetBtn.type = 'button';
+  const createBtn = document.createElement('button'); createBtn.type = 'button';
+  const deleteBtn = document.createElement('button'); deleteBtn.type = 'button';
+  const status = document.createElement('span');
+
+  const meta = {
+    prevButton: defaultBuiltinControlMeta('prevButton'),
+    nextButton: defaultBuiltinControlMeta('nextButton'),
+    saveButton: defaultBuiltinControlMeta('saveButton'),
+    resetButton: defaultBuiltinControlMeta('resetButton'),
+    createButton: defaultBuiltinControlMeta('createButton'),
+    deleteButton: defaultBuiltinControlMeta('deleteButton'),
+  };
+  prevBtn.textContent = meta.prevButton.label; prevBtn.className = meta.prevButton.css;
+  nextBtn.textContent = meta.nextButton.label; nextBtn.className = meta.nextButton.css;
+  saveBtn.textContent = meta.saveButton.label; saveBtn.className = meta.saveButton.css;
+  resetBtn.textContent = meta.resetButton.label; resetBtn.className = meta.resetButton.css;
+  createBtn.textContent = meta.createButton.label; createBtn.className = meta.createButton.css;
+  deleteBtn.textContent = meta.deleteButton.label; deleteBtn.className = meta.deleteButton.css;
+
+  toolbar.append(prevBtn, nextBtn, indicator, saveBtn, resetBtn, createBtn, deleteBtn, status);
+  root.appendChild(toolbar);
+  return { toolbar, prevBtn, nextBtn, indicator, saveBtn, resetBtn, createBtn, deleteBtn, status };
+}
+
 function bindClick(controlEl, role, handler) {
   if (!controlEl) return () => {};
   let bindings = CONTROL_CLICK_BINDINGS.get(controlEl);
@@ -35,16 +152,7 @@ export function blinxForm({
   // - any other string: resolves to store.view(name) / store.collection(name).
   dataView,
   recordIndex = 0,
-  controls = {
-    saveButtonId: null,
-    resetButtonId: null,
-    nextButtonId: null,
-    prevButtonId: null,
-    createButtonId: null,
-    deleteButtonId: null,
-    recordIndicatorId: null,
-    saveStatusId: null,
-  }
+  controls,
 }) {
   // Resolve declarative data view (if requested).
   if (dataView && typeof dataView === 'string') {
@@ -99,6 +207,10 @@ export function blinxForm({
 
   root.innerHTML = '';
 
+  const contentRoot = document.createElement('div');
+  contentRoot.className = 'blinx-form__content';
+  root.appendChild(contentRoot);
+
   let currentIndex = recordIndex;
   let sectionEls = [];
   let internalChangeDepth = 0;
@@ -123,16 +235,131 @@ export function blinxForm({
     [EventTypes.viewChanged]: 'View changed; refreshed view.',
   };
 
+  // Resolve controls:
+  // - Legacy external ids: { saveButtonId: '...', ... }
+  // - Declarative view controls: view.controls (or explicit `controls` param)
+  // - Omitted controls => auto-render a default toolbar
+  const explicitControlsProvided = Object.prototype.hasOwnProperty.call(arguments?.[0] || {}, 'controls');
+  const viewControlsSpec = view && typeof view === 'object' ? view.controls : undefined;
+  const resolvedControlsSpec = explicitControlsProvided ? controls : viewControlsSpec;
+
   const dom = {
-    saveBtn: controls.saveButtonId ? document.getElementById(controls.saveButtonId) : null,
-    resetBtn: controls.resetButtonId ? document.getElementById(controls.resetButtonId) : null,
-    nextBtn: controls.nextButtonId ? document.getElementById(controls.nextButtonId) : null,
-    prevBtn: controls.prevButtonId ? document.getElementById(controls.prevButtonId) : null,
-    createBtn: controls.createButtonId ? document.getElementById(controls.createButtonId) : null,
-    deleteBtn: controls.deleteButtonId ? document.getElementById(controls.deleteButtonId) : null,
-    indicator: controls.recordIndicatorId ? document.getElementById(controls.recordIndicatorId) : null,
-    status: controls.saveStatusId ? document.getElementById(controls.saveStatusId) : null,
+    saveBtn: null,
+    resetBtn: null,
+    nextBtn: null,
+    prevBtn: null,
+    createBtn: null,
+    deleteBtn: null,
+    indicator: null,
+    status: null,
+    custom: {},
   };
+
+  let internalToolbar = null;
+
+  if (resolvedControlsSpec === false || resolvedControlsSpec === null) {
+    // Explicitly disable controls rendering/binding.
+  } else if (!explicitControlsProvided && (resolvedControlsSpec === undefined)) {
+    // No controls were declared anywhere => auto-render opinionated defaults.
+    internalToolbar = createDefaultToolbar(root);
+    cleanupFns.push(() => {
+      try { internalToolbar?.toolbar?.remove(); } catch { /* ignore */ }
+      internalToolbar = null;
+    });
+    dom.prevBtn = internalToolbar.prevBtn;
+    dom.nextBtn = internalToolbar.nextBtn;
+    dom.saveBtn = internalToolbar.saveBtn;
+    dom.resetBtn = internalToolbar.resetBtn;
+    dom.createBtn = internalToolbar.createBtn;
+    dom.deleteBtn = internalToolbar.deleteBtn;
+    dom.indicator = internalToolbar.indicator;
+    dom.status = internalToolbar.status;
+  } else if (hasLegacyControlIds(resolvedControlsSpec)) {
+    const legacy = resolvedControlsSpec || {};
+    dom.saveBtn = legacy.saveButtonId ? resolveElementByIdWithinRoot(root, legacy.saveButtonId) : null;
+    dom.resetBtn = legacy.resetButtonId ? resolveElementByIdWithinRoot(root, legacy.resetButtonId) : null;
+    dom.nextBtn = legacy.nextButtonId ? resolveElementByIdWithinRoot(root, legacy.nextButtonId) : null;
+    dom.prevBtn = legacy.prevButtonId ? resolveElementByIdWithinRoot(root, legacy.prevButtonId) : null;
+    dom.createBtn = legacy.createButtonId ? resolveElementByIdWithinRoot(root, legacy.createButtonId) : null;
+    dom.deleteBtn = legacy.deleteButtonId ? resolveElementByIdWithinRoot(root, legacy.deleteButtonId) : null;
+    dom.indicator = legacy.recordIndicatorId ? resolveElementByIdWithinRoot(root, legacy.recordIndicatorId) : null;
+    dom.status = legacy.saveStatusId ? resolveElementByIdWithinRoot(root, legacy.saveStatusId) : null;
+  } else if (resolvedControlsSpec && typeof resolvedControlsSpec === 'object') {
+    // Declarative controls: only render/bind what is explicitly mentioned.
+    const specObj = resolvedControlsSpec;
+    let toolbar = null;
+    function ensureToolbar() {
+      if (toolbar) return toolbar;
+      toolbar = document.createElement('div');
+      toolbar.className = 'flex blinx-controls';
+      root.appendChild(toolbar);
+      cleanupFns.push(() => { try { toolbar && toolbar.remove(); } catch { /* ignore */ } });
+      return toolbar;
+    }
+
+    function ensureBuiltin(key) {
+      const entry = normalizeControlSpecEntry(specObj[key]);
+      if (!entry) return null; // not declared
+      const meta = { ...defaultBuiltinControlMeta(key), ...entry };
+      const visible = (typeof meta.visible === 'boolean') ? meta.visible : true;
+      const disabled = (typeof meta.disabled === 'boolean') ? meta.disabled : false;
+      meta.visible = visible;
+      meta.disabled = disabled;
+
+      if (typeof meta.domId === 'string' && meta.domId) {
+        const existing = resolveElementByIdWithinRoot(root, meta.domId);
+        applyControlPresentation(existing, meta);
+        return existing;
+      }
+
+      // Auto-render for declared controls (true/object without domId).
+      let el;
+      if (key === 'recordIndicator' || key === 'saveStatus') {
+        el = document.createElement('span');
+      } else {
+        el = document.createElement('button');
+        el.type = 'button';
+      }
+      if (meta.label && el.tagName === 'BUTTON') el.textContent = meta.label;
+      applyControlPresentation(el, meta);
+      ensureToolbar().appendChild(el);
+      return el;
+    }
+
+    dom.prevBtn = ensureBuiltin('prevButton');
+    dom.nextBtn = ensureBuiltin('nextButton');
+    dom.indicator = ensureBuiltin('recordIndicator');
+    dom.saveBtn = ensureBuiltin('saveButton');
+    dom.resetBtn = ensureBuiltin('resetButton');
+    dom.createBtn = ensureBuiltin('createButton');
+    dom.deleteBtn = ensureBuiltin('deleteButton');
+    dom.status = ensureBuiltin('saveStatus');
+
+    // Custom controls: any keys not in the builtin set.
+    for (const [key, raw] of Object.entries(specObj)) {
+      if (BUILTIN_CONTROL_KEYS.includes(key)) continue;
+      const entry = normalizeControlSpecEntry(raw);
+      if (!entry) continue;
+      const meta = { label: key, ...entry };
+      const visible = (typeof meta.visible === 'boolean') ? meta.visible : true;
+      const disabled = (typeof meta.disabled === 'boolean') ? meta.disabled : false;
+      meta.visible = visible;
+      meta.disabled = disabled;
+
+      let el = null;
+      if (typeof meta.domId === 'string' && meta.domId) {
+        el = resolveElementByIdWithinRoot(root, meta.domId);
+        applyControlPresentation(el, meta);
+      } else {
+        el = document.createElement('button');
+        el.type = 'button';
+        el.textContent = meta.label || key;
+        applyControlPresentation(el, meta);
+        ensureToolbar().appendChild(el);
+      }
+      if (el) dom.custom[key] = { el, spec: meta };
+    }
+  }
 
   const listeners = {
     save: [], reset: [], next: [], prev: [], create: [], delete: [], indexChanged: [],
@@ -216,8 +443,8 @@ export function blinxForm({
       frag.appendChild(sectionEl);
     });
 
-    root.innerHTML = '';
-    root.appendChild(frag);
+    contentRoot.innerHTML = '';
+    contentRoot.appendChild(frag);
   }
 
   async function validateAll() {
@@ -323,6 +550,28 @@ export function blinxForm({
   cleanupFns.push(bindClick(dom.nextBtn, 'next', () => runInterceptors('next', doNext)));
   cleanupFns.push(bindClick(dom.prevBtn, 'prev', () => runInterceptors('prev', doPrev)));
 
+  // Bind custom control actions (if any)
+  for (const [name, { el, spec }] of Object.entries(dom.custom || {})) {
+    const action = spec?.action;
+    if (!el || typeof action !== 'function') continue;
+    cleanupFns.push(bindClick(el, `custom:${name}`, async () => {
+      const ctx = {
+        formApi: api,
+        store,
+        get recordIndex() { return currentIndex; },
+        get record() { return store.getRecord(currentIndex); },
+        setStatus,
+        clearStatus,
+      };
+      try {
+        await action(ctx);
+      } catch (e) {
+        setStatus(`Action "${name}" failed.`, '#e53e3e');
+        throw e;
+      }
+    }));
+  }
+
   function destroy() {
     if (pendingResetSync) {
       clearTimeout(pendingResetSync);
@@ -338,18 +587,18 @@ export function blinxForm({
 
   if (root) root[ROOT_CLEANUP] = destroy;
 
-  return {
-    formApi: {
-      setRecordIndex: idx => rebind(idx),
-      onSave: fn => listeners.save.push(fn),
-      onReset: fn => listeners.reset.push(fn),
-      onCreate: fn => listeners.create.push(fn),
-      onDelete: fn => listeners.delete.push(fn),
-      onNext: fn => listeners.next.push(fn),
-      onPrev: fn => listeners.prev.push(fn),
-      destroy,
-    }
+  const api = {
+    setRecordIndex: idx => rebind(idx),
+    onSave: fn => listeners.save.push(fn),
+    onReset: fn => listeners.reset.push(fn),
+    onCreate: fn => listeners.create.push(fn),
+    onDelete: fn => listeners.delete.push(fn),
+    onNext: fn => listeners.next.push(fn),
+    onPrev: fn => listeners.prev.push(fn),
+    destroy,
   };
+
+  return { formApi: api };
 }
 
 // Backwards-compatible alias (deprecated)

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -2,6 +2,11 @@
 import { validateField } from './blinx.validate.js';
 import { EventTypes } from './blinx.store.js';
 import { RegisteredUI } from './blinx.registered-ui.js';
+import {
+  normalizeControlSpecEntry,
+  resolveElementByIdWithinRoot,
+  applyControlPresentation,
+} from './blinx.controls.js';
 
 // Prevent handler accumulation when blinxForm is called multiple times
 // with the same DOM controls (common in tests and re-renders).
@@ -18,74 +23,6 @@ const BUILTIN_CONTROL_KEYS = [
   'recordIndicator',
   'saveStatus',
 ];
-
-function assertNoLegacyControlIds(obj, source = 'controls') {
-  if (!obj || typeof obj !== 'object') return;
-  const legacyKeys = [
-    'saveButtonId',
-    'resetButtonId',
-    'nextButtonId',
-    'prevButtonId',
-    'createButtonId',
-    'deleteButtonId',
-    'recordIndicatorId',
-    'saveStatusId',
-  ].filter(k => Object.prototype.hasOwnProperty.call(obj, k));
-  if (legacyKeys.length > 0) {
-    throw new Error(
-      `blinxForm: legacy control id keys are no longer supported (${legacyKeys.join(', ')}). `
-      + `Use ${source}.{ saveButton, resetButton, nextButton, prevButton, createButton, deleteButton, recordIndicator, saveStatus } `
-      + 'with shorthand: true | false | "domId" | { domId, label, visible, disabled, css, action }.'
-    );
-  }
-}
-
-function normalizeControlSpecEntry(entry) {
-  // Shorthand forms:
-  // - string: domId
-  // - true: visible + auto-render
-  // - false: hidden
-  if (typeof entry === 'string') return { domId: entry };
-  if (entry === true) return { visible: true, disabled: false };
-  if (entry === false) return { visible: false, disabled: true };
-  if (entry && typeof entry === 'object') return { ...entry };
-  // undefined/null => treat as omitted (not declared)
-  return null;
-}
-
-function resolveElementByIdWithinRoot(root, id) {
-  if (!id) return null;
-  // Prefer scoping to root (important for nested renderers); fall back to global.
-  if (root && typeof root.querySelector === 'function') {
-    try {
-      // CSS.escape is not guaranteed in all runtimes; best-effort.
-      const escaped = (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') ? CSS.escape(id) : id;
-      const within = root.querySelector(`#${escaped}`);
-      if (within) return within;
-    } catch { /* ignore */ }
-  }
-  return document.getElementById(id);
-}
-
-function applyControlPresentation(el, spec) {
-  if (!el || !spec) return;
-  if (typeof spec.visible === 'boolean') {
-    // Use hidden for accessibility & easy toggling.
-    el.hidden = !spec.visible;
-  }
-  if (typeof spec.disabled === 'boolean') {
-    // Only meaningful for interactive controls.
-    if ('disabled' in el) el.disabled = !!spec.disabled;
-    el.setAttribute('aria-disabled', spec.disabled ? 'true' : 'false');
-  }
-  if (typeof spec.css === 'string' && spec.css.trim()) {
-    el.className = `${el.className || ''} ${spec.css}`.trim();
-  }
-  if (typeof spec.label === 'string') {
-    // For buttons, update label.
-    if (el.tagName === 'BUTTON') el.textContent = spec.label;
-  }
-}
 
 function defaultBuiltinControlMeta(key) {
   switch (key) {
@@ -250,7 +187,6 @@ export function blinxForm({
   const explicitControlsProvided = Object.prototype.hasOwnProperty.call(arguments?.[0] || {}, 'controls');
   const viewControlsSpec = view && typeof view === 'object' ? view.controls : undefined;
   const resolvedControlsSpec = explicitControlsProvided ? controls : viewControlsSpec;
-  assertNoLegacyControlIds(resolvedControlsSpec, explicitControlsProvided ? 'controls' : 'view.controls');
 
   const dom = {
     saveBtn: null,

--- a/lib/blinx.table.js
+++ b/lib/blinx.table.js
@@ -5,11 +5,7 @@ export function blinxTable({
   root, view, store,
   pageSize = 20,
   onRowClick,
-  controls = {
-    createButtonId: null,
-    deleteSelectedButtonId: null,
-    statusId: null,
-  }
+  controls,
 }) {
   if (!store || typeof store.getModel !== 'function') {
     throw new Error('blinxTable requires a store that exposes getModel().');
@@ -19,16 +15,19 @@ export function blinxTable({
     throw new Error('blinxTable requires the store model to define fields.');
   }
 
-  const { api } = blinxCollection({
+  const args = arguments?.[0] || {};
+  const opts = {
     root,
     store,
     view: { ...view, layout: 'table' },
     paging: { pageSize, page: 0 },
     selection: { mode: 'multi' },
     actions: { create: true, deleteSelected: true },
-    controls,
     onItemClick: onRowClick ? ({ index }) => onRowClick(index) : null,
-  });
+  };
+  if (Object.prototype.hasOwnProperty.call(args, 'controls')) opts.controls = controls;
+
+  const { api } = blinxCollection(opts);
 
   return {
     tableApi: {

--- a/test-results/junit.xml
+++ b/test-results/junit.xml
@@ -1,6 +1,0 @@
-<testsuites id="" name="" tests="1" failures="0" skipped="0" errors="0" time="2.178926">
-<testsuite name="basic-model.spec.js" timestamp="2025-12-19T19:15:03.195Z" hostname="" tests="1" failures="0" skipped="0" time="0.898" errors="0">
-<testcase name="demo/basic-model/basic-model.html › Form + Table controls work end-to-end" classname="basic-model.spec.js" time="0.898">
-</testcase>
-</testsuite>
-</testsuites>


### PR DESCRIPTION
Add declarative `controls` to UI-view and auto-render a default toolbar when controls are omitted.

This change allows controls to be defined directly in the `view` object, supporting shorthand for binding to existing DOM or auto-rendering, and provides a zero-boilerplate default toolbar for rapid prototyping. It also enables custom controls with `action` functions.

---
<a href="https://cursor.com/background-agent?bcId=bc-d777126b-c857-49b1-ad11-1f06478f49f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d777126b-c857-49b1-ad11-1f06478f49f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `view.controls` with shorthand (true/false/id/object), auto-render default toolbars when controls are omitted, support custom control actions, and drop legacy `*Id` control options.
> 
> - **Runtime (Form & Collection/Table)**
>   - Add declarative `view.controls` (or `controls` option) supporting `true | false | "domId" | { domId, label, visible, disabled, css, action }`.
>   - Auto-render default toolbars when controls are omitted; `controls: {}` suppresses toolbar while content still renders.
>   - Support custom controls with `action` handlers; bind to external DOM by id or auto-create elements in `.blinx-controls`.
>   - Remove legacy `*Id` control keys; now throw helpful errors if used.
>   - Pager/controls only bind when declared or when auto-rendering; update pager label logic.
>   - Wrap content in `div.blinx-form__content` / `div.blinx-collection__content`.
> - **Table Wrapper (`blinx.table.js`)**
>   - Forward `controls` only when explicitly provided to allow view-driven/auto controls.
> - **Demo & Docs**
>   - Move control wiring into `product.model.js` via `controls`; remove boilerplate from HTML.
>   - Update README to document declarative controls and auto toolbar.
> - **Tests**
>   - Update to new control keys; add coverage for omitted/empty controls, external binding, and default toolbar behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c51688d170aeba3299a9197068460327bc194646. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->