### PR TITLE
Blinx ui view design

### DIFF
--- a/__tests__/blinx.controls.equivalence.test.js
+++ b/__tests__/blinx.controls.equivalence.test.js
@@ -1,0 +1,204 @@
+/** @jest-environment jsdom */
+
+import { blinxStore } from '../lib/blinx.store.js';
+import { blinxForm } from '../lib/blinx.form.js';
+import { blinxCollection } from '../lib/blinx.collection.js';
+
+function setupExternalControls(ids = []) {
+  for (const id of ids) {
+    const el = document.createElement('button');
+    el.id = id;
+    document.body.appendChild(el);
+  }
+}
+
+function getToolbarButtonLabels(root) {
+  const toolbar = root.querySelector('.blinx-controls');
+  if (!toolbar) return [];
+  return Array.from(toolbar.querySelectorAll('button')).map(b => b.textContent);
+}
+
+describe('Controls equivalence + mixed domId/auto-render + custom actions', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('controls param supports partial + mixed domId and auto-render, including custom action (form)', async () => {
+    setupExternalControls(['save', 'custom-external']);
+    const indicator = document.createElement('div');
+    indicator.id = 'indicator';
+    document.body.appendChild(indicator);
+
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }, { name: 'B' }], model);
+    const root = document.createElement('div');
+
+    const onExternal = jest.fn();
+    const onInternal = jest.fn();
+
+    const view = { sections: [{ title: 'Main', columns: 1, fields: ['name'] }] };
+
+    blinxForm({
+      root,
+      store,
+      view,
+      recordIndex: 0,
+      controls: {
+        // Mixed: external dom binding + auto-rendered builtins
+        saveButton: 'save',
+        recordIndicator: 'indicator',
+        prevButton: true,
+        nextButton: true,
+
+        // Custom control (external) + custom control (auto-rendered)
+        customExternal: { domId: 'custom-external', action: async () => onExternal('ok') },
+        customInternal: { label: 'Custom Internal', action: async () => onInternal('ok') },
+      },
+    });
+
+    // Auto-rendered controls should create an internal toolbar (even though some controls are external).
+    expect(root.querySelector('.blinx-controls')).not.toBeNull();
+    expect(getToolbarButtonLabels(root)).toEqual(expect.arrayContaining(['Previous', 'Next', 'Custom Internal']));
+
+    // Built-in next/prev should update external indicator.
+    expect(document.getElementById('indicator')?.textContent).toBe('Record 1 of 2');
+    Array.from(root.querySelectorAll('.blinx-controls button')).find(b => b.textContent === 'Next')?.click();
+    expect(document.getElementById('indicator')?.textContent).toBe('Record 2 of 2');
+
+    Array.from(root.querySelectorAll('.blinx-controls button')).find(b => b.textContent === 'Previous')?.click();
+    expect(document.getElementById('indicator')?.textContent).toBe('Record 1 of 2');
+
+    // Custom actions should fire for external and internal custom controls.
+    document.getElementById('custom-external')?.click();
+    await Promise.resolve();
+    expect(onExternal).toHaveBeenCalledWith('ok');
+
+    Array.from(root.querySelectorAll('.blinx-controls button')).find(b => b.textContent === 'Custom Internal')?.click();
+    await Promise.resolve();
+    expect(onInternal).toHaveBeenCalledWith('ok');
+  });
+
+  test('same control spec behaves the same via view.controls vs controls param (form)', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const storeA = blinxStore([{ name: 'A' }, { name: 'B' }], model);
+    const storeB = blinxStore([{ name: 'A' }, { name: 'B' }], model);
+
+    // External DOM elements:
+    // IMPORTANT: controls bind event listeners directly to the target element.
+    // If two forms bind to the same element id, the second binding replaces the first.
+    // Use distinct buttons so we can assert both instances independently.
+    setupExternalControls(['custom-external-a', 'custom-external-b']);
+    const indicator = document.createElement('div');
+    indicator.id = 'indicator';
+    document.body.appendChild(indicator);
+
+    const onExternalA = jest.fn();
+    const onInternalA = jest.fn();
+    const onExternalB = jest.fn();
+    const onInternalB = jest.fn();
+
+    const commonControlsForView = {
+      recordIndicator: 'indicator',
+      prevButton: true,
+      nextButton: true,
+      customExternal: { domId: 'custom-external-a', action: async () => onExternalA('ok') },
+      customInternal: { label: 'Custom Internal', action: async () => onInternalA('ok') },
+    };
+
+    const commonControlsForParam = {
+      recordIndicator: 'indicator',
+      prevButton: true,
+      nextButton: true,
+      customExternal: { domId: 'custom-external-b', action: async () => onExternalB('ok') },
+      customInternal: { label: 'Custom Internal', action: async () => onInternalB('ok') },
+    };
+
+    const rootViewControls = document.createElement('div');
+    const rootParamControls = document.createElement('div');
+
+    blinxForm({
+      root: rootViewControls,
+      store: storeA,
+      recordIndex: 0,
+      view: {
+        sections: [{ title: 'Main', columns: 1, fields: ['name'] }],
+        controls: commonControlsForView,
+      },
+    });
+
+    blinxForm({
+      root: rootParamControls,
+      store: storeB,
+      recordIndex: 0,
+      view: { sections: [{ title: 'Main', columns: 1, fields: ['name'] }] },
+      controls: commonControlsForParam,
+    });
+
+    // Compare rendered toolbar buttons (labels should match).
+    expect(getToolbarButtonLabels(rootViewControls).sort()).toEqual(getToolbarButtonLabels(rootParamControls).sort());
+
+    // Compare navigation effect: both should update the same external indicator text (Record 1 -> 2).
+    document.getElementById('indicator').textContent = '';
+    Array.from(rootViewControls.querySelectorAll('.blinx-controls button')).find(b => b.textContent === 'Next')?.click();
+    expect(document.getElementById('indicator')?.textContent).toBe('Record 2 of 2');
+
+    // Reset indicator and test the other instance.
+    document.getElementById('indicator').textContent = '';
+    Array.from(rootParamControls.querySelectorAll('.blinx-controls button')).find(b => b.textContent === 'Next')?.click();
+    expect(document.getElementById('indicator')?.textContent).toBe('Record 2 of 2');
+
+    // Compare custom action firing for external and internal controls.
+    document.getElementById('custom-external-a')?.click();
+    await Promise.resolve();
+    expect(onExternalA).toHaveBeenCalledWith('ok');
+    expect(onExternalB).not.toHaveBeenCalled();
+
+    document.getElementById('custom-external-b')?.click();
+    await Promise.resolve();
+    expect(onExternalB).toHaveBeenCalledWith('ok');
+
+    Array.from(rootViewControls.querySelectorAll('.blinx-controls button')).find(b => b.textContent === 'Custom Internal')?.click();
+    Array.from(rootParamControls.querySelectorAll('.blinx-controls button')).find(b => b.textContent === 'Custom Internal')?.click();
+    await Promise.resolve();
+    expect(onInternalA).toHaveBeenCalledWith('ok');
+    expect(onInternalB).toHaveBeenCalledWith('ok');
+  });
+
+  test('custom controls work with domId and without (plus action) (collection)', async () => {
+    // One custom control is bound externally, one auto-renders.
+    setupExternalControls(['custom-external']);
+
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+
+    const onExternal = jest.fn();
+    const onInternal = jest.fn();
+
+    blinxCollection({
+      root,
+      store,
+      paging: { pageSize: 20 },
+      view: {
+        layout: 'table',
+        columns: [{ field: 'name', label: 'Name' }],
+        controls: {
+          customExternal: { domId: 'custom-external', action: async () => onExternal('ok') },
+          customInternal: { label: 'Custom Internal', action: async () => onInternal('ok') },
+        },
+      },
+    });
+
+    // Since customInternal has no domId, it should be auto-rendered in an internal toolbar.
+    expect(getToolbarButtonLabels(root)).toEqual(['Custom Internal']);
+
+    document.getElementById('custom-external')?.click();
+    await Promise.resolve();
+    expect(onExternal).toHaveBeenCalledWith('ok');
+
+    Array.from(root.querySelectorAll('.blinx-controls button')).find(b => b.textContent === 'Custom Internal')?.click();
+    await Promise.resolve();
+    expect(onInternal).toHaveBeenCalledWith('ok');
+  });
+});
+

--- a/__tests__/blinx.nested-uiviews.integration.test.js
+++ b/__tests__/blinx.nested-uiviews.integration.test.js
@@ -1,0 +1,129 @@
+/** @jest-environment jsdom */
+
+import { blinxStore } from '../lib/blinx.store.js';
+import { blinxForm } from '../lib/blinx.form.js';
+import { registerModelViews } from '../lib/blinx.ui-views.js';
+
+describe('Nested UI views (Option A registry) (integration)', () => {
+  test('blinxForm renders nested model + collection using model defaults and parent overrides', () => {
+    const AddressModel = {
+      id: 'Address',
+      fields: {
+        line1: { type: 'string' },
+        city: { type: 'string' },
+        zip: { type: 'string' },
+        country: { type: 'string' },
+      },
+    };
+
+    const CustomerModel = {
+      id: 'Customer',
+      fields: {
+        customerId: { type: 'string' },
+        name: { type: 'string' },
+        address: { type: 'model', model: AddressModel },
+      },
+    };
+
+    const OrderItemModel = {
+      id: 'OrderItem',
+      fields: {
+        sku: { type: 'string' },
+        qty: { type: 'number' },
+        price: { type: 'number' },
+      },
+    };
+
+    const OrderModel = {
+      id: 'Order',
+      fields: {
+        orderId: { type: 'string' },
+        customer: { type: 'model', model: CustomerModel },
+        items: { type: 'collection', model: OrderItemModel },
+        shippingAddress: { type: 'model', model: AddressModel },
+      },
+    };
+
+    registerModelViews(AddressModel, {
+      form: {
+        default: { sections: [{ title: 'Address', columns: 2, fields: ['line1', 'city', 'zip', 'country'] }] },
+        'short-address': { sections: [{ title: 'Short Address', columns: 2, fields: ['city', 'zip'] }] },
+      },
+    });
+
+    registerModelViews(CustomerModel, {
+      form: {
+        default: { sections: [{ title: 'Customer', columns: 2, fields: ['customerId', 'name', 'address'] }] },
+      },
+    });
+
+    registerModelViews(OrderItemModel, {
+      form: {
+        default: { sections: [{ title: 'Item', columns: 3, fields: ['sku', 'qty', 'price'] }] },
+        'name-qty-price-only': { sections: [{ title: 'Item Compact', columns: 2, fields: ['sku', 'qty'] }] },
+      },
+    });
+
+    registerModelViews(OrderModel, {
+      form: {
+        default: {
+          sections: [
+            {
+              title: 'Order',
+              columns: 1,
+              fields: [
+                'orderId',
+                'customer', // uses CustomerModel form.default
+                { field: 'items', itemView: 'name-qty-price-only' }, // override item view
+                { field: 'shippingAddress', view: 'short-address' }, // override nested model view
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    const store = blinxStore([{
+      orderId: 'o-1',
+      customer: {
+        customerId: 'c-1',
+        name: 'Alice',
+        address: { line1: '1 Main', city: 'NY', zip: '10001', country: 'US' },
+      },
+      items: [
+        { sku: 'SKU-1', qty: 2, price: 10 },
+      ],
+      shippingAddress: { line1: '2 Ship', city: 'SF', zip: '94105', country: 'US' },
+    }], OrderModel);
+
+    const root = document.createElement('div');
+    blinxForm({ root, store }); // no `view`: should resolve OrderModel form.default from registry
+
+    // Top-level field renders
+    expect(root.textContent).toContain('orderId');
+    expect(root.querySelector('input')?.value).toBe('o-1');
+
+    // Nested model: customer uses CustomerModel default view and renders its own nested address (AddressModel default view)
+    const customerRoot = root.querySelector('[data-blinx-field="customer"]');
+    expect(customerRoot).toBeTruthy();
+    expect(customerRoot.textContent).toContain('customerId');
+    expect(customerRoot.querySelector('[data-blinx-field="address"]')).toBeTruthy();
+    // Address default view includes "country"
+    expect(customerRoot.textContent).toContain('country');
+
+    // Nested collection: items uses override itemView, so it should NOT include "price" label
+    const itemsRoot = root.querySelector('[data-blinx-field="items"]');
+    expect(itemsRoot).toBeTruthy();
+    expect(itemsRoot.textContent).toContain('sku');
+    expect(itemsRoot.textContent).toContain('qty');
+    expect(itemsRoot.textContent).not.toContain('price');
+
+    // Nested model override: shippingAddress uses "short-address", so it should NOT include "country" label
+    const shippingRoot = root.querySelector('[data-blinx-field="shippingAddress"]');
+    expect(shippingRoot).toBeTruthy();
+    expect(shippingRoot.textContent).toContain('city');
+    expect(shippingRoot.textContent).toContain('zip');
+    expect(shippingRoot.textContent).not.toContain('country');
+  });
+});
+

--- a/__tests__/blinx.ui-views.registry.test.js
+++ b/__tests__/blinx.ui-views.registry.test.js
@@ -1,0 +1,37 @@
+import { registerModelViews, resolveModelUIView, resolveComponentUIView } from '../lib/blinx.ui-views.js';
+
+describe('UI Views registry (Option A)', () => {
+  test('resolveModelUIView: kind-bucketed views support default + named', () => {
+    const ModelA = { id: 'A', fields: {} };
+    const viewsA = {
+      form: {
+        default: { sections: [{ title: 'A', columns: 1, fields: [] }] },
+        compact: { sections: [{ title: 'A compact', columns: 1, fields: [] }] },
+      },
+      collection: {
+        default: { layout: 'table', columns: [{ field: 'id', label: 'ID' }] },
+      },
+    };
+
+    registerModelViews(ModelA, viewsA);
+
+    expect(resolveModelUIView({ model: ModelA, kind: 'form' })?.sections?.[0]?.title).toBe('A');
+    expect(resolveModelUIView({ model: ModelA, kind: 'form', viewName: 'compact' })?.sections?.[0]?.title).toBe('A compact');
+    expect(resolveModelUIView({ model: ModelA, kind: 'collection' })?.layout).toBe('table');
+  });
+
+  test('resolveComponentUIView: store-scoped uiViews win over registry for string keys', () => {
+    const ModelA = { id: 'A', fields: {} };
+    registerModelViews(ModelA, { form: { default: { sections: [] }, edit: { sections: [{ title: 'from-registry', columns: 1, fields: [] }] } } });
+
+    const store = {
+      getUIViews: () => ({
+        edit: { sections: [{ title: 'from-store', columns: 1, fields: [] }] },
+      }),
+    };
+
+    const resolved = resolveComponentUIView({ store, model: ModelA, kind: 'form', view: 'edit' });
+    expect(resolved?.sections?.[0]?.title).toBe('from-store');
+  });
+});
+

--- a/__tests__/blinx.view-controls.integration.test.js
+++ b/__tests__/blinx.view-controls.integration.test.js
@@ -1,0 +1,100 @@
+/** @jest-environment jsdom */
+
+import { blinxStore } from '../lib/blinx.store.js';
+import { blinxForm } from '../lib/blinx.form.js';
+import { blinxCollection } from '../lib/blinx.collection.js';
+import { blinxTable } from '../lib/blinx.table.js';
+
+function elById(id) {
+  return document.getElementById(id);
+}
+
+describe('Controls declared on view definition (view.controls)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('blinxForm binds DOM controls from view.controls when controls param is omitted', () => {
+    // Controls live outside root (supported via document.getElementById fallback)
+    document.body.innerHTML = `
+      <button id="next"></button>
+      <button id="prev"></button>
+      <span id="indicator"></span>
+    `;
+
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }, { name: 'B' }], model);
+
+    const root = document.createElement('div');
+    const view = {
+      sections: [{ title: 'Main', columns: 1, fields: ['name'] }],
+      controls: {
+        nextButton: 'next',
+        prevButton: 'prev',
+        recordIndicator: 'indicator',
+      },
+    };
+
+    blinxForm({ root, store, view, recordIndex: 0 });
+
+    expect(elById('indicator')?.textContent).toBe('Record 1 of 2');
+    elById('next').click();
+    expect(elById('indicator')?.textContent).toBe('Record 2 of 2');
+    elById('prev').click();
+    expect(elById('indicator')?.textContent).toBe('Record 1 of 2');
+  });
+
+  test('blinxCollection binds DOM controls from view.controls when controls param is omitted', () => {
+    document.body.innerHTML = `
+      <button id="create"></button>
+      <span id="status"></span>
+    `;
+
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+
+    const view = {
+      layout: 'table',
+      columns: [{ field: 'name', label: 'Name' }],
+      controls: {
+        createButton: 'create',
+        status: 'status',
+      },
+    };
+
+    blinxCollection({ root, store, view, paging: { pageSize: 20 } });
+
+    expect(root.querySelectorAll('tbody tr').length).toBe(1);
+    elById('create').click();
+    expect(root.querySelectorAll('tbody tr').length).toBe(2);
+    expect(elById('status')?.textContent).toBe('New row created.');
+  });
+
+  test('blinxTable binds DOM controls from view.controls when controls param is omitted', () => {
+    document.body.innerHTML = `
+      <button id="tbl-create"></button>
+      <span id="tbl-status"></span>
+    `;
+
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+
+    const view = {
+      columns: [{ field: 'name', label: 'Name' }],
+      controls: {
+        createButton: 'tbl-create',
+        status: 'tbl-status',
+      },
+    };
+
+    blinxTable({ root, store, view, pageSize: 20 });
+
+    expect(root.querySelectorAll('tbody tr').length).toBe(1);
+    elById('tbl-create').click();
+    expect(root.querySelectorAll('tbody tr').length).toBe(2);
+    expect(elById('tbl-status')?.textContent).toBe('New row created.');
+  });
+});
+

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -1,5 +1,6 @@
 import { EventTypes } from './blinx.store.js';
 import { RegisteredUI } from './blinx.registered-ui.js';
+import { resolveComponentUIView } from './blinx.ui-views.js';
 import {
   normalizeControlSpecEntry,
   resolveElementByIdWithinRoot,
@@ -253,14 +254,6 @@ export function blinxCollection({
     }
   }
 
-  // Resolve declarative UI view by key (if provided as string).
-  if (typeof view === 'string') {
-    const uiViews = (store && typeof store.getUIViews === 'function') ? store.getUIViews() : null;
-    const resolved = uiViews && typeof uiViews === 'object' ? uiViews[view] : null;
-    if (!resolved) throw new Error(`blinxCollection: unknown ui view "${String(view)}".`);
-    view = resolved;
-  }
-
   if (!store || typeof store.getModel !== 'function') {
     throw new Error('blinxCollection requires a store that exposes getModel().');
   }
@@ -269,7 +262,18 @@ export function blinxCollection({
     throw new Error('blinxCollection requires the store model to define fields.');
   }
   if (!root) throw new Error('blinxCollection requires a root element.');
-  if (!view) throw new Error('blinxCollection requires a view.');
+
+  // Resolve declarative UI view:
+  // - object => already resolved
+  // - string => store-scoped uiViews[key] first, then registry (model+kind+name)
+  // - omitted => registry default for model+kind
+  const kind = 'collection';
+  const resolvedView = resolveComponentUIView({ store, model, kind, view });
+  if (!resolvedView) {
+    const key = (typeof view === 'string') ? `"${String(view)}"` : '(default)';
+    throw new Error(`blinxCollection: unable to resolve ui view ${key} for model "${String(model?.id || model?.name || 'unknown')}".`);
+  }
+  view = resolvedView;
   // Note: legacy API used to accept `ui`. It is intentionally not supported anymore.
   // If callers still pass it, fail fast with a helpful message.
   if (Object.prototype.hasOwnProperty.call(arguments?.[0] || {}, 'ui')) {

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -448,9 +448,14 @@ export function blinxForm({
               getLength: () => 1,
               setField: (_idx, field, nextVal) => {
                 nestedRecord = { ...nestedRecord, [field]: nextVal };
-                const nextItems = items.slice();
-                nextItems[itemIndex] = nestedRecord;
                 if (!store.getRecord(currentIndex)) return;
+                // IMPORTANT: do not use the captured `items` array (stale closure).
+                // Always derive from the latest parent store state to avoid overwriting
+                // previous edits when multiple items are edited sequentially.
+                const latest = store.getRecord(currentIndex)?.[key];
+                const base = Array.isArray(latest) ? latest : [];
+                const nextItems = base.slice();
+                nextItems[itemIndex] = nestedRecord;
                 runInternalChange(() => store.setField(currentIndex, key, nextItems));
                 subs.forEach(fn => fn({ path: [0, field], value: nextVal, data: [nestedRecord], store: itemStore }));
               },

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -2,6 +2,7 @@
 import { validateField } from './blinx.validate.js';
 import { EventTypes } from './blinx.store.js';
 import { RegisteredUI } from './blinx.registered-ui.js';
+import { resolveComponentUIView, resolveModelUIView } from './blinx.ui-views.js';
 import {
   normalizeControlSpecEntry,
   resolveElementByIdWithinRoot,
@@ -109,20 +110,27 @@ export function blinxForm({
     }
   }
 
-  // Resolve declarative UI view by key (if provided as string).
-  if (typeof view === 'string') {
-    const uiViews = (store && typeof store.getUIViews === 'function') ? store.getUIViews() : null;
-    const resolved = uiViews && typeof uiViews === 'object' ? uiViews[view] : null;
-    if (!resolved) throw new Error(`blinxForm: unknown ui view "${String(view)}".`);
-    view = resolved;
-  }
-
   if (!store || typeof store.getModel !== 'function') {
     throw new Error('blinxForm requires a store that exposes getModel().');
   }
   const model = store.getModel();
   if (!model || !model.fields) {
     throw new Error('blinxForm requires the store model to define fields.');
+  }
+
+  // Resolve declarative UI view:
+  // - object => already resolved
+  // - string => store-scoped uiViews[key] first, then registry (model+kind+name)
+  // - omitted => registry default for model+kind
+  const kind = 'form';
+  const resolvedView = resolveComponentUIView({ store, model, kind, view });
+  if (!resolvedView) {
+    const key = (typeof view === 'string') ? `"${String(view)}"` : '(default)';
+    throw new Error(`blinxForm: unable to resolve ui view ${key} for model "${String(model?.id || model?.name || 'unknown')}".`);
+  }
+  view = resolvedView;
+  if (!view || typeof view !== 'object' || !Array.isArray(view.sections)) {
+    throw new Error('blinxForm: view must be an object with sections[].');
   }
 
   RegisteredUI.__internal_onRenderStart();
@@ -162,6 +170,7 @@ export function blinxForm({
   let internalChangeDepth = 0;
   let pendingResetSync = null;
   const cleanupFns = [];
+  let fieldCleanupFns = [];
 
   const trackedStoreEvents = new Set([
     EventTypes.add,
@@ -335,6 +344,12 @@ export function blinxForm({
   }
 
   function buildSections() {
+    // Destroy any nested renderers from the previous build.
+    while (fieldCleanupFns.length) {
+      const fn = fieldCleanupFns.pop();
+      try { fn && fn(); } catch { /* ignore */ }
+    }
+
     sectionEls = [];
     const record = store.getRecord(currentIndex);
     const frag = document.createDocumentFragment();
@@ -355,8 +370,115 @@ export function blinxForm({
         const def = model.fields[key];
         if (!def) return;
 
-        const value = record ? record[key] : '';
+        const value = record ? record[key] : undefined;
         const rendererName = (f && typeof f === 'object' && f.renderer) ? f.renderer : defaultRendererName;
+
+        // Nested model rendering (Option A registry + nested overrides)
+        // - def.type === 'model': render nested blinxForm using the nested model's default view (or override via { view })
+        // - def.type === 'collection': render repeated nested blinxForm for items using item model default view (or override via { itemView })
+        if (def?.type === 'model' && def?.model && typeof def.model === 'object') {
+          const nestedModel = def.model;
+          const overrideViewName = (f && typeof f === 'object') ? (f.view || null) : null;
+          const nestedView = resolveModelUIView({ model: nestedModel, kind: 'form', viewName: overrideViewName });
+
+          if (nestedView) {
+            const nestedRoot = document.createElement('div');
+            nestedRoot.className = 'blinx-nested blinx-nested--model';
+            nestedRoot.setAttribute('data-blinx-field', key);
+
+            // Minimal nested store wrapper: edits propagate by replacing the whole nested object.
+            const subs = new Set();
+            let nestedRecord = (value && typeof value === 'object' && !Array.isArray(value)) ? { ...value } : {};
+            const nestedStore = {
+              getModel: () => nestedModel,
+              getRecord: () => nestedRecord,
+              getLength: () => 1,
+              setField: (_idx, field, nextVal) => {
+                nestedRecord = { ...nestedRecord, [field]: nextVal };
+                if (!store.getRecord(currentIndex)) return;
+                runInternalChange(() => store.setField(currentIndex, key, nestedRecord));
+                subs.forEach(fn => fn({ path: [0, field], value: nextVal, data: [nestedRecord], store: nestedStore }));
+              },
+              subscribe: fn => { subs.add(fn); return () => subs.delete(fn); },
+              toJSON: () => [nestedRecord],
+              diff: () => [],
+              commit: () => {},
+              reset: () => {},
+            };
+
+            const { formApi } = blinxForm({
+              root: nestedRoot,
+              store: nestedStore,
+              view: nestedView,
+              recordIndex: 0,
+              controls: false,
+            });
+            fieldCleanupFns.push(() => { try { formApi?.destroy?.(); } catch { /* ignore */ } });
+
+            const cell = document.createElement('div');
+            if (typeof f === 'object' && f.span === 2) cell.style.gridColumn = 'span 2';
+            cell.appendChild(nestedRoot);
+            grid.appendChild(cell);
+            return;
+          }
+        }
+
+        if (def?.type === 'collection' && def?.model && typeof def.model === 'object') {
+          const itemModel = def.model;
+          const overrideItemViewName = (f && typeof f === 'object') ? (f.itemView || null) : null;
+          const items = Array.isArray(value) ? value : [];
+
+          const list = document.createElement('div');
+          list.className = 'blinx-nested blinx-nested--collection';
+          list.setAttribute('data-blinx-field', key);
+
+          items.forEach((item, itemIndex) => {
+            const itemView = resolveModelUIView({ model: itemModel, kind: 'form', viewName: overrideItemViewName });
+            if (!itemView) return;
+
+            const itemRoot = document.createElement('div');
+            itemRoot.className = 'blinx-nested__item';
+            itemRoot.setAttribute('data-blinx-item-index', String(itemIndex));
+
+            const subs = new Set();
+            let nestedRecord = (item && typeof item === 'object' && !Array.isArray(item)) ? { ...item } : {};
+            const itemStore = {
+              getModel: () => itemModel,
+              getRecord: () => nestedRecord,
+              getLength: () => 1,
+              setField: (_idx, field, nextVal) => {
+                nestedRecord = { ...nestedRecord, [field]: nextVal };
+                const nextItems = items.slice();
+                nextItems[itemIndex] = nestedRecord;
+                if (!store.getRecord(currentIndex)) return;
+                runInternalChange(() => store.setField(currentIndex, key, nextItems));
+                subs.forEach(fn => fn({ path: [0, field], value: nextVal, data: [nestedRecord], store: itemStore }));
+              },
+              subscribe: fn => { subs.add(fn); return () => subs.delete(fn); },
+              toJSON: () => [nestedRecord],
+              diff: () => [],
+              commit: () => {},
+              reset: () => {},
+            };
+
+            const { formApi } = blinxForm({
+              root: itemRoot,
+              store: itemStore,
+              view: itemView,
+              recordIndex: 0,
+              controls: false,
+            });
+            fieldCleanupFns.push(() => { try { formApi?.destroy?.(); } catch { /* ignore */ } });
+            list.appendChild(itemRoot);
+          });
+
+          const cell = document.createElement('div');
+          if (typeof f === 'object' && f.span === 2) cell.style.gridColumn = 'span 2';
+          cell.appendChild(list);
+          grid.appendChild(cell);
+          return;
+        }
+
         const widget = getUI(rendererName).createField({
           fieldKey: key,
           def,
@@ -386,7 +508,14 @@ export function blinxForm({
     const rec = store.getRecord(currentIndex);
     if (!rec) return true;
     return view.sections.every(section =>
-      section.fields.every(f => validateField(rec[typeof f === 'string' ? f : f.field], model.fields[typeof f === 'string' ? f : f.field]).length === 0)
+      section.fields.every(f => {
+        const key = typeof f === 'string' ? f : f.field;
+        const def = model.fields[key];
+        if (!def) return true;
+        // Nested types are validated by their own sub-forms (if any).
+        if (def.type === 'model' || def.type === 'collection') return true;
+        return validateField(rec[key], def).length === 0;
+      })
     );
   }
 
@@ -511,6 +640,10 @@ export function blinxForm({
     if (pendingResetSync) {
       clearTimeout(pendingResetSync);
       pendingResetSync = null;
+    }
+    while (fieldCleanupFns.length) {
+      const fn = fieldCleanupFns.pop();
+      try { fn && fn(); } catch { /* ignore */ }
     }
     // Unbind in reverse order in case any dependencies exist.
     while (cleanupFns.length) {

--- a/lib/blinx.ui-views.js
+++ b/lib/blinx.ui-views.js
@@ -1,0 +1,121 @@
+/**
+ * UI Views registry + resolver (Option A).
+ *
+ * Goals:
+ * - Keep UI views separate from model definitions.
+ * - Allow Blinx components to resolve:
+ *   (model, kind=form|collection|table, viewName?) -> view object
+ * - Support "default" view per kind, plus named views.
+ * - Remain backwards compatible with legacy store-scoped `uiViews` maps
+ *   (flat: { [key]: viewObj }).
+ */
+ 
+const VIEWS_BY_MODEL = new WeakMap(); // model object -> views object
+const VIEWS_BY_ID = new Map();        // model id/name -> views object (fallback)
+
+function modelKey(model) {
+  if (!model || typeof model !== 'object') return null;
+  const id = (typeof model.id === 'string' && model.id) ? model.id : null;
+  const name = (typeof model.name === 'string' && model.name) ? model.name : null;
+  return id || name || null;
+}
+
+function isPlainObject(v) {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Register UI views for a model.
+ *
+ * @param {object} model - model object reference (preferred registry key)
+ * @param {object} views - either:
+ *   - kind-bucketed: { form: { default: {...}, compact: {...} }, collection: { default: {...} }, ... }
+ *   - legacy flat map: { edit: {...}, list: {...} } (supported, but has no per-kind default)
+ */
+export function registerModelViews(model, views) {
+  if (!model || typeof model !== 'object') throw new Error('registerModelViews(model, views): model must be an object.');
+  if (!views || typeof views !== 'object') throw new Error('registerModelViews(model, views): views must be an object.');
+  VIEWS_BY_MODEL.set(model, views);
+  const key = modelKey(model);
+  if (key) VIEWS_BY_ID.set(key, views);
+}
+
+export function getModelViews(model) {
+  if (!model || typeof model !== 'object') return null;
+  if (VIEWS_BY_MODEL.has(model)) return VIEWS_BY_MODEL.get(model);
+  const key = modelKey(model);
+  if (key && VIEWS_BY_ID.has(key)) return VIEWS_BY_ID.get(key);
+  return null;
+}
+
+/**
+ * Resolve a UI view for a model + kind + optional name.
+ *
+ * Resolution order:
+ * - If kind-bucketed:
+ *   - viewName provided:
+ *     - views[kind][viewName]
+ *     - views[kind].default (fallback)
+ *   - no viewName:
+ *     - views[kind].default
+ * - If legacy flat map:
+ *   - viewName provided:
+ *     - views[viewName]
+ *   - no viewName:
+ *     - null (no implicit default possible)
+ *
+ * @returns {object|null} view object or null when unresolved
+ */
+export function resolveModelUIView({ model, kind, viewName } = {}) {
+  const views = getModelViews(model);
+  if (!views) return null;
+
+  const k = (typeof kind === 'string' && kind) ? kind : null;
+  const name = (typeof viewName === 'string' && viewName) ? viewName : null;
+
+  // Kind-bucketed: views.form / views.collection / views.table / ...
+  if (k && isPlainObject(views[k])) {
+    const bucket = views[k];
+    if (name && bucket[name]) return bucket[name];
+    if (bucket.default) return bucket.default;
+    return null;
+  }
+
+  // Legacy flat map: { edit: {...}, list: {...} }
+  if (name && views[name]) return views[name];
+
+  return null;
+}
+
+/**
+ * Resolve a UI view for a *component call*.
+ * Supports:
+ * - view as object (already resolved)
+ * - view as string:
+ *   - first lookup store.getUIViews()[view] (legacy store-scoped map)
+ *   - then lookup registry by (model, kind, viewName=view)
+ * - view omitted:
+ *   - lookup registry by (model, kind, viewName=null) => default
+ */
+export function resolveComponentUIView({ store, model, kind, view } = {}) {
+  // Explicit object always wins.
+  if (view && typeof view === 'object') return view;
+
+  // String: legacy store-scoped map first (preserves historic behavior).
+  if (typeof view === 'string') {
+    const uiViews = (store && typeof store.getUIViews === 'function') ? store.getUIViews() : null;
+    const fromStore = uiViews && typeof uiViews === 'object' ? uiViews[view] : null;
+    if (fromStore) return fromStore;
+
+    const fromRegistry = resolveModelUIView({ model, kind, viewName: view });
+    if (fromRegistry) return fromRegistry;
+    return null;
+  }
+
+  // Omitted: use registry default for the kind (if any).
+  const fromRegistryDefault = resolveModelUIView({ model, kind, viewName: null });
+  if (fromRegistryDefault) return fromRegistryDefault;
+
+  return null;
+}
+


### PR DESCRIPTION
Implement a UI view registry to support nested model and collection rendering with default and override views.

The previous design only allowed top-level UI view definitions, preventing proper view resolution for nested models and collection items. This change introduces a global registry (`registerModelViews`) that explicitly connects models to their UI views, enabling Blinx to deterministically resolve views for any model in a nested structure. This allows `blinxForm` to automatically render nested models and collection items using their registered default views, while also providing parent views with the ability to override specific nested views via `view` and `itemView` field properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-01d4dc5f-344a-406f-9b47-0e64c5e1ccb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-01d4dc5f-344a-406f-9b47-0e64c5e1ccb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a UI view registry and updates blinxForm/blinxCollection to resolve default/named views, render nested models/collections, and support view-declared/external controls, with comprehensive tests.
> 
> - **UI Views Registry**:
>   - Introduce `lib/blinx.ui-views.js` with `registerModelViews`, `resolveModelUIView`, and `resolveComponentUIView` to resolve views by `(model, kind, name)` with default and legacy-store fallbacks.
> - **Form (`lib/blinx.form.js`)**:
>   - Resolve `view` via registry/legacy store (`resolveComponentUIView`) and require sectioned view.
>   - Implement nested rendering: fields of type `model`/`collection` render sub-forms using registered defaults or overrides (`view`, `itemView`); track and cleanup nested form instances; skip nested types in top-level validation.
>   - Maintain/extend controls handling: support `view.controls` vs `controls` param, auto-render toolbar when omitted, and bind custom actions.
> - **Collection (`lib/blinx.collection.js`)**:
>   - Resolve `view` via `resolveComponentUIView` (default/name) and remove inline string-lookup logic; improve errors when unresolved.
>   - Preserve/extend controls: auto/default toolbar when omitted, support declared controls and custom actions.
> - **Tests**:
>   - Add registry resolution tests, nested UI view integration (default + overrides), and controls equivalence/integration tests for form, collection, and table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df6aaaeabfeb4637b09c476b0c17aea0a1794678. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->