### PR TITLE
Default view schema exploration

### DIFF
--- a/__tests__/blinx.schema-default-view.integration.test.js
+++ b/__tests__/blinx.schema-default-view.integration.test.js
@@ -1,0 +1,72 @@
+/** @jest-environment jsdom */
+
+import { blinxStore, DataTypes } from '../lib/blinx.store.js';
+import { blinxForm } from '../lib/blinx.form.js';
+import { blinxCollection } from '../lib/blinx.collection.js';
+import { blinxDump } from '../lib/blinx.dump.js';
+
+describe('schema-driven default UI view fallback', () => {
+  test('blinxForm: when no explicit view exists, generates a default form view from schema', () => {
+    const model = {
+      id: 'ModelX',
+      fields: {
+        id: { type: DataTypes.string },
+        name: { type: DataTypes.string },
+        bio: { type: DataTypes.longText }, // hidden by default
+        payload: { type: DataTypes.json }, // hidden by default
+        token: { type: DataTypes.secret }, // hidden by default
+      },
+    };
+    const store = blinxStore([{ id: '1', name: 'A' }], model);
+    const root = document.createElement('div');
+
+    // No `view` => should not throw
+    blinxForm({ root, store });
+
+    const labels = Array.from(root.querySelectorAll('label')).map(el => el.textContent);
+    expect(labels).toContain('id');
+    expect(labels).toContain('name');
+    expect(labels).not.toContain('bio');
+    expect(labels).not.toContain('payload');
+    expect(labels).not.toContain('token');
+  });
+
+  test('blinxCollection: generates a default table view with columns and search controls', () => {
+    const model = {
+      id: 'ModelY',
+      fields: {
+        id: { type: DataTypes.string },
+        name: { type: DataTypes.string },
+        createdAt: { type: DataTypes.date },
+        blob: { type: DataTypes.blob }, // hidden by default
+      },
+    };
+    const store = blinxStore([{ id: '1', name: 'A', createdAt: '2024-01-01' }], model);
+    const root = document.createElement('div');
+
+    blinxCollection({ root, store }); // no view
+
+    // Columns should exist (thead contains "Sel" + generated columns)
+    const ths = Array.from(root.querySelectorAll('thead th')).map(el => el.textContent);
+    expect(ths.length).toBeGreaterThan(1);
+
+    // Search input only appears when view.searchFields exist (schema generator provides it)
+    const searchInput = root.querySelector('input[type="text"].input');
+    expect(searchInput).toBeTruthy();
+  });
+
+  test("blinxDump('ui-view') prints copy/pasteable generated views", () => {
+    const model = {
+      id: 'ModelDump',
+      fields: { id: { type: DataTypes.string }, name: { type: DataTypes.string } },
+    };
+    const store = blinxStore([{ id: '1', name: 'A' }], model);
+    const root = document.createElement('div');
+    blinxForm({ root, store }); // triggers generation + caching
+
+    const out = blinxDump('ui-view');
+    expect(out).toContain('"model": "ModelDump"');
+    expect(out).toContain('"form"');
+  });
+});
+

--- a/__tests__/blinx.schema-default-view.integration.test.js
+++ b/__tests__/blinx.schema-default-view.integration.test.js
@@ -5,6 +5,7 @@ import { blinxForm } from '../lib/blinx.form.js';
 import { blinxCollection } from '../lib/blinx.collection.js';
 import { blinxDump } from '../lib/blinx.dump.js';
 import { BlinxConfig } from '../lib/blinx.config.js';
+import { registerModelViews } from '../lib/blinx.ui-views.js';
 
 describe('schema-driven default UI view fallback', () => {
   afterEach(() => {
@@ -131,6 +132,84 @@ describe('schema-driven default UI view fallback', () => {
       store: store2,
       view: { sections: [{ title: 'Main', columns: 1, fields: ['child'] }] },
     })).toThrow('strict mode: missing nested ui view');
+  });
+
+  test('a) rendering succeeds (top-level + nested) when all models have declarative views (even in strict mode)', () => {
+    BlinxConfig.setDefaultViewGenerationEnabled(false); // strict mode
+
+    const Child = { id: 'ChildOK', fields: { street: { type: DataTypes.string } } };
+    const Parent = { id: 'ParentOK', fields: { name: { type: DataTypes.string }, child: { type: 'model', model: Child } } };
+
+    registerModelViews(Child, {
+      form: { default: { sections: [{ title: 'Child', columns: 1, fields: ['street'] }] } },
+    });
+    registerModelViews(Parent, {
+      form: { default: { sections: [{ title: 'Parent', columns: 1, fields: ['name', 'child'] }] } },
+    });
+
+    const store = blinxStore([{ name: 'A', child: { street: '1st' } }], Parent);
+    const root = document.createElement('div');
+
+    expect(() => blinxForm({ root, store })).not.toThrow();
+
+    const labels = Array.from(root.querySelectorAll('label')).map(el => el.textContent);
+    expect(labels).toContain('name');
+    expect(labels).toContain('street');
+  });
+
+  test('b) explicit nested view override must exist (field.view / field.itemView) regardless of allowGeneratedViews', () => {
+    const Child = { id: 'ChildOverride', fields: { street: { type: DataTypes.string } } };
+    const Parent = { id: 'ParentOverride', fields: { child: { type: 'model', model: Child } } };
+
+    // Provide parent view imperatively; nested override points to a missing view.
+    const store = blinxStore([{ child: { street: 'x' } }], Parent);
+    const root = document.createElement('div');
+
+    // allowGeneratedViews = true
+    BlinxConfig.setDefaultViewGenerationEnabled(true);
+    expect(() => blinxForm({
+      root,
+      store,
+      view: {
+        sections: [{
+          title: 'Main',
+          columns: 1,
+          fields: [{ field: 'child', view: 'missing-view' }],
+        }],
+      }
+    })).toThrow('unknown nested ui view "missing-view"');
+
+    // allowGeneratedViews = false
+    BlinxConfig.setDefaultViewGenerationEnabled(false);
+    expect(() => blinxForm({
+      root,
+      store,
+      view: {
+        sections: [{
+          title: 'Main',
+          columns: 1,
+          fields: [{ field: 'child', view: 'missing-view' }],
+        }],
+      }
+    })).toThrow('unknown nested ui view "missing-view"');
+
+    const Item = { id: 'ItemOverride', fields: { sku: { type: DataTypes.string } } };
+    const Parent2 = { id: 'ParentOverride2', fields: { items: { type: 'collection', model: Item } } };
+    const store2 = blinxStore([{ items: [{ sku: 'a' }] }], Parent2);
+    const root2 = document.createElement('div');
+
+    BlinxConfig.setDefaultViewGenerationEnabled(true);
+    expect(() => blinxForm({
+      root: root2,
+      store: store2,
+      view: {
+        sections: [{
+          title: 'Main',
+          columns: 1,
+          fields: [{ field: 'items', itemView: 'missing-item-view' }],
+        }],
+      }
+    })).toThrow('unknown nested item ui view "missing-item-view"');
   });
 });
 

--- a/__tests__/blinx.table.test.js
+++ b/__tests__/blinx.table.test.js
@@ -2,6 +2,7 @@
 
 import { blinxStore } from '../lib/blinx.store.js';
 import { blinxTable } from '../lib/blinx.table.js';
+import { registerModelViews } from '../lib/blinx.ui-views.js';
 
 function setupButtons({ createId, deleteSelectedId, statusId }) {
   document.body.innerHTML = '';
@@ -69,6 +70,23 @@ describe('blinxTable', () => {
     const cb = rows[0].querySelector('input[type="checkbox"]');
     cb.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(onRowClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('enforces table layout even when view is a string', () => {
+    const model = { id: 'M-table', fields: { name: { type: 'string' } } };
+    registerModelViews(model, {
+      collection: {
+        cardsView: { layout: 'cards', item: { titleField: 'name' } },
+      },
+    });
+
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+
+    blinxTable({ root, store, view: 'cardsView' });
+
+    // Should still render a <table> regardless of named view layout.
+    expect(root.querySelector('table')).toBeTruthy();
   });
 
   test('create/deleteSelected buttons update store and status; delete requires selection', async () => {

--- a/lib/blinx.adapters.default.js
+++ b/lib/blinx.adapters.default.js
@@ -39,6 +39,9 @@ export class BlinxDefaultUI {
         input = document.createElement(def.length?.max > 200 ? 'textarea' : 'input');
         if (input.tagName === 'INPUT') input.type = 'text';
         common(input); input.value = value ?? ''; break;
+      case 'longText':
+        input = document.createElement('textarea');
+        common(input); input.value = value ?? ''; break;
       case 'number':
         input = document.createElement('input'); input.type = 'number';
         if (def.step !== undefined) input.step = String(def.step);
@@ -61,6 +64,19 @@ export class BlinxDefaultUI {
       case 'array':
         input = document.createElement('input'); input.type = 'text';
         common(input); input.value = Array.isArray(value) ? value.join(', ') : ''; break;
+      case 'json':
+        input = document.createElement('textarea');
+        common(input);
+        try { input.value = value === undefined ? '' : (typeof value === 'string' ? value : JSON.stringify(value, null, 2)); }
+        catch { input.value = String(value ?? ''); }
+        break;
+      case 'secret':
+        input = document.createElement('input'); input.type = 'password';
+        common(input); input.value = value ?? ''; break;
+      case 'blob':
+        // Keep simple and headless-friendly (host apps can override via custom renderer)
+        input = document.createElement('input'); input.type = 'text';
+        common(input); input.value = value ?? ''; break;
       default:
         input = document.createElement('input'); input.type = 'text';
         common(input); input.value = value ?? '';
@@ -92,6 +108,11 @@ export class BlinxDefaultUI {
       case 'number':  return value === '' || value === null || value === undefined ? '' : String(value);
       case 'date':    return value || '';
       case 'array':   return Array.isArray(value) ? value.join(', ') : '';
+      case 'json':
+        try { return value === undefined || value === null ? '' : (typeof value === 'string' ? value : JSON.stringify(value)); }
+        catch { return String(value ?? ''); }
+      case 'secret':
+        return value ? '••••••' : '';
       default:        return value ?? '';
     }
   }

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -16,6 +16,8 @@ const BUILTIN_CONTROL_KEYS = [
   'prevButton',
   'nextButton',
   'pageLabel',
+  'searchInput',
+  'searchButton',
 ];
 
 function defaultBuiltinControlMeta(key) {
@@ -25,6 +27,7 @@ function defaultBuiltinControlMeta(key) {
     case 'prevButton': return { label: 'Prev', css: 'btn' };
     case 'nextButton': return { label: 'Next', css: 'btn' };
     case 'pageLabel': return { label: '', css: '' };
+    case 'searchButton': return { label: 'Search', css: 'btn' };
     case 'status': return { label: '', css: '' };
     default: return { label: '', css: '' };
   }
@@ -36,7 +39,7 @@ function setStatus(dom, msg, color = '#4a5568') {
   dom.status.style.color = color;
 }
 
-function createDefaultToolbar(root, { includeActions = true, includePager = true } = {}) {
+function createDefaultToolbar(root, { includeActions = true, includePager = true, includeSearch = false } = {}) {
   const toolbar = document.createElement('div');
   toolbar.className = 'flex blinx-controls';
   const createBtn = document.createElement('button'); createBtn.type = 'button';
@@ -44,6 +47,8 @@ function createDefaultToolbar(root, { includeActions = true, includePager = true
   const prevBtn = document.createElement('button'); prevBtn.type = 'button';
   const nextBtn = document.createElement('button'); nextBtn.type = 'button';
   const pageLabel = document.createElement('span'); pageLabel.textContent = 'Page: 1';
+  const searchInput = document.createElement('input'); searchInput.type = 'text'; searchInput.className = 'input';
+  const searchBtn = document.createElement('button'); searchBtn.type = 'button';
   const status = document.createElement('span');
 
   const meta = {
@@ -51,19 +56,22 @@ function createDefaultToolbar(root, { includeActions = true, includePager = true
     deleteSelectedButton: defaultBuiltinControlMeta('deleteSelectedButton'),
     prevButton: defaultBuiltinControlMeta('prevButton'),
     nextButton: defaultBuiltinControlMeta('nextButton'),
+    searchButton: defaultBuiltinControlMeta('searchButton'),
   };
   createBtn.textContent = meta.createButton.label; createBtn.className = meta.createButton.css;
   deleteSelectedBtn.textContent = meta.deleteSelectedButton.label; deleteSelectedBtn.className = meta.deleteSelectedButton.css;
   prevBtn.textContent = meta.prevButton.label; prevBtn.className = meta.prevButton.css;
   nextBtn.textContent = meta.nextButton.label; nextBtn.className = meta.nextButton.css;
+  searchBtn.textContent = meta.searchButton.label; searchBtn.className = meta.searchButton.css;
 
   const nodes = [];
   if (includeActions) nodes.push(createBtn, deleteSelectedBtn);
   if (includePager) nodes.push(prevBtn, nextBtn, pageLabel);
+  if (includeSearch) nodes.push(searchInput, searchBtn);
   nodes.push(status);
   toolbar.append(...nodes);
   root.appendChild(toolbar);
-  return { toolbar, createBtn, deleteSelectedBtn, prevBtn, nextBtn, pageLabel, status };
+  return { toolbar, createBtn, deleteSelectedBtn, prevBtn, nextBtn, pageLabel, searchInput, searchBtn, status };
 }
 
 function defaultExternalStatusMessages(layout) {
@@ -341,6 +349,8 @@ export function blinxCollection({
     prevBtn: null,
     nextBtn: null,
     pageLabel: null,
+    searchInput: null,
+    searchBtn: null,
     custom: {},
   };
   let internalToolbar = null;
@@ -374,6 +384,7 @@ export function blinxCollection({
 
     let el;
     if (key === 'status' || key === 'pageLabel') el = document.createElement('span');
+    else if (key === 'searchInput') { el = document.createElement('input'); el.type = 'text'; el.className = 'input'; }
     else { el = document.createElement('button'); el.type = 'button'; }
     if (meta.label && el.tagName === 'BUTTON') el.textContent = meta.label;
     applyControlPresentation(el, meta);
@@ -381,19 +392,27 @@ export function blinxCollection({
     return el;
   }
 
+  const searchFields = Array.isArray(view?.searchFields)
+    ? view.searchFields.filter(f => typeof f === 'string' && f.length > 0)
+    : [];
+  let searchTerm = '';
+
   if (resolvedControlsSpec === false || resolvedControlsSpec === null) {
     // Explicitly disable controls.
   } else if (!explicitControlsProvided && resolvedControlsSpec === undefined) {
     // Auto-render defaults when controls are omitted everywhere.
     const includeActions = !!actions?.create || !!actions?.deleteSelected;
     const includePager = true;
-    const t = createDefaultToolbar(root, { includeActions, includePager });
+    const includeSearch = searchFields.length > 0;
+    const t = createDefaultToolbar(root, { includeActions, includePager, includeSearch });
     cleanupFns.push(() => { try { t?.toolbar?.remove(); } catch { /* ignore */ } });
     dom.createBtn = t.createBtn;
     dom.deleteSelectedBtn = t.deleteSelectedBtn;
     dom.prevBtn = t.prevBtn;
     dom.nextBtn = t.nextBtn;
     dom.pageLabel = t.pageLabel;
+    dom.searchInput = t.searchInput || null;
+    dom.searchBtn = t.searchBtn || null;
     dom.status = t.status;
   } else if (resolvedControlsSpec && typeof resolvedControlsSpec === 'object') {
     // Render/bind only explicitly declared controls.
@@ -402,6 +421,8 @@ export function blinxCollection({
     dom.prevBtn = ensureBuiltin('prevButton');
     dom.nextBtn = ensureBuiltin('nextButton');
     dom.pageLabel = ensureBuiltin('pageLabel');
+    dom.searchInput = ensureBuiltin('searchInput');
+    dom.searchBtn = ensureBuiltin('searchButton');
     dom.status = ensureBuiltin('status');
 
     for (const [key, raw] of Object.entries(resolvedControlsSpec)) {
@@ -472,21 +493,69 @@ export function blinxCollection({
 
   function getItemsForCurrentPage(data) {
     const remotePaging = typeof store.pageNext === 'function' || typeof store.pagePrev === 'function';
+    const itemsAll = [];
+    for (let i = 0; i < data.length; i++) itemsAll.push({ index: i, record: data[i] });
+
+    const effective = (() => {
+      let rows = itemsAll;
+
+      // UI-level keyword search over view.searchFields (no store mutation).
+      const term = String(searchTerm || '').trim().toLowerCase();
+      if (term && searchFields.length) {
+        rows = rows.filter(({ record }) => {
+          for (const f of searchFields) {
+            const v = record?.[f];
+            if (v === undefined || v === null) continue;
+            const s = Array.isArray(v) ? v.join(', ') : String(v);
+            if (s.toLowerCase().includes(term)) return true;
+          }
+          return false;
+        });
+      }
+
+      // UI-level default sort for consistency across local + remote stores.
+      const sort = Array.isArray(view?.defaultSort) ? view.defaultSort : null;
+      if (sort && sort.length) {
+        const specs = sort
+          .filter(Boolean)
+          .map(s => ({ field: s.field, dir: (s.dir || 'asc').toLowerCase() === 'desc' ? 'desc' : 'asc' }))
+          .filter(s => typeof s.field === 'string' && s.field.length > 0);
+
+        if (specs.length) {
+          // Stable sort: decorate with original position.
+          const decorated = rows.map((r, pos) => ({ ...r, __pos: pos }));
+          decorated.sort((a, b) => {
+            for (const s of specs) {
+              const av = a.record?.[s.field];
+              const bv = b.record?.[s.field];
+              if (av === bv) continue;
+              if (av === undefined || av === null) return s.dir === 'asc' ? 1 : -1;
+              if (bv === undefined || bv === null) return s.dir === 'asc' ? -1 : 1;
+              if (av < bv) return s.dir === 'asc' ? -1 : 1;
+              if (av > bv) return s.dir === 'asc' ? 1 : -1;
+            }
+            return a.__pos - b.__pos;
+          });
+          rows = decorated.map(({ __pos, ...rest }) => rest);
+        }
+      }
+
+      return rows;
+    })();
+
     if (remotePaging) {
       page = 0;
       pruneSelection(data.length);
-      const items = [];
-      for (let i = 0; i < data.length; i++) items.push({ index: i, record: data[i] });
-      return { items, start: 0, end: data.length, total: data.length, maxPage: 0 };
+      return { items: effective, start: 0, end: effective.length, total: effective.length, maxPage: 0 };
     }
-    const maxPage = getMaxPage(data.length);
+    const maxPage = getMaxPage(effective.length);
     page = Math.min(Math.max(page, 0), maxPage);
     pruneSelection(data.length);
     const start = page * pageSize;
-    const end = Math.min(data.length, start + pageSize);
+    const end = Math.min(effective.length, start + pageSize);
     const items = [];
-    for (let i = start; i < end; i++) items.push({ index: i, record: data[i] });
-    return { items, start, end, total: data.length, maxPage };
+    for (let i = start; i < end; i++) items.push(effective[i]);
+    return { items, start, end, total: effective.length, maxPage: getMaxPage(effective.length) };
   }
 
   function updatePagerLabel() {
@@ -625,6 +694,23 @@ export function blinxCollection({
 
   // Note: pager is rendered/bound only when declared or when controls are omitted (auto default).
 
+  function bindSearchControls() {
+    if (!dom.searchInput || !searchFields.length) return;
+    const input = dom.searchInput;
+    const apply = () => {
+      searchTerm = input.value || '';
+      refresh();
+    };
+    const onInput = () => apply();
+    input.addEventListener('input', onInput);
+    cleanupFns.push(() => input.removeEventListener('input', onInput));
+    if (dom.searchBtn) {
+      const onClick = () => apply();
+      dom.searchBtn.addEventListener('click', onClick);
+      cleanupFns.push(() => dom.searchBtn.removeEventListener('click', onClick));
+    }
+  }
+
   const controller = {
     getState: () => {
       const data = getDataSnapshot();
@@ -675,6 +761,7 @@ export function blinxCollection({
 
   bindPagerButtons();
   bindActionButtons();
+  bindSearchControls();
 
   // Bind custom control actions (if any)
   for (const [name, { el, spec }] of Object.entries(dom.custom || {})) {
@@ -710,6 +797,19 @@ export function blinxCollection({
   if (typeof unsubscribe === 'function') cleanupFns.push(unsubscribe);
 
   refresh();
+
+  // Best-effort: for remote stores, apply default sort via criteria if not already set.
+  // This avoids the "page-only" limitations of client-side sorting across remote pages.
+  try {
+    const sort = Array.isArray(view?.defaultSort) ? view.defaultSort : null;
+    if (sort && typeof store.search === 'function' && typeof store.getStatus === 'function') {
+      const cur = store.getStatus()?.criteria?.sort || null;
+      if (!cur) {
+        // Fire-and-forget; store events will refresh the UI.
+        store.search({ sort }).catch(() => {});
+      }
+    }
+  } catch { /* ignore */ }
 
   function destroy() {
     if (pendingResetSync) {

--- a/lib/blinx.config.js
+++ b/lib/blinx.config.js
@@ -1,0 +1,35 @@
+let CONFIG = {
+  allowGeneratedViews: true,
+};
+
+function normalize(next = {}) {
+  const out = { ...CONFIG };
+  if (Object.prototype.hasOwnProperty.call(next, 'allowGeneratedViews')) {
+    out.allowGeneratedViews = Boolean(next.allowGeneratedViews);
+  }
+  return out;
+}
+
+export const BlinxConfig = Object.freeze({
+  get() {
+    return { ...CONFIG };
+  },
+
+  set(next = {}) {
+    if (!next || typeof next !== 'object') {
+      throw new Error('BlinxConfig.set(next): next must be an object.');
+    }
+    CONFIG = normalize(next);
+    return BlinxConfig.get();
+  },
+
+  // Convenience helpers
+  isGeneratedViewAllowed() {
+    return Boolean(CONFIG.allowGeneratedViews);
+  },
+
+  setDefaultViewGenerationEnabled(enabled = true) {
+    return BlinxConfig.set({ allowGeneratedViews: Boolean(enabled) });
+  },
+});
+

--- a/lib/blinx.default-uiviews.js
+++ b/lib/blinx.default-uiviews.js
@@ -1,0 +1,238 @@
+import { DataTypes } from './blinx.store.js';
+
+const GENERATED = new WeakMap(); // model -> Map(kind -> view)
+const GENERATED_BY_ID = new Map(); // modelKey -> Map(kind -> view) (fallback)
+
+function modelKey(model) {
+  if (!model || typeof model !== 'object') return null;
+  const id = (typeof model.id === 'string' && model.id) ? model.id : null;
+  const name = (typeof model.name === 'string' && model.name) ? model.name : null;
+  const entity = (typeof model.entity === 'string' && model.entity) ? model.entity : null;
+  return id || name || entity || null;
+}
+
+function toTitle(s) {
+  const str = String(s || '');
+  if (!str) return '';
+  // snake_case, kebab-case, camelCase => "Title Case"
+  const spaced = str
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .trim();
+  return spaced ? spaced[0].toUpperCase() + spaced.slice(1) : str;
+}
+
+function isHiddenByDefault(fieldKey, def) {
+  const t = def?.type;
+  if (t === DataTypes.blob || t === DataTypes.longText || t === DataTypes.json || t === DataTypes.secret) return true;
+  // Relationships / deep structures: hidden by default
+  if (t === DataTypes.array || t === 'model' || t === 'collection') return true;
+  // Conservative name-based hiding (optional safety even without metadata)
+  const k = String(fieldKey || '').toLowerCase();
+  if (!k) return false;
+  if (k.includes('password') || k.includes('token') || k.includes('apikey') || k.includes('api_key') || k.includes('ssn')) return true;
+  return false;
+}
+
+function isDateLikeField(fieldKey, def) {
+  if (def?.type === DataTypes.date) return true;
+  const k = String(fieldKey || '').toLowerCase();
+  return k === 'createdat' || k === 'updatedat' || k.endsWith('_at');
+}
+
+function isIdentifierField(fieldKey, def) {
+  const k = String(fieldKey || '').toLowerCase();
+  if (k === 'id' || k.endsWith('id') || k.endsWith('_id')) return true;
+  // Fallback: short string/number often used as identifier
+  return def?.type === DataTypes.string || def?.type === DataTypes.number;
+}
+
+function isHumanReadableString(fieldKey, def) {
+  if (def?.type !== DataTypes.string) return false;
+  const k = String(fieldKey || '').toLowerCase();
+  if (k === 'name' || k === 'title' || k === 'label') return true;
+  // Prefer short strings
+  const max = def?.length?.max;
+  if (typeof max === 'number' && max > 0 && max <= 200) return true;
+  if (max === undefined) return true;
+  return false;
+}
+
+function pickPrimaryDisplayField(model, visibleKeys) {
+  const preferred = ['name', 'title', 'label', 'id'];
+  const lower = new Map(visibleKeys.map(k => [String(k).toLowerCase(), k]));
+  for (const p of preferred) {
+    if (lower.has(p)) return lower.get(p);
+  }
+
+  // First visible short string
+  for (const k of visibleKeys) {
+    const def = model?.fields?.[k];
+    if (def?.type === DataTypes.string && !isHiddenByDefault(k, def) && isHumanReadableString(k, def)) return k;
+  }
+
+  // Fallback: any visible field
+  return visibleKeys[0] || null;
+}
+
+function scoreFieldForColumns(fieldKey, def) {
+  // Higher score = more likely to appear in columns
+  const k = String(fieldKey || '').toLowerCase();
+  let score = 0;
+
+  // Explicit primary candidates
+  if (k === 'name' || k === 'title' || k === 'label') score += 1000;
+
+  // Human-readable strings
+  if (def?.type === DataTypes.string) score += 400;
+
+  // Enum / boolean
+  if (def?.type === DataTypes.enum) score += 300;
+  if (def?.type === DataTypes.boolean) score += 250;
+
+  // Dates (timestamps)
+  if (isDateLikeField(fieldKey, def)) score += 200;
+  if (k === 'updatedat' || k === 'updated_at') score += 120;
+  if (k === 'createdat' || k === 'created_at') score += 100;
+
+  // Identifiers
+  if (k === 'id') score += 150;
+  else if (k.endsWith('id') || k.endsWith('_id')) score += 40;
+
+  // De-prioritize very long strings
+  const max = def?.length?.max;
+  if (def?.type === DataTypes.string && typeof max === 'number' && max > 200) score -= 200;
+
+  return score;
+}
+
+function chooseDefaultSort(model, visibleKeys) {
+  const lower = new Map(visibleKeys.map(k => [String(k).toLowerCase(), k]));
+  const updated = lower.get('updatedat') || lower.get('updated_at') || null;
+  const created = lower.get('createdat') || lower.get('created_at') || null;
+
+  if (updated) return [{ field: updated, dir: 'desc' }];
+  if (created) return [{ field: created, dir: 'desc' }];
+
+  const id = lower.get('id') || null;
+  const name = lower.get('name') || null;
+  const title = lower.get('title') || null;
+
+  if (id) return [{ field: id, dir: 'asc' }];
+  if (name) return [{ field: name, dir: 'asc' }];
+  if (title) return [{ field: title, dir: 'asc' }];
+
+  return null;
+}
+
+function buildDefaultFormView(model) {
+  const fields = model?.fields || {};
+  const keys = Object.keys(fields);
+  const visible = keys.filter(k => !isHiddenByDefault(k, fields[k]));
+
+  // Minimal view for ambiguous schemas
+  if (visible.length === 0) {
+    const safe = keys.filter(k => {
+      const def = fields[k];
+      if (!def) return false;
+      if (def.type === DataTypes.blob || def.type === DataTypes.longText || def.type === DataTypes.json || def.type === DataTypes.secret) return false;
+      if (def.type === DataTypes.array || def.type === 'model' || def.type === 'collection') return false;
+      return String(k).toLowerCase() === 'id' || String(k).toLowerCase().includes('created') || String(k).toLowerCase().includes('updated');
+    });
+    return { sections: [{ title: 'Main', columns: 2, fields: safe }] };
+  }
+
+  return { sections: [{ title: 'Main', columns: 2, fields: visible }] };
+}
+
+function buildDefaultCollectionView(model) {
+  const fields = model?.fields || {};
+  const keys = Object.keys(fields);
+  const visible = keys.filter(k => !isHiddenByDefault(k, fields[k]));
+
+  // Minimal view for ambiguous schemas
+  if (visible.length === 0) {
+    const safe = keys.filter(k => {
+      const def = fields[k];
+      if (!def) return false;
+      if (def.type === DataTypes.blob || def.type === DataTypes.longText || def.type === DataTypes.json || def.type === DataTypes.secret) return false;
+      if (def.type === DataTypes.array || def.type === 'model' || def.type === 'collection') return false;
+      return String(k).toLowerCase() === 'id' || String(k).toLowerCase().includes('created') || String(k).toLowerCase().includes('updated');
+    });
+    const cols = safe.slice(0, 6).map(k => ({ field: k, label: toTitle(k) }));
+    return { layout: 'table', columns: cols };
+  }
+
+  const primary = pickPrimaryDisplayField(model, visible);
+  const scored = visible
+    .map(k => ({ k, score: scoreFieldForColumns(k, fields[k]) }))
+    .sort((a, b) => (b.score - a.score) || 0);
+
+  const cap = 8; // within the requested 6–10 window
+  const chosen = [];
+  if (primary) chosen.push(primary);
+  for (const { k } of scored) {
+    if (chosen.includes(k)) continue;
+    chosen.push(k);
+    if (chosen.length >= cap) break;
+  }
+
+  const columns = chosen.map(k => ({ field: k, label: toTitle(k) }));
+  const sort = chooseDefaultSort(model, visible);
+  const searchFields = primary ? [primary] : [];
+
+  return {
+    layout: 'table',
+    columns,
+    ...(sort ? { defaultSort: sort } : {}),
+    ...(searchFields.length ? { searchFields } : {}),
+  };
+}
+
+export function generateSchemaDefaultUIView({ model, kind } = {}) {
+  if (!model || typeof model !== 'object') return null;
+  const k = String(kind || '');
+  if (!k) return null;
+  if (!model.fields || typeof model.fields !== 'object') return null;
+
+  if (k === 'form') return buildDefaultFormView(model);
+  if (k === 'collection' || k === 'table') return buildDefaultCollectionView(model);
+
+  return null;
+}
+
+export function __internal_cacheGeneratedUIView({ model, kind, view } = {}) {
+  if (!model || typeof model !== 'object') return;
+  if (!kind) return;
+  if (!view || typeof view !== 'object') return;
+
+  let byKind = GENERATED.get(model);
+  if (!byKind) {
+    byKind = new Map();
+    GENERATED.set(model, byKind);
+  }
+  byKind.set(String(kind), view);
+
+  const mk = modelKey(model);
+  if (mk) {
+    let byId = GENERATED_BY_ID.get(mk);
+    if (!byId) {
+      byId = new Map();
+      GENERATED_BY_ID.set(mk, byId);
+    }
+    byId.set(String(kind), view);
+  }
+}
+
+export function __internal_getGeneratedUIViewSnapshots() {
+  const out = [];
+  for (const [mk, byKind] of GENERATED_BY_ID.entries()) {
+    const entry = { model: mk, kinds: {} };
+    for (const [kind, view] of byKind.entries()) {
+      entry.kinds[kind] = view;
+    }
+    out.push(entry);
+  }
+  return out;
+}
+

--- a/lib/blinx.default-uiviews.js
+++ b/lib/blinx.default-uiviews.js
@@ -139,10 +139,10 @@ function buildDefaultFormView(model) {
       if (def.type === DataTypes.array || def.type === 'model' || def.type === 'collection') return false;
       return String(k).toLowerCase() === 'id' || String(k).toLowerCase().includes('created') || String(k).toLowerCase().includes('updated');
     });
-    return { sections: [{ title: 'Main', columns: 2, fields: safe }] };
+    return { origin: 'generated', sections: [{ title: 'Main', columns: 2, fields: safe }] };
   }
 
-  return { sections: [{ title: 'Main', columns: 2, fields: visible }] };
+  return { origin: 'generated', sections: [{ title: 'Main', columns: 2, fields: visible }] };
 }
 
 function buildDefaultCollectionView(model) {
@@ -160,7 +160,7 @@ function buildDefaultCollectionView(model) {
       return String(k).toLowerCase() === 'id' || String(k).toLowerCase().includes('created') || String(k).toLowerCase().includes('updated');
     });
     const cols = safe.slice(0, 6).map(k => ({ field: k, label: toTitle(k) }));
-    return { layout: 'table', columns: cols };
+    return { origin: 'generated', layout: 'table', columns: cols };
   }
 
   const primary = pickPrimaryDisplayField(model, visible);
@@ -182,6 +182,7 @@ function buildDefaultCollectionView(model) {
   const searchFields = primary ? [primary] : [];
 
   return {
+    origin: 'generated',
     layout: 'table',
     columns,
     ...(sort ? { defaultSort: sort } : {}),

--- a/lib/blinx.dump.js
+++ b/lib/blinx.dump.js
@@ -1,0 +1,32 @@
+import { __internal_getGeneratedUIViewSnapshots } from './blinx.default-uiviews.js';
+
+function safeStringify(value) {
+  // JSON-only: keeps output copy/pasteable.
+  return JSON.stringify(value, null, 2);
+}
+
+/**
+ * Dev helper to dump internal Blinx artifacts for copy/paste.
+ *
+ * Currently supported:
+ * - blinxDump('ui-view'): dumps cached schema-generated UI views (if any)
+ */
+export function blinxDump(what, _options = {}) {
+  const key = String(what || '').trim();
+  if (!key) throw new Error('blinxDump(what): missing "what".');
+
+  if (key === 'ui-view') {
+    const snaps = __internal_getGeneratedUIViewSnapshots();
+    const payload = snaps.length === 1 ? snaps[0] : { generatedUIViews: snaps };
+    const out = safeStringify(payload);
+
+    // Intentionally no "auto-generated" label; dev explicitly opted into dumping.
+    if (typeof console !== 'undefined' && console && typeof console.log === 'function') {
+      console.log(out);
+    }
+    return out;
+  }
+
+  throw new Error(`blinxDump: unsupported dump target "${key}".`);
+}
+

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -396,6 +396,10 @@ export function blinxForm({
             );
           }
 
+          // Non-strict: if we still can't resolve a nested view (e.g., malformed nested model),
+          // do NOT fall through to default field rendering (which would stringify objects as "[object Object]").
+          if (!nestedView) return;
+
           if (nestedView) {
             const nestedRoot = document.createElement('div');
             nestedRoot.className = 'blinx-nested blinx-nested--model';

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -3,6 +3,7 @@ import { validateField } from './blinx.validate.js';
 import { EventTypes } from './blinx.store.js';
 import { RegisteredUI } from './blinx.registered-ui.js';
 import { resolveComponentUIView, resolveModelUIView } from './blinx.ui-views.js';
+import { BlinxConfig } from './blinx.config.js';
 import {
   normalizeControlSpecEntry,
   resolveElementByIdWithinRoot,
@@ -381,6 +382,13 @@ export function blinxForm({
           const overrideViewName = (f && typeof f === 'object') ? (f.view || null) : null;
           const nestedView = resolveModelUIView({ model: nestedModel, kind: 'form', viewName: overrideViewName });
 
+          if (!nestedView && BlinxConfig.isGeneratedViewAllowed() === false) {
+            // Strict mode: nested model rendering requires an explicit view.
+            throw new Error(
+              `blinxForm: strict mode: missing nested ui view for model "${String(nestedModel?.id || nestedModel?.name || nestedModel?.entity || 'unknown')}" (field "${String(key)}").`
+            );
+          }
+
           if (nestedView) {
             const nestedRoot = document.createElement('div');
             nestedRoot.className = 'blinx-nested blinx-nested--model';
@@ -434,6 +442,11 @@ export function blinxForm({
 
           items.forEach((item, itemIndex) => {
             const itemView = resolveModelUIView({ model: itemModel, kind: 'form', viewName: overrideItemViewName });
+            if (!itemView && BlinxConfig.isGeneratedViewAllowed() === false) {
+              throw new Error(
+                `blinxForm: strict mode: missing nested item ui view for model "${String(itemModel?.id || itemModel?.name || itemModel?.entity || 'unknown')}" (field "${String(key)}").`
+              );
+            }
             if (!itemView) return;
 
             const itemRoot = document.createElement('div');

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -382,6 +382,13 @@ export function blinxForm({
           const overrideViewName = (f && typeof f === 'object') ? (f.view || null) : null;
           const nestedView = resolveModelUIView({ model: nestedModel, kind: 'form', viewName: overrideViewName });
 
+          // If the caller explicitly requested a nested view, it must exist (no schema fallback for typos).
+          if (overrideViewName && !nestedView) {
+            throw new Error(
+              `blinxForm: unknown nested ui view "${String(overrideViewName)}" for model "${String(nestedModel?.id || nestedModel?.name || nestedModel?.entity || 'unknown')}" (field "${String(key)}").`
+            );
+          }
+
           if (!nestedView && BlinxConfig.isGeneratedViewAllowed() === false) {
             // Strict mode: nested model rendering requires an explicit view.
             throw new Error(
@@ -442,6 +449,11 @@ export function blinxForm({
 
           items.forEach((item, itemIndex) => {
             const itemView = resolveModelUIView({ model: itemModel, kind: 'form', viewName: overrideItemViewName });
+            if (overrideItemViewName && !itemView) {
+              throw new Error(
+                `blinxForm: unknown nested item ui view "${String(overrideItemViewName)}" for model "${String(itemModel?.id || itemModel?.name || itemModel?.entity || 'unknown')}" (field "${String(key)}").`
+              );
+            }
             if (!itemView && BlinxConfig.isGeneratedViewAllowed() === false) {
               throw new Error(
                 `blinxForm: strict mode: missing nested item ui view for model "${String(itemModel?.id || itemModel?.name || itemModel?.entity || 'unknown')}" (field "${String(key)}").`

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -2,11 +2,15 @@ import { BlinxArrayDataSource, BlinxDataSource, BlinxRestDataSource } from './bl
 
 export const DataTypes = {
   string: 'string',
+  longText: 'longText',
   number: 'number',
   boolean: 'boolean',
   date: 'date',
   enum: 'enum',
   array: 'array',
+  json: 'json',
+  blob: 'blob',
+  secret: 'secret',
 };
 
 export const EventTypes = {

--- a/lib/blinx.table.js
+++ b/lib/blinx.table.js
@@ -16,10 +16,15 @@ export function blinxTable({
   }
 
   const args = arguments?.[0] || {};
+  const viewProvided = Object.prototype.hasOwnProperty.call(args, 'view');
+  const viewForCollection = (viewProvided && view && typeof view === 'object')
+    ? { ...view, layout: 'table' }
+    : view;
+
   const opts = {
     root,
     store,
-    view: { ...view, layout: 'table' },
+    view: viewForCollection,
     paging: { pageSize, page: 0 },
     selection: { mode: 'multi' },
     actions: { create: true, deleteSelected: true },

--- a/lib/blinx.table.js
+++ b/lib/blinx.table.js
@@ -1,5 +1,6 @@
 
 import { blinxCollection } from './blinx.collection.js';
+import { resolveComponentUIView } from './blinx.ui-views.js';
 
 export function blinxTable({
   root, view, store,
@@ -17,9 +18,13 @@ export function blinxTable({
 
   const args = arguments?.[0] || {};
   const viewProvided = Object.prototype.hasOwnProperty.call(args, 'view');
-  const viewForCollection = (viewProvided && view && typeof view === 'object')
-    ? { ...view, layout: 'table' }
-    : view;
+
+  // Resolve the view here so we can ALWAYS enforce table layout,
+  // even when `view` is a string (named view reference).
+  const resolveArgs = { store, model, kind: 'collection' };
+  if (viewProvided) resolveArgs.view = view;
+  const resolved = resolveComponentUIView(resolveArgs);
+  const viewForCollection = resolved ? { ...resolved, layout: 'table' } : resolved;
 
   const opts = {
     root,

--- a/lib/blinx.ui-views.js
+++ b/lib/blinx.ui-views.js
@@ -11,6 +11,7 @@
  */
  
 import { generateSchemaDefaultUIView, __internal_cacheGeneratedUIView } from './blinx.default-uiviews.js';
+import { BlinxConfig } from './blinx.config.js';
 
 const VIEWS_BY_MODEL = new WeakMap(); // model object -> views object
 const VIEWS_BY_ID = new Map();        // model id/name -> views object (fallback)
@@ -75,7 +76,7 @@ export function resolveModelUIView({ model, kind, viewName } = {}) {
 
   // If no declarative views exist at all, allow schema fallback (only when no viewName is requested).
   if (!views) {
-    if (k && !name) {
+    if (k && !name && BlinxConfig.isGeneratedViewAllowed()) {
       const generated = generateSchemaDefaultUIView({ model, kind: k });
       if (generated) {
         __internal_cacheGeneratedUIView({ model, kind: k, view: generated });
@@ -91,7 +92,7 @@ export function resolveModelUIView({ model, kind, viewName } = {}) {
     if (name && bucket[name]) return bucket[name];
     if (bucket.default) return bucket.default;
     // Schema fallback only when caller did NOT request a specific viewName.
-    if (!name) {
+    if (!name && BlinxConfig.isGeneratedViewAllowed()) {
       const generated = generateSchemaDefaultUIView({ model, kind: k });
       if (generated) {
         __internal_cacheGeneratedUIView({ model, kind: k, view: generated });
@@ -105,7 +106,7 @@ export function resolveModelUIView({ model, kind, viewName } = {}) {
   if (name && views[name]) return views[name];
 
   // Legacy flat map has no per-kind default; fallback only when viewName omitted.
-  if (k && !name) {
+  if (k && !name && BlinxConfig.isGeneratedViewAllowed()) {
     const generated = generateSchemaDefaultUIView({ model, kind: k });
     if (generated) {
       __internal_cacheGeneratedUIView({ model, kind: k, view: generated });
@@ -150,7 +151,7 @@ export function resolveComponentUIView({ store, model, kind, view } = {}) {
   // otherwise typos would silently succeed.
   const hasViewProp = Object.prototype.hasOwnProperty.call(arguments?.[0] || {}, 'view');
   const viewWasOmitted = !hasViewProp || view === undefined;
-  if (viewWasOmitted) {
+  if (viewWasOmitted && BlinxConfig.isGeneratedViewAllowed()) {
     const generated = generateSchemaDefaultUIView({ model, kind });
     if (generated) {
       __internal_cacheGeneratedUIView({ model, kind, view: generated });

--- a/lib/blinx.ui-views.js
+++ b/lib/blinx.ui-views.js
@@ -10,6 +10,8 @@
  *   (flat: { [key]: viewObj }).
  */
  
+import { generateSchemaDefaultUIView, __internal_cacheGeneratedUIView } from './blinx.default-uiviews.js';
+
 const VIEWS_BY_MODEL = new WeakMap(); // model object -> views object
 const VIEWS_BY_ID = new Map();        // model id/name -> views object (fallback)
 
@@ -115,6 +117,19 @@ export function resolveComponentUIView({ store, model, kind, view } = {}) {
   // Omitted: use registry default for the kind (if any).
   const fromRegistryDefault = resolveModelUIView({ model, kind, viewName: null });
   if (fromRegistryDefault) return fromRegistryDefault;
+
+  // Final fallback: schema-driven default view generation (only when `view` is truly omitted).
+  // IMPORTANT: do NOT generate when caller explicitly requested a missing viewName (string),
+  // otherwise typos would silently succeed.
+  const hasViewProp = Object.prototype.hasOwnProperty.call(arguments?.[0] || {}, 'view');
+  const viewWasOmitted = !hasViewProp || view === undefined;
+  if (viewWasOmitted) {
+    const generated = generateSchemaDefaultUIView({ model, kind });
+    if (generated) {
+      __internal_cacheGeneratedUIView({ model, kind, view: generated });
+      return generated;
+    }
+  }
 
   return null;
 }

--- a/lib/blinx.ui-views.js
+++ b/lib/blinx.ui-views.js
@@ -70,21 +70,48 @@ export function getModelViews(model) {
  */
 export function resolveModelUIView({ model, kind, viewName } = {}) {
   const views = getModelViews(model);
-  if (!views) return null;
-
   const k = (typeof kind === 'string' && kind) ? kind : null;
   const name = (typeof viewName === 'string' && viewName) ? viewName : null;
+
+  // If no declarative views exist at all, allow schema fallback (only when no viewName is requested).
+  if (!views) {
+    if (k && !name) {
+      const generated = generateSchemaDefaultUIView({ model, kind: k });
+      if (generated) {
+        __internal_cacheGeneratedUIView({ model, kind: k, view: generated });
+        return generated;
+      }
+    }
+    return null;
+  }
 
   // Kind-bucketed: views.form / views.collection / views.table / ...
   if (k && isPlainObject(views[k])) {
     const bucket = views[k];
     if (name && bucket[name]) return bucket[name];
     if (bucket.default) return bucket.default;
+    // Schema fallback only when caller did NOT request a specific viewName.
+    if (!name) {
+      const generated = generateSchemaDefaultUIView({ model, kind: k });
+      if (generated) {
+        __internal_cacheGeneratedUIView({ model, kind: k, view: generated });
+        return generated;
+      }
+    }
     return null;
   }
 
   // Legacy flat map: { edit: {...}, list: {...} }
   if (name && views[name]) return views[name];
+
+  // Legacy flat map has no per-kind default; fallback only when viewName omitted.
+  if (k && !name) {
+    const generated = generateSchemaDefaultUIView({ model, kind: k });
+    if (generated) {
+      __internal_cacheGeneratedUIView({ model, kind: k, view: generated });
+      return generated;
+    }
+  }
 
   return null;
 }


### PR DESCRIPTION
Add new `DataTypes` to support schema-driven default view generation.

These new data types (`longText`, `json`, `blob`, `secret`) will be used to identify and hide complex or sensitive fields when automatically generating UI views from the data model schema.

---
<a href="https://cursor.com/background-agent?bcId=bc-3fcf6bb9-2657-471c-a85f-2eb4c0ac3e59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3fcf6bb9-2657-471c-a85f-2eb4c0ac3e59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds schema-driven default UI view generation (form/table) with a global config toggle, client-side search/default sort in collections, new DataTypes (longText/json/blob/secret), stricter nested view resolution, and a dump utility.
> 
> - **Schema-generated UI views**:
>   - Adds `generateSchemaDefaultUIView` with defaults for `form` and `collection/table`, hiding complex/sensitive fields and choosing columns/searchFields/defaultSort.
>   - Caches generated views and introduces `blinxDump('ui-view')` to export them.
> - **Config**:
>   - New `BlinxConfig` with `allowGeneratedViews` and helpers to enable/disable fallback (strict mode).
> - **View resolution** (`blinx.ui-views.js`):
>   - Falls back to schema-generated views when no declarative view is found (unless strict or a specific view name was requested).
>   - Caches generated results per model/kind.
> - **Form** (`blinx.form.js`):
>   - Honors strict mode for nested models/collections; throws if explicit `view`/`itemView` is missing when specified.
> - **Collection/Table** (`blinx.collection.js`, `blinx.table.js`):
>   - Adds search controls (`searchInput`/`searchButton`) driven by `view.searchFields`; client-side filtering and stable `defaultSort` applied; best-effort remote sort initiation.
> - **Default adapter** (`blinx.adapters.default.js`):
>   - Renders/reads `longText`, `json`, `blob`, `secret`; formats `json`/`secret` cells.
> - **Model/Data** (`blinx.store.js`):
>   - Extends `DataTypes` with `longText`, `json`, `blob`, `secret`.
> - **Tests**:
>   - Adds integration tests for default generation, collection search, nested fallback, strict mode behavior, and dump output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e35dc6025bffb62f5047aa13ff705ac7a69905da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->