### PR TITLE
Blinx computed fields exploration

### DIFF
--- a/__tests__/blinx.adapters.default.test.js
+++ b/__tests__/blinx.adapters.default.test.js
@@ -134,4 +134,20 @@ describe('BlinxDefaultUI', () => {
     select.dispatchEvent(new Event('change'));
     expect(onChange.calls).toEqual([['A', []]]);
   });
+
+  test('createField: computed fields are rendered read-only/disabled', () => {
+    const a = new BlinxDefaultUI();
+    const onChange = createOnChangeSpy();
+
+    const { el } = a.createField({
+      fieldKey: 'total',
+      def: { type: 'number', computed: true },
+      value: 123,
+      onChange,
+    });
+
+    const input = el.querySelector('input');
+    expect(input).toBeTruthy();
+    expect(input.getAttribute('readonly')).toBe('true');
+  });
 });

--- a/__tests__/blinx.computed-fields.test.js
+++ b/__tests__/blinx.computed-fields.test.js
@@ -1,0 +1,127 @@
+import { blinxStore } from '../lib/blinx.store.js';
+
+describe('computed fields', () => {
+  test('exposes virtual computed fields via getRecord() and toJSON()', () => {
+    const model = {
+      fields: {
+        price: { type: 'number' },
+        discount: { type: 'number' },
+        priceAfterDiscount: {
+          type: 'number',
+          computed: true,
+          dependsOn: ['price', 'discount'],
+          compute: (record) => record.price * (1 - record.discount),
+        },
+      },
+    };
+    const store = blinxStore([{ price: 100, discount: 0.2 }], model);
+
+    expect(store.getRecord(0).priceAfterDiscount).toBe(80);
+    expect(store.toJSON()[0].priceAfterDiscount).toBe(80);
+  });
+
+  test('caches computed values per-record and invalidates when dependencies change', () => {
+    const compute = jest.fn((record) => record.price * 2);
+    const model = {
+      fields: {
+        price: { type: 'number' },
+        doublePrice: {
+          type: 'number',
+          computed: true,
+          dependsOn: ['price'],
+          compute,
+        },
+      },
+    };
+    const store = blinxStore([{ price: 5 }], model);
+
+    expect(store.getRecord(0).doublePrice).toBe(10);
+    expect(store.getRecord(0).doublePrice).toBe(10);
+    expect(compute).toHaveBeenCalledTimes(1);
+
+    store.setField(0, 'price', 7);
+    expect(store.getRecord(0).doublePrice).toBe(14);
+    expect(compute).toHaveBeenCalledTimes(2);
+  });
+
+  test('computed fields are read-only and are stripped from stored records', () => {
+    const model = {
+      fields: {
+        price: { type: 'number' },
+        discount: { type: 'number' },
+        priceAfterDiscount: {
+          type: 'number',
+          computed: true,
+          dependsOn: ['price', 'discount'],
+          compute: (record) => record.price * (1 - record.discount),
+        },
+      },
+    };
+    const store = blinxStore([{ price: 100, discount: 0.5 }], model);
+
+    expect(() => store.setField(0, 'priceAfterDiscount', 1)).toThrow('Cannot set computed field');
+
+    store.addRecord({ price: 20, discount: 0.25, priceAfterDiscount: 999 });
+
+    // Value is computed (not persisted from input)
+    expect(store.toJSON()[1].priceAfterDiscount).toBe(15);
+    // And the underlying stored object should not have the computed key at all
+    expect(Object.prototype.hasOwnProperty.call(store.getRecord(1), 'priceAfterDiscount')).toBe(false);
+  });
+
+  test('supports computed fields depending on other computed fields', () => {
+    const calls = [];
+    const model = {
+      fields: {
+        price: { type: 'number' },
+        qty: { type: 'number' },
+        tax: { type: 'number' },
+        subtotal: {
+          type: 'number',
+          computed: true,
+          dependsOn: ['price', 'qty'],
+          compute: (r) => {
+            calls.push('subtotal');
+            return r.price * r.qty;
+          },
+        },
+        total: {
+          type: 'number',
+          computed: true,
+          dependsOn: ['subtotal', 'tax'],
+          compute: (r) => {
+            calls.push('total');
+            return r.subtotal * (1 + r.tax);
+          },
+        },
+      },
+    };
+    const store = blinxStore([{ price: 10, qty: 2, tax: 0.1 }], model);
+
+    expect(store.getRecord(0).total).toBe(22);
+    // total may compute subtotal lazily during evaluation, so call order is not guaranteed.
+    expect(calls.sort()).toEqual(['subtotal', 'total']);
+  });
+
+  test('throws on computed dependency cycles', () => {
+    const model = {
+      fields: {
+        a: {
+          type: 'number',
+          computed: true,
+          dependsOn: ['b'],
+          compute: (r) => (r.b ?? 0) + 1,
+        },
+        b: {
+          type: 'number',
+          computed: true,
+          dependsOn: ['a'],
+          compute: (r) => (r.a ?? 0) + 1,
+        },
+      },
+    };
+
+    expect(() => blinxStore([], model)).toThrow('dependency cycle');
+  });
+});
+

--- a/lib/blinx.adapters.default.js
+++ b/lib/blinx.adapters.default.js
@@ -19,7 +19,7 @@ export class BlinxDefaultUI {
 
     const common = (el) => {
       el.className = 'input';
-      if (def.readonly) el.setAttribute('readonly', 'true');
+      if (def.readonly || def.computed) el.setAttribute('readonly', 'true');
       if (def.required) el.setAttribute('required', 'true');
       el.addEventListener('change', () => {
         const v = this.readValue(el, def);
@@ -50,14 +50,14 @@ export class BlinxDefaultUI {
         common(input); input.value = value ?? ''; break;
       case 'boolean':
         input = document.createElement('input'); input.type = 'checkbox'; input.checked = Boolean(value);
-        if (def.readonly) input.disabled = true;
+        if (def.readonly || def.computed) input.disabled = true;
         input.addEventListener('change', () => onChange(input.checked, [])); break;
       case 'date':
         input = document.createElement('input'); input.type = 'date';
         common(input); input.value = value ?? ''; break;
       case 'enum':
         input = document.createElement('select'); input.className = 'input';
-        if (def.readonly) input.disabled = true;
+        if (def.readonly || def.computed) input.disabled = true;
         (def.values || []).forEach(v => { const opt = document.createElement('option'); opt.value = v; opt.textContent = v; input.appendChild(opt); });
         input.value = value ?? (def.values?.[0] || '');
         input.addEventListener('change', () => onChange(input.value, [])); break;

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -620,7 +620,8 @@ export function blinxCollection({
   }
 
   async function doCreate() {
-    runInternalChange(() => store.addRecord(Object.fromEntries(Object.keys(model.fields).map(k => [k, '']))));
+    const keys = Object.keys(model.fields || {}).filter(k => !model?.fields?.[k]?.computed);
+    runInternalChange(() => store.addRecord(Object.fromEntries(keys.map(k => [k, '']))));
     refresh();
     setStatus(dom, 'New row created.', '#2f855a');
   }

--- a/lib/blinx.computed.js
+++ b/lib/blinx.computed.js
@@ -1,0 +1,287 @@
+// Computed fields support (virtual, read-only, on-demand).
+//
+// Design goals:
+// - Keep compute logic as plain JS: compute(record, ctx)
+// - Treat computed fields as virtual + read-only (never persisted in store state)
+// - Cache per-record computed values and invalidate on dependency changes (dependsOn)
+// - Detect dependency cycles at model analysis time
+//
+// NOTE: This module intentionally avoids any DSL.
+
+const MODEL_META = new WeakMap(); // model -> meta
+const RECORD_STATE = new WeakMap(); // record(obj) -> { values: Map, inProgress: Set }
+
+function isPlainObject(v) {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function uniqStrings(arr) {
+  const out = [];
+  const seen = new Set();
+  for (const v of arr || []) {
+    if (typeof v !== 'string') continue;
+    const s = v.trim();
+    if (!s) continue;
+    if (seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+  }
+  return out;
+}
+
+function topoSortComputed({ computedKeys, computedDeps }) {
+  // computedDeps: Map(field -> Set(computedFieldDepsOnly))
+  const indeg = new Map();
+  for (const k of computedKeys) indeg.set(k, 0);
+  for (const [k, deps] of computedDeps.entries()) {
+    for (const d of deps) indeg.set(d, (indeg.get(d) || 0) + 1);
+  }
+
+  const q = [];
+  for (const [k, n] of indeg.entries()) if (n === 0) q.push(k);
+  const out = [];
+  while (q.length) {
+    const n = q.shift();
+    out.push(n);
+    const deps = computedDeps.get(n);
+    if (!deps) continue;
+    for (const d of deps) {
+      const next = (indeg.get(d) || 0) - 1;
+      indeg.set(d, next);
+      if (next === 0) q.push(d);
+    }
+  }
+
+  if (out.length !== computedKeys.length) {
+    // Best-effort cycle reporting: list remaining nodes.
+    const remaining = [];
+    for (const [k, n] of indeg.entries()) if (n > 0) remaining.push(k);
+    throw new Error(`Blinx computed fields: dependency cycle detected: ${remaining.join(' -> ')}`);
+  }
+
+  return out;
+}
+
+function buildModelMeta(model) {
+  const fields = model?.fields;
+  if (!isPlainObject(fields)) return null;
+
+  const computed = new Set();
+  const computeFns = new Map(); // key -> fn
+  const dependsOn = new Map(); // key -> string[]
+  const dependentsByField = new Map(); // anyField -> Set(computedFieldsThatDependOnItDirectly)
+  const computedDepsOnly = new Map(); // computedField -> Set(computedFieldDepsOnly)
+
+  for (const [key, def] of Object.entries(fields)) {
+    if (!def || typeof def !== 'object') continue;
+    if (!def.computed) continue;
+    computed.add(key);
+    const fn = def.compute || def.computeLogic; // allow legacy-ish naming
+    if (typeof fn !== 'function') {
+      throw new Error(`Blinx computed fields: field "${key}" is marked computed but has no compute(record, ctx) function.`);
+    }
+    computeFns.set(key, fn);
+    const deps = uniqStrings(def.dependsOn || []);
+    dependsOn.set(key, deps);
+  }
+
+  if (computed.size === 0) {
+    return {
+      hasComputed: false,
+      computedKeys: [],
+      computeFns,
+      dependsOn,
+      dependentsByField,
+      order: [],
+    };
+  }
+
+  // Validate dependsOn references + build dependency maps.
+  for (const key of computed) {
+    const deps = dependsOn.get(key) || [];
+    for (const dep of deps) {
+      if (!Object.prototype.hasOwnProperty.call(fields, dep)) {
+        throw new Error(`Blinx computed fields: field "${key}" dependsOn unknown field "${dep}".`);
+      }
+      if (!dependentsByField.has(dep)) dependentsByField.set(dep, new Set());
+      dependentsByField.get(dep).add(key);
+    }
+    // Computed->computed edges only for cycle detection / ordering.
+    const computedOnly = new Set(deps.filter(d => computed.has(d)));
+    computedDepsOnly.set(key, computedOnly);
+  }
+
+  // Cycle detection on computed-only graph.
+  // NOTE: We are not auto-inferring dependencies from compute() body; dependsOn is authoritative.
+  topoSortComputed({ computedKeys: Array.from(computed), computedDeps: computedDepsOnly });
+
+  // Precompute a full evaluation order (topological) for "compute all" cases.
+  // We want dependencies first, so we invert edges for topo ordering:
+  // Our computedDepsOnly currently stores key -> deps; we can topo sort by Kahn using reversed edges:
+  const forward = new Map(); // dep -> Set(dependent)
+  const indeg = new Map();
+  for (const k of computed) indeg.set(k, 0);
+  for (const [k, deps] of computedDepsOnly.entries()) {
+    for (const dep of deps) {
+      if (!forward.has(dep)) forward.set(dep, new Set());
+      forward.get(dep).add(k);
+      indeg.set(k, (indeg.get(k) || 0) + 1);
+    }
+  }
+  const q = [];
+  for (const [k, n] of indeg.entries()) if (n === 0) q.push(k);
+  const order = [];
+  while (q.length) {
+    const n = q.shift();
+    order.push(n);
+    const outs = forward.get(n);
+    if (!outs) continue;
+    for (const d of outs) {
+      const next = (indeg.get(d) || 0) - 1;
+      indeg.set(d, next);
+      if (next === 0) q.push(d);
+    }
+  }
+
+  return {
+    hasComputed: true,
+    computedKeys: Array.from(computed),
+    computeFns,
+    dependsOn,
+    dependentsByField,
+    order,
+  };
+}
+
+export function getComputedModelMeta(model) {
+  if (!model || typeof model !== 'object') return null;
+  if (MODEL_META.has(model)) return MODEL_META.get(model);
+  const meta = buildModelMeta(model);
+  MODEL_META.set(model, meta);
+  return meta;
+}
+
+export function isComputedField(model, fieldKey) {
+  const meta = getComputedModelMeta(model);
+  if (!meta || !meta.hasComputed) return false;
+  return meta.computeFns.has(String(fieldKey));
+}
+
+export function stripComputedFields(model, recordLike) {
+  if (!recordLike || typeof recordLike !== 'object') return recordLike;
+  const meta = getComputedModelMeta(model);
+  if (!meta || !meta.hasComputed) return recordLike;
+  const out = { ...recordLike };
+  for (const k of meta.computedKeys) {
+    if (Object.prototype.hasOwnProperty.call(out, k)) delete out[k];
+  }
+  return out;
+}
+
+function getRecordState(record) {
+  let st = RECORD_STATE.get(record);
+  if (!st) {
+    st = { values: new Map(), inProgress: new Set() };
+    RECORD_STATE.set(record, st);
+  }
+  return st;
+}
+
+export function invalidateComputedForField(model, record, changedField) {
+  if (!record || typeof record !== 'object') return;
+  const meta = getComputedModelMeta(model);
+  if (!meta || !meta.hasComputed) return;
+
+  const start = String(changedField);
+  const visited = new Set([start]);
+  const q = [start];
+  const st = getRecordState(record);
+
+  while (q.length) {
+    const cur = q.shift();
+    const deps = meta.dependentsByField.get(cur);
+    if (!deps) continue;
+    for (const computedField of deps) {
+      st.values.delete(computedField);
+      if (visited.has(computedField)) continue;
+      visited.add(computedField);
+      q.push(computedField);
+    }
+  }
+}
+
+function computeField(model, record, fieldKey, ctx) {
+  const meta = getComputedModelMeta(model);
+  if (!meta || !meta.hasComputed) return undefined;
+  const key = String(fieldKey);
+  const fn = meta.computeFns.get(key);
+  if (!fn) return undefined;
+
+  const st = getRecordState(record);
+  if (st.values.has(key)) return st.values.get(key);
+  if (st.inProgress.has(key)) {
+    throw new Error(`Blinx computed fields: cycle while computing "${key}". Check dependsOn configuration.`);
+  }
+
+  st.inProgress.add(key);
+  try {
+    const localCtx = ctx || {};
+    // Provide a stable ctx.get() so compute functions can explicitly read dependencies.
+    if (typeof localCtx.get !== 'function') {
+      localCtx.get = (name) => {
+        const n = String(name);
+        if (meta.computeFns.has(n)) return computeField(model, record, n, localCtx);
+        return record?.[n];
+      };
+    }
+    // Pass a computed-aware record view so compute() can read other computed
+    // fields via normal property access (e.g., record.subtotal).
+    const recordView = new Proxy(record, {
+      get(target, prop, receiver) {
+        if (typeof prop === 'string' && meta.computeFns.has(prop)) {
+          return computeField(model, target, prop, localCtx);
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    });
+    const val = fn(recordView, localCtx);
+    st.values.set(key, val);
+    return val;
+  } finally {
+    st.inProgress.delete(key);
+  }
+}
+
+export function decorateRecordWithComputed(model, record, { ctx } = {}) {
+  const meta = getComputedModelMeta(model);
+  if (!meta || !meta.hasComputed || !record || typeof record !== 'object') return record;
+  // Proxy is intentionally minimal:
+  // - Does NOT add computed fields to enumeration (keeps backwards-compatible equality checks)
+  // - Only intercepts property get for computed keys
+  return new Proxy(record, {
+    get(target, prop, receiver) {
+      if (typeof prop === 'string' && meta.computeFns.has(prop)) {
+        return computeField(model, target, prop, ctx);
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+export function cloneWithComputed(model, record, { clone, ctx } = {}) {
+  // clone: optional deep-clone function; if not provided, do a JSON-only clone.
+  if (!record || typeof record !== 'object') return record;
+  const meta = getComputedModelMeta(model);
+  const base = (typeof clone === 'function')
+    ? clone(record)
+    : JSON.parse(JSON.stringify(record));
+  if (!meta || !meta.hasComputed) return base;
+
+  // Compute in topological order so dependsOn computed fields are available.
+  // We compute against the *real* record (not the clone) to keep behavior consistent.
+  for (const k of meta.order) {
+    base[k] = computeField(model, record, k, ctx);
+  }
+  return base;
+}
+

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -370,6 +370,8 @@ export function blinxForm({
         const key = typeof f === 'string' ? f : f.field;
         const def = model.fields[key];
         if (!def) return;
+        // Computed fields are read-only; renderers can still show them,
+        // but Blinx should never allow editing them.
 
         const value = record ? record[key] : undefined;
         const rendererName = (f && typeof f === 'object' && f.renderer) ? f.renderer : defaultRendererName;
@@ -519,6 +521,7 @@ export function blinxForm({
           value,
           onChange: val => {
             if (!store.getRecord(currentIndex)) return;
+            if (def?.computed) return; // read-only by contract
             runInternalChange(() => store.setField(currentIndex, key, val));
           }
         });
@@ -548,6 +551,7 @@ export function blinxForm({
         if (!def) return true;
         // Nested types are validated by their own sub-forms (if any).
         if (def.type === 'model' || def.type === 'collection') return true;
+        if (def.computed) return true;
         return validateField(rec[key], def).length === 0;
       })
     );
@@ -626,7 +630,8 @@ export function blinxForm({
 
   async function doReset() { await runInternalChange(() => store.reset()); buildSections(); updateIndicator(); setStatus('Reset done.', '#4a5568'); }
   async function doCreate() {
-    const idx = runInternalChange(() => store.addRecord(Object.fromEntries(Object.keys(model.fields).map(k => [k, '']))));
+    const keys = Object.keys(model.fields || {}).filter(k => !model?.fields?.[k]?.computed);
+    const idx = runInternalChange(() => store.addRecord(Object.fromEntries(keys.map(k => [k, '']))));
     rebind(idx);
     setStatus('New record created.', '#2f855a');
   }

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -1,4 +1,12 @@
 import { BlinxArrayDataSource, BlinxDataSource, BlinxRestDataSource } from './blinx.datasource.js';
+import {
+  getComputedModelMeta,
+  isComputedField,
+  stripComputedFields,
+  decorateRecordWithComputed,
+  cloneWithComputed,
+  invalidateComputedForField,
+} from './blinx.computed.js';
 
 export const DataTypes = {
   string: 'string',
@@ -27,8 +35,10 @@ export const EventTypes = {
 const clone = value => JSON.parse(JSON.stringify(value));
 
 function createLegacyArrayStore(initialArray, dataModel) {
-  let original = clone(initialArray);
-  let current = clone(initialArray);
+  // Validate computed metadata early (throws on cycles / invalid dependsOn).
+  getComputedModelMeta(dataModel);
+  let original = clone((initialArray || []).map(r => stripComputedFields(dataModel, r)));
+  let current = clone((initialArray || []).map(r => stripComputedFields(dataModel, r)));
   const model = dataModel;
   const subs = new Set();
   let storeApi;
@@ -37,18 +47,26 @@ function createLegacyArrayStore(initialArray, dataModel) {
     subs.forEach(fn => fn({ path, value, data: current, store: storeApi }));
   }
 
-  function getRecord(idx) { return current[idx]; }
+  function getRecord(idx) {
+    const rec = current[idx];
+    return decorateRecordWithComputed(model, rec);
+  }
   function getModel() { return model; }
   function getLength() { return current.length; }
 
   function setField(idx, field, value) {
+    if (isComputedField(model, field)) {
+      throw new Error(`Cannot set computed field "${String(field)}".`);
+    }
     current[idx][field] = value;
+    invalidateComputedForField(model, current[idx], field);
     notify([idx, field], value);
   }
 
   function addRecord(record, atIndex = current.length) {
-    current.splice(atIndex, 0, record);
-    notify([EventTypes.add, atIndex], record);
+    const sanitized = stripComputedFields(model, record || {});
+    current.splice(atIndex, 0, sanitized);
+    notify([EventTypes.add, atIndex], sanitized);
     return atIndex;
   }
 
@@ -72,19 +90,20 @@ function createLegacyArrayStore(initialArray, dataModel) {
   function updateIndex(index) {
     if (index < 0 || index >= current.length) return null;
     const record = current[index];
-    notify([EventTypes.update, index], record);
-    return record;
+    notify([EventTypes.update, index], cloneWithComputed(model, record, { clone }));
+    return decorateRecordWithComputed(model, record);
   }
 
   function update(index, record) {
     if (index < 0 || index >= current.length) return null;
-    current[index] = record;
-    notify([EventTypes.update, index], record);
-    return record;
+    const sanitized = stripComputedFields(model, record || {});
+    current[index] = sanitized;
+    notify([EventTypes.update, index], cloneWithComputed(model, sanitized, { clone }));
+    return decorateRecordWithComputed(model, sanitized);
   }
 
   function subscribe(fn) { subs.add(fn); return () => subs.delete(fn); }
-  function toJSON() { return clone(current); }
+  function toJSON() { return current.map(r => cloneWithComputed(model, r, { clone })); }
 
   function diff() {
     const changes = [];
@@ -108,7 +127,7 @@ function createLegacyArrayStore(initialArray, dataModel) {
   function commit() {
     const snapshot = clone(current);
     original = snapshot;
-    notify([EventTypes.commit], snapshot);
+    notify([EventTypes.commit], snapshot.map(r => cloneWithComputed(model, r, { clone })));
   }
 
   function reset() {
@@ -151,6 +170,8 @@ function normalizeViewsConfig(input) {
 }
 
 function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
+  // Validate computed metadata early (throws on cycles / invalid dependsOn).
+  getComputedModelMeta(model);
   const subs = new Set();
   let storeApi;
 
@@ -183,9 +204,12 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
 
   function getModel() { return model; }
   function getLength() { return current.length; }
-  function getRecord(idx) { return current[idx]; }
+  function getRecord(idx) {
+    const rec = current[idx];
+    return decorateRecordWithComputed(model, rec);
+  }
   function subscribe(fn) { subs.add(fn); return () => subs.delete(fn); }
-  function toJSON() { return clone(current); }
+  function toJSON() { return current.map(r => cloneWithComputed(model, r, { clone })); }
   function getStatus() { return { status, error, pageInfo, pageState: { ...pageState }, criteria: clone(criteria) }; }
 
   function diff() {
@@ -266,7 +290,11 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   function setField(idx, field, value) {
     const rec = ensureRecord(idx);
     if (!rec) return;
+    if (isComputedField(model, field)) {
+      throw new Error(`Cannot set computed field "${String(field)}".`);
+    }
     rec[field] = value;
+    invalidateComputedForField(model, rec, field);
     notify([idx, field], value);
 
     const id = rec?.[keyField];
@@ -277,13 +305,13 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   }
 
   function addRecord(record, atIndex = current.length) {
-    const rec = clone(record || {});
+    const rec = stripComputedFields(model, clone(record || {}));
     if (rec[keyField] === undefined || rec[keyField] === null || rec[keyField] === '') {
       rec[keyField] = `tmp-${viewName}-${opSeq++}`;
     }
     if (rec[versionField] === undefined) rec[versionField] = '0';
     current.splice(atIndex, 0, rec);
-    notify([EventTypes.add, atIndex], rec);
+    notify([EventTypes.add, atIndex], cloneWithComputed(model, rec, { clone }));
 
     enqueue({
       opId: `op-${viewName}-${opSeq++}`,
@@ -324,15 +352,15 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   function updateIndex(index) {
     if (index < 0 || index >= current.length) return null;
     const record = current[index];
-    notify([EventTypes.update, index], record);
-    return record;
+    notify([EventTypes.update, index], cloneWithComputed(model, record, { clone }));
+    return decorateRecordWithComputed(model, record);
   }
 
   function update(index, record) {
     if (index < 0 || index >= current.length) return null;
-    current[index] = clone(record);
-    notify([EventTypes.update, index], current[index]);
-    return current[index];
+    current[index] = stripComputedFields(model, clone(record));
+    notify([EventTypes.update, index], cloneWithComputed(model, current[index], { clone }));
+    return decorateRecordWithComputed(model, current[index]);
   }
 
   function buildQuerySpec(overrides = {}) {
@@ -364,7 +392,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     pageState = { ...pageState, cursor: defaultPage.after ?? null, page: defaultPage.page ?? 0, offset: defaultPage.offset ?? 0, pageIndex: 0 };
     const res = await dataSource.query(buildQuerySpec(), { resource, entityType, keyField, versionField });
     // Materialize as page-local array
-    const records = (res?.entities?.[entityType] || []).map(r => clone(r));
+    const records = (res?.entities?.[entityType] || []).map(r => stripComputedFields(model, clone(r)));
     current = records;
     original = clone(records);
     pageInfo = res?.pageInfo || null;
@@ -385,7 +413,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     }
     status = 'loading'; error = null;
     const res = await dataSource.query(buildQuerySpec(), { resource, entityType, keyField, versionField });
-    const records = (res?.entities?.[entityType] || []).map(r => clone(r));
+    const records = (res?.entities?.[entityType] || []).map(r => stripComputedFields(model, clone(r)));
     current = records;
     original = clone(records);
     pageInfo = res?.pageInfo || null;
@@ -406,7 +434,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     }
     status = 'loading'; error = null;
     const res = await dataSource.query(buildQuerySpec(), { resource, entityType, keyField, versionField });
-    const records = (res?.entities?.[entityType] || []).map(r => clone(r));
+    const records = (res?.entities?.[entityType] || []).map(r => stripComputedFields(model, clone(r)));
     current = records;
     original = clone(records);
     pageInfo = res?.pageInfo || null;
@@ -476,7 +504,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     const canonical = res?.entities?.[entityType] || null;
     if (canonical && Array.isArray(canonical)) {
       // Replace by id for any returned records; keep current ordering.
-      const byId = new Map(canonical.map(r => [String(r?.[keyField]), clone(r)]));
+      const byId = new Map(canonical.map(r => [String(r?.[keyField]), stripComputedFields(model, clone(r))]));
       current = current.map(r => {
         const id = String(r?.[keyField]);
         return byId.has(id) ? byId.get(id) : r;
@@ -484,7 +512,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     }
     original = clone(current);
     status = 'success';
-    notify([EventTypes.commit], clone(current));
+    notify([EventTypes.commit], current.map(r => cloneWithComputed(model, r, { clone })));
     return res;
   }
 

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -66,7 +66,8 @@ function createLegacyArrayStore(initialArray, dataModel) {
   function addRecord(record, atIndex = current.length) {
     const sanitized = stripComputedFields(model, record || {});
     current.splice(atIndex, 0, sanitized);
-    notify([EventTypes.add, atIndex], sanitized);
+    // Keep notification payload consistent with remote view store (include computed values).
+    notify([EventTypes.add, atIndex], cloneWithComputed(model, sanitized, { clone }));
     return atIndex;
   }
 
@@ -236,7 +237,8 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     // Local snapshot only (does not sync remotely). Provided for backwards compatibility.
     const snapshot = clone(current);
     original = snapshot;
-    notify([EventTypes.commit], snapshot);
+    // Keep notification payload consistent with legacy store + remote save() commit notifications.
+    notify([EventTypes.commit], snapshot.map(r => cloneWithComputed(model, r, { clone })));
   }
 
   function reset() {


### PR DESCRIPTION
Adds per-model virtual computed fields to Blinx to enable defining derived values directly within schemas.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9f877ce-920f-428c-9e13-af72df62159d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9f877ce-920f-428c-9e13-af72df62159d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds first-class support for virtual, read-only computed fields across the data layer and UI.
> 
> - New `lib/blinx.computed.js`: compute engine (`compute`, `dependsOn`), per-record cache + invalidation, topological ordering, and cycle detection; helpers to decorate records, clone with computed, strip computed, and detect computed fields
> - Store integration (`blinx.store.js`): validate models on init; expose computed via `getRecord()` proxy and `toJSON()`; forbid `setField()` on computed; strip computed on add/update/load/save; invalidate dependent caches on edits; include computed values in event payload clones
> - Remote view store: same computed handling for paging/load/save flows, including ID reconciliation and commit notifications
> - UI updates: default adapter renders computed fields read-only/disabled; `blinx.form` ignores edits/validation for computed fields and excludes them when creating records; `blinx.collection` excludes computed keys on create
> - Tests: new coverage for computed behavior, caching/invalidations, nested computed deps, cycle detection, and read-only rendering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6979cb030bfe2c10466e96d55b55942f6dcddd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->