### PR TITLE
View schema conditional display

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,14 @@ if ((saveRes.conflicts || []).length) {
 - React/Chakra adapter for enterprise-grade UI.
 - Virtualized table rendering for very large datasets.
 
+## Roadmap
+
+- **MVP1**: Deliver a minimum workable headless, model-driven UI framework that renders forms and tables from a shared schema. ✅
+- **MVP2**: Better and more customizable layout and practical validation.
+- **MVP3**: Better renderer and components with Shoelace integration and custom HTML template.
+- **MVP4**: React integration.
+- **MVP5**: Workflow and compliant control / data privacy supports.
+
 ## Open Questions / Next Bets
 
 - Can adapter-level theming tokens keep Tailwind, Chakra, and other libraries aligned?

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ This layering keeps validation, diffing, and messaging logic reusable while adap
 - Selection in the table for bulk delete.
 - Interceptor pattern for every action with access to state, controls, and `proceed()`.
 - Event-driven UI refresh so actions stay slim and predictable.
+- Conditional UI presentation via `present()`/`rowPresent` hooks (attrs-only, browser-enforced where possible).
 
 ## Remote Data (REST) with `BlinxRestDataSource`
 
@@ -173,7 +174,6 @@ if ((saveRes.conflicts || []).length) {
 
 ## Future Enhancements
 
-- Conditional display rules baked into the view schema.
 - Undo/Redo stack in the store.
 - Soft delete flows (mark inactive instead of removal).
 - Bulk create with prefilled values.
@@ -183,7 +183,6 @@ if ((saveRes.conflicts || []).length) {
 
 ## Open Questions / Next Bets
 
-- How should conditional visibility rules be declared so both form and table understand them?
 - Can adapter-level theming tokens keep Tailwind, Chakra, and other libraries aligned?
 - Should diff batching understand array moves (drag-and-drop) rather than treating them as delete+add pairs?
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ What ships today:
 - Field rendering driven by datatype, constraints, and view preferences (readonly, required, min/max, CSS hints).
 - Layout definitions that allow form grouping to evolve independently from the data model.
 - Client-side runtime with pagination, diff tracking, and interceptor hooks.
+- Specs: see `docs/spec/README.md` for the supported Model / Data View / UI View shapes.
 
 ## Core Goals
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,41 @@ What ships today:
 3. Funnel every action (`save`, `reset`, `next`, `prev`, `create`, `delete`) through a shared interceptor pipeline.
 4. Stay client-first and performance-conscious without leaning on SSR.
 
+## Quick Start
+
+Minimal form + table rendering (using the default HTML adapter):
+
+```js
+import { blinxStore, DataTypes } from './lib/blinx.store.js';
+import { blinxForm } from './lib/blinx.form.js';
+import { blinxTable } from './lib/blinx.table.js';
+
+const model = {
+  id: 'Product',
+  fields: {
+    id: { type: DataTypes.string },
+    name: { type: DataTypes.string, required: true },
+    price: { type: DataTypes.number, min: 0 },
+  },
+};
+
+const store = blinxStore([{ id: '1', name: 'Apple', price: 1.25 }], model);
+
+blinxForm({
+  root: document.getElementById('form'),
+  store,
+  view: { sections: [{ title: 'Main', columns: 2, fields: ['name', 'price'] }] },
+});
+
+blinxTable({
+  root: document.getElementById('table'),
+  store,
+  view: { layout: 'table', columns: [{ field: 'name', label: 'Name' }, { field: 'price', label: 'Price' }] },
+});
+```
+
+For the full syntax of models, data views, and UI views, see `docs/spec/README.md`.
+
 ## Architecture & Data Flow
 
 ```
@@ -36,8 +71,8 @@ What ships today:
              └─ Headless UI / Radix UI adapters
 ```
 
-1. **Demo model** (`demo/basic-model/model/product.model.js`) describes fields, datatypes, constraints, and defaults.
-2. **View descriptors** outline sections, column layouts, and visibility rules.
+1. **Model** (`docs/spec/model.md`) describes fields, datatypes, constraints, and defaults.
+2. **UI views** (`docs/spec/ui-views.md`) outline sections/columns/layouts, controls, and presentation hooks.
 3. **Store** (`lib/blinx.store.js`) hydrates model + dataset, exposes mutation APIs, and emits granular events.
 4. **UI adapters** (`lib/blinx.form.js`, `lib/blinx.table.js`, or customs) build DOM widgets using model + view metadata.
 
@@ -108,7 +143,7 @@ This layering keeps validation, diffing, and messaging logic reusable while adap
 
 - **Interceptors**: Pre/post logic without mutating core behavior.
 - **Adapters**: Override `createField` and `formatCell` to integrate with any component library.
-- **View schema**: Extend sections/columns with conditional visibility, spans, or custom renderers.
+- **View schema**: Extend sections/columns with spans, custom renderers, and attrs-only presentation via `present()`/`rowPresent`.
 - **Store subscribe**: External listeners can sync with remote APIs, websockets, or optimistic UI flows.
 
 ## Current Capabilities
@@ -121,6 +156,7 @@ This layering keeps validation, diffing, and messaging logic reusable while adap
 - Reset & Save with diff tracking and messaging.
 - Create/Delete operations for both form and table.
 - Selection in the table for bulk delete.
+- Declarative controls (built-in + custom) and custom control actions.
 - Interceptor pattern for every action with access to state, controls, and `proceed()`.
 - Event-driven UI refresh so actions stay slim and predictable.
 - Conditional UI presentation via `present()`/`rowPresent` hooks (attrs-only, browser-enforced where possible).
@@ -195,13 +231,12 @@ if ((saveRes.conflicts || []).length) {
 
 ## Key Improvements Over Time
 
-1. Added Next/Prev navigation and the record indicator.
+1. Added Next/Prev navigation, record indicator, and consistent status messaging.
 2. Introduced the interceptor pattern for all actions with idempotent `proceed()`.
-3. Added Create/Delete buttons for both form and table.
-4. Implemented table selection for bulk delete.
-5. Moved `formatCell` into adapters for pluggable rendering.
-6. Optimized rendering with `DocumentFragment`.
-7. Enhanced `store.diff()` to detect add/remove events.
-8. Let the form listen to `remove` events for auto-refresh.
-9. Cleared `saveStatus` on record navigation.
-10. Simplified `doDelete()` to rely on event-driven refresh.
+3. Added Create/Delete flows for form and collection/table (including bulk delete selection).
+4. Added pluggable renderers (`RegisteredUI`) and per-field/column renderer overrides.
+5. Added schema-driven default UI view generation (safe defaults; strict-mode opt-out).
+6. Added declarative UI view registry with fallback resolution (registry + legacy store-scoped maps).
+7. Added declarative toolbar controls (built-in + custom controls) with custom actions.
+8. Added computed fields support (virtual, read-only, dependency tracked).
+9. Added attrs-only presentation hooks (`present()` / `rowPresent`) for conditional UI behavior without a large DSL.

--- a/__tests__/blinx.present.collection.integration.test.js
+++ b/__tests__/blinx.present.collection.integration.test.js
@@ -1,0 +1,54 @@
+/** @jest-environment jsdom */
+
+import { blinxStore, DataTypes } from '../lib/blinx.store.js';
+import { blinxCollection } from '../lib/blinx.collection.js';
+
+describe('present(): collection/table integration', () => {
+  test('applies column present attrs to header/cell and rowPresent attrs to row', () => {
+    const model = {
+      id: 'Product',
+      fields: {
+        id: { type: DataTypes.string },
+        name: { type: DataTypes.string },
+      },
+    };
+    const store = blinxStore([{ id: '1', name: 'A' }], model);
+    const root = document.createElement('div');
+
+    const view = {
+      layout: 'table',
+      columns: [{
+        field: 'name',
+        label: 'Name',
+        present: (c, r) => ({
+          attrs: {
+            header: { 'data-tenant': c.tenant },
+            cell: { 'data-variant': `primary-${c.role}`, 'data-has-id': !!r?.id },
+          },
+        }),
+      }],
+      rowPresent: (_c, r) => ({ attrs: { row: { 'data-row-id': r?.id || '' } } }),
+      controls: false,
+    };
+
+    blinxCollection({ root, store, view, context: { tenant: 't1', role: 'admin' } });
+
+    const ths = root.querySelectorAll('thead th');
+    expect(ths.length).toBeGreaterThanOrEqual(2); // Sel + Name
+    const thName = Array.from(ths).find(th => th.textContent === 'Name');
+    expect(thName).toBeTruthy();
+    expect(thName.getAttribute('data-tenant')).toBe('t1');
+
+    const tr = root.querySelector('tbody tr');
+    expect(tr).toBeTruthy();
+    expect(tr.getAttribute('data-row-id')).toBe('1');
+
+    const tds = tr.querySelectorAll('td');
+    // first td is selection checkbox, second is name column
+    expect(tds.length).toBeGreaterThanOrEqual(2);
+    const tdName = tds[1];
+    expect(tdName.getAttribute('data-variant')).toBe('primary-admin');
+    expect(tdName.getAttribute('data-has-id')).toBe('true');
+  });
+});
+

--- a/__tests__/blinx.present.form.integration.test.js
+++ b/__tests__/blinx.present.form.integration.test.js
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+
+import { blinxStore, DataTypes } from '../lib/blinx.store.js';
+import { blinxForm } from '../lib/blinx.form.js';
+
+function getFieldInputByLabel(root, labelText) {
+  const labels = Array.from(root.querySelectorAll('label'));
+  const label = labels.find(l => l.textContent === labelText);
+  if (!label) return null;
+  const wrapper = label.parentElement;
+  if (!wrapper) return null;
+  return wrapper.querySelector('input, textarea, select');
+}
+
+describe('present(): form integration', () => {
+  test('recomputes present on record change (setRecordIndex) without caching', () => {
+    const model = {
+      id: 'Product',
+      fields: {
+        id: { type: DataTypes.string },
+        name: { type: DataTypes.string },
+        price: { type: DataTypes.number },
+      },
+    };
+
+    const store = blinxStore([
+      { id: '1', name: 'A', price: 10 },
+      { id: '', name: 'B', price: 20 },
+    ], model);
+
+    let calls = 0;
+    const view = {
+      sections: [{
+        title: 'Main',
+        columns: 2,
+        fields: [
+          'name',
+          {
+            field: 'price',
+            present: (_c, r) => {
+              calls += 1;
+              return { attrs: { input: { readonly: !!r?.id } } };
+            },
+          },
+        ],
+      }],
+    };
+
+    const root = document.createElement('div');
+    const { formApi } = blinxForm({ root, store, view });
+
+    const priceInput0 = getFieldInputByLabel(root, 'price');
+    expect(priceInput0).toBeTruthy();
+    expect(priceInput0.readOnly).toBe(true);
+    expect(calls).toBeGreaterThan(0);
+    const callsAfterFirstRender = calls;
+
+    // Switch record: present must re-run and flip readonly.
+    formApi.setRecordIndex(1);
+    const priceInput1 = getFieldInputByLabel(root, 'price');
+    expect(priceInput1).toBeTruthy();
+    expect(priceInput1.readOnly).toBe(false);
+    expect(calls).toBeGreaterThan(callsAfterFirstRender);
+  });
+
+  test('supports attrs.wrapper.hidden via present()', () => {
+    const model = { id: 'M', fields: { id: { type: DataTypes.string }, name: { type: DataTypes.string } } };
+    const store = blinxStore([{ id: '1', name: 'A' }, { id: '', name: 'B' }], model);
+
+    const view = {
+      sections: [{
+        title: 'Main',
+        columns: 2,
+        fields: [{
+          field: 'name',
+          present: (_c, r) => ({ attrs: { wrapper: { hidden: !!r?.id } } }),
+        }],
+      }],
+    };
+
+    const root = document.createElement('div');
+    const { formApi } = blinxForm({ root, store, view });
+
+    // When id exists, wrapper is hidden.
+    const label0 = Array.from(root.querySelectorAll('label')).find(l => l.textContent === 'name');
+    expect(label0).toBeTruthy();
+    expect(label0.parentElement.hidden).toBe(true);
+
+    // When id falsy, wrapper is visible.
+    formApi.setRecordIndex(1);
+    const label1 = Array.from(root.querySelectorAll('label')).find(l => l.textContent === 'name');
+    expect(label1).toBeTruthy();
+    expect(label1.parentElement.hidden).toBe(false);
+  });
+});
+

--- a/__tests__/blinx.present.unit.test.js
+++ b/__tests__/blinx.present.unit.test.js
@@ -1,0 +1,34 @@
+/** @jest-environment jsdom */
+
+import { applyAttrs } from '../lib/blinx.present.js';
+
+describe('blinx.present: applyAttrs', () => {
+  test('maps readonly variants to readOnly + readonly attribute', () => {
+    const input = document.createElement('input');
+    expect(input.readOnly).toBe(false);
+
+    applyAttrs(input, { readonly: true });
+    expect(input.readOnly).toBe(true);
+    expect(input.hasAttribute('readonly')).toBe(true);
+
+    applyAttrs(input, { readonly: false });
+    expect(input.readOnly).toBe(false);
+    expect(input.hasAttribute('readonly')).toBe(false);
+
+    applyAttrs(input, { 'read-only': true });
+    expect(input.readOnly).toBe(true);
+    expect(input.hasAttribute('readonly')).toBe(true);
+  });
+
+  test('supports hidden + data-* attributes', () => {
+    const div = document.createElement('div');
+    applyAttrs(div, { hidden: true, 'data-tenant': 't1' });
+    expect(div.hidden).toBe(true);
+    expect(div.getAttribute('data-tenant')).toBe('t1');
+
+    applyAttrs(div, { hidden: false, 'data-tenant': null });
+    expect(div.hidden).toBe(false);
+    expect(div.hasAttribute('data-tenant')).toBe(false);
+  });
+});
+

--- a/__tests__/blinx.present.unit.test.js
+++ b/__tests__/blinx.present.unit.test.js
@@ -18,6 +18,11 @@ describe('blinx.present: applyAttrs', () => {
     applyAttrs(input, { 'read-only': true });
     expect(input.readOnly).toBe(true);
     expect(input.hasAttribute('readonly')).toBe(true);
+
+    // Bug regression: removing 'read-only' must remove the readonly attribute (not 'read-only').
+    applyAttrs(input, { 'read-only': false });
+    expect(input.readOnly).toBe(false);
+    expect(input.hasAttribute('readonly')).toBe(false);
   });
 
   test('supports hidden + data-* attributes', () => {

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,0 +1,14 @@
+# Blinx Specs (Model / Data Views / UI Views)
+
+This folder documents the **supported shapes** (syntax) and **semantics** (behavior) of Blinx’s:
+
+- **Model schema**: field definitions, constraints, computed fields
+- **Data views**: store/data-source configuration and multi-view manager behavior
+- **UI views**: form/collection/table schemas, view resolution, and presentation hooks (`present`, `rowPresent`)
+
+Docs:
+
+- `model.md`
+- `data-views.md`
+- `ui-views.md`
+

--- a/docs/spec/data-views.md
+++ b/docs/spec/data-views.md
@@ -1,0 +1,96 @@
+# Data views spec (store + multi-view manager)
+
+This describes how Blinx models **data access** and **multiple “data views”** (collections) via `blinxStore`.
+
+## Two store modes
+
+### 1) Legacy local store (array-backed)
+
+```js
+import { blinxStore, DataTypes } from '../lib/blinx.store.js';
+
+const model = { id: 'Product', fields: { id: { type: DataTypes.string }, name: { type: DataTypes.string } } };
+const store = blinxStore([{ id: '1', name: 'A' }], model);
+```
+
+This returns a single store with:
+- local mutation (`setField`, `addRecord`, `removeRecords`, `commit`, `reset`)
+- diffing (`diff`)
+- event subscription (`subscribe`)
+
+### 2) Data-source + multi-view manager (remote-capable)
+
+```js
+import { blinxStore } from '../lib/blinx.store.js';
+import { BlinxRestDataSource } from '../lib/blinx.datasource.js';
+
+const store = blinxStore({
+  model,
+  dataSource: new BlinxRestDataSource({ baseUrl: 'https://api.example.com' }),
+  views: {
+    default: { resource: 'products', entityType: 'Product', keyField: 'id', versionField: 'version' },
+    archived: { resource: 'products', defaultFilter: { archived: true } },
+  },
+  defaultView: 'default',
+  // Optional store-scoped UI view map (legacy): uiViews: { edit: {...}, list: {...} }
+  uiViews: {},
+});
+```
+
+This returns a **manager** that:
+- exposes a **single event bus** for the model
+- proxies store-like operations to the **active view store**
+- lets you create/select per-view stores via `store.view(name)` / `store.collection(name)`
+
+## Store config shape (remote-capable)
+
+`blinxStore({ ... })` accepts either:
+
+### A) `{ model, dataSource, views, defaultView }`
+
+- **`model`**: model schema (see `model.md`)
+- **`dataSource`**: object implementing `query(querySpec)` and `mutate(ops)` (see `lib/blinx.datasource.js`)
+  - convenience: if `dataSource` is an array, it is wrapped in `BlinxArrayDataSource`
+  - convenience: `initialArray` can be used instead of `dataSource`
+- **`views`**: map of viewName -> viewConfig (see below)
+- **`defaultView`**: name of the default active view (fallback: first key, else `"default"`)
+- **`uiViews`**: optional store-scoped UI view map (legacy compatibility)
+- **`dataSourceOptions`**: optional defaults passed to `dataSource.init(...)` (if implemented)
+
+### B) `{ model, dataSource, view }` (single-view shorthand)
+
+If you pass a single `view` object, Blinx normalizes it into `views: { [view.name||'default']: view }`.
+
+## Data view config (`views[viewName]`)
+
+These are consumed by the remote view store layer (and partially by array data source implementations):
+
+Common keys:
+- **`name?: string`** (the view name is also provided by the `views` map key)
+- **`resource?: string`** (used for querySpec)
+- **`entityType?: string`** (normalization namespace)
+- **`keyField?: string`** (default `"id"`)
+- **`versionField?: string`** (default `"version"`)
+
+Defaults & criteria:
+- **`defaultFilter?: object | (record)=>boolean`**
+- **`defaultSort?: Array<{ field: string, dir?: 'asc'|'desc' }>`**
+- **`defaultSelect?: string[]`** (field selection hint)
+
+Pagination defaults (one of):
+- **`defaultPage?: { mode: 'cursor'|'page'|'offset', limit?: number, after?: string|null, page?: number, offset?: number }`**
+- alias: **`page`** (same shape as `defaultPage`)
+
+## Multi-view manager API surface (important bits)
+
+- **`store.view(name)` / `store.collection(name)`**
+  - with a name: returns the per-view store for that view name
+  - without a name: returns the **active** per-view store
+- **`store.setActiveView(name)` / `store.getActiveView()`**
+- **`store.getViews()`**: returns the configured data views
+- **`store.getUIViews()`**: returns the store-scoped UI view map (legacy)
+
+The manager also proxies common store APIs to the active view:
+`getRecord/getLength/setField/addRecord/removeRecords/update/updateIndex/toJSON/diff/commit/reset`
+and remote APIs: `loadFirst/pageNext/pagePrev/search/save/getStatus/getPagingState`.
+

--- a/docs/spec/model.md
+++ b/docs/spec/model.md
@@ -1,0 +1,78 @@
+# Model schema spec
+
+This describes the **model object** used by `blinxStore(...)` and UI renderers.
+
+## Top-level model shape
+
+```js
+export const ProductModel = {
+  id: 'Product',          // optional but strongly recommended (used in error messages + UI view registry)
+  name: 'Product',        // optional alternative identifier in some places
+  entity: 'Product',      // optional alternative identifier in some places
+  fields: {
+    // fieldName: FieldDef
+  },
+  // Optional legacy: model.uiViews (store-scoped UI view map; prefer registerModelViews or cfg.uiViews)
+  uiViews: { /* legacy map */ },
+};
+```
+
+## Field definitions (`model.fields[fieldKey]`)
+
+Each field definition is a plain object. Common keys:
+
+### `type`
+
+Supported primitives are exported as `DataTypes` from `lib/blinx.store.js`:
+
+- `DataTypes.string`
+- `DataTypes.longText`
+- `DataTypes.number`
+- `DataTypes.boolean`
+- `DataTypes.date`
+- `DataTypes.enum`
+- `DataTypes.array`
+- `DataTypes.json`
+- `DataTypes.blob`
+- `DataTypes.secret`
+
+In UI rendering, two additional structural types are supported:
+
+- **nested model**: `{ type: 'model', model: <Model> }`
+- **nested collection**: `{ type: 'collection', model: <Model> }`
+
+### Validation / constraints (consumed by validation + default UI adapter)
+
+- **`required: boolean`**
+- **`readonly: boolean`**
+- **`length?: { max?: number, min?: number }`** (mostly used for strings)
+- **`min?: number` / `max?: number` / `step?: number`** (numbers)
+- **`values?: string[]`** (enums)
+- **`css?: string`** (default adapter uses this on the field wrapper)
+
+Notes:
+- Validation runs through `validateField(value, def)` in `lib/blinx.validate.js`.
+- Computed fields are always treated as read-only by the store (cannot be set via `setField`).
+
+### Computed fields
+
+A field can be declared as computed (virtual, read-only, derived at read-time):
+
+```js
+{
+  type: DataTypes.string,
+  computed: true,
+  dependsOn: ['firstName', 'lastName'],      // required for correctness (no inference from function body)
+  compute: (record, ctx) => `${record.firstName} ${record.lastName}`,
+}
+```
+
+Semantics:
+
+- **Not persisted**: computed values are not stored in the underlying record state.
+- **Read-only**: `store.setField(..., computedField, ...)` throws.
+- **Invalidation**: when a dependency changes, cached computed values are invalidated.
+- **Cycle detection**: dependency cycles throw early (during model analysis).
+
+See `lib/blinx.computed.js` for implementation.
+

--- a/docs/spec/ui-views.md
+++ b/docs/spec/ui-views.md
@@ -1,0 +1,184 @@
+# UI views spec (form / collection / table)
+
+This describes the **UI view schema** Blinx uses to render:
+
+- `blinxForm(...)` (single-record)
+- `blinxCollection(...)` (multi-record, multiple layouts)
+- `blinxTable(...)` (a convenience wrapper around `blinxCollection` forcing table layout)
+
+It also documents how UI views are **resolved** (registry vs store-scoped maps vs generated fallbacks).
+
+---
+
+## UI view resolution (where views come from)
+
+Blinx can resolve a UI view from multiple sources (in this order):
+
+1) **Explicit object** passed as `view` to the component call (always wins)
+2) **String view name** passed as `view`:
+   - first: store-scoped `store.getUIViews()[name]` (legacy)
+   - then: model registry via `registerModelViews(model, views)` (preferred)
+3) **Omitted `view`**:
+   - use model registry default for the kind (`form` or `collection`)
+   - if allowed, fall back to **schema-generated default view** (see `BlinxConfig.isGeneratedViewAllowed()`)
+
+Registry/resolution logic lives in `lib/blinx.ui-views.js`.
+
+---
+
+## Shared concepts
+
+### Renderer selection
+
+UI views can reference a named renderer:
+
+- **`view.renderer?: string`** (default renderer name)
+- **field/column `renderer?: string`** overrides per entry
+
+Renderers are registered via `RegisteredUI.register(name, renderer)`.
+
+### `present()` and `rowPresent` (minimal conditional behavior)
+
+Instead of a large DSL, Blinx supports **attrs-only presentation hooks**:
+
+```js
+present: (ctx, record, index) => ({
+  attrs: {
+    // part -> attrs bag
+  }
+})
+```
+
+Notes:
+- `ctx` is a merged object: `{ store, model, view, kind, ...context }`
+- `present()` is **recomputed whenever the UI rebuilds/refreshes** (no caching)
+- Boolean mapping:
+  - standard HTML boolean attrs like `hidden/disabled/required/readonly` are applied as real DOM semantics
+  - `data-*` booleans serialize to `"true"` / removed (to work well with CSS selectors)
+
+You provide extra keys for `ctx` via the optional `context` argument:
+
+```js
+blinxForm({ root, store, view, context: { role: 'admin', tenant: 't1' } });
+blinxCollection({ root, store, view, context: { role: 'admin', tenant: 't1' } });
+```
+
+---
+
+## Form UI view schema (`kind: 'form'`)
+
+### Top-level
+
+```js
+const formView = {
+  renderer: 'default',          // optional
+  controls: undefined | false | { /* control spec */ },
+  sections: [ /* Section[] */ ],
+};
+```
+
+### Section
+
+```js
+{
+  title: 'Basics',
+  columns: 1 | 2 | 3,
+  present: (ctx, record, index) => ({
+    attrs: {
+      root: { 'data-section': 'basics' },     // applied to section container
+      wrapper: { 'data-grid': 'main' },       // applied to the section grid
+    }
+  }),
+  fields: [ /* FieldSpec[] */ ],
+}
+```
+
+### FieldSpec
+
+Supported entries:
+
+1) **String field key**:
+
+```js
+'name'
+```
+
+2) **Object field entry** (recommended for customization):
+
+```js
+{
+  field: 'price',
+  span: 1 | 2,                 // grid span (supported by default adapter)
+  renderer: 'default',         // override renderer for this field
+
+  // Nested model overrides (only meaningful when the model field type is 'model' / 'collection')
+  view: 'some-nested-form-view-name',
+  itemView: 'some-item-form-view-name',
+
+  present: (ctx, record, index) => ({
+    attrs: {
+      cell: { 'data-cell': 'price' },         // applied to outer grid cell wrapper
+      wrapper: { hidden: false },             // applied to widget wrapper (default adapter: same as widget root)
+      root: { 'data-field': 'price' },        // applied to widget root
+      label: { title: 'Your price' },         // best-effort
+      input: { readonly: !!record?.id },      // best-effort (native semantics where possible)
+      error: { 'data-error-for': 'price' },   // best-effort
+      help: { 'data-help': 'price' },         // best-effort
+    }
+  }),
+}
+```
+
+Implementation notes:
+- The default adapter exposes `parts: { wrapper, label, input, error }` from `createField(...)`.
+- For custom adapters, `present().attrs.*` is applied best-effort (Blinx tries to locate `label/input/error` under the returned `el`).
+
+---
+
+## Collection UI view schema (`kind: 'collection'`)
+
+### Top-level
+
+```js
+const collectionView = {
+  layout: 'table' | 'cards' | 'feed' | { mount(...) { ... } },
+  renderer: 'default',                // optional default cell renderer
+  columns: [ /* Column[] */ ],        // used by table layout
+  item: { titleField?: string, bodyField?: string }, // used by cards/feed layouts
+
+  searchFields: ['name'],             // optional UI-level keyword search fields
+  defaultSort: [{ field: 'updatedAt', dir: 'desc' }], // optional UI-level sort
+
+  controls: undefined | false | { /* control spec */ },
+
+  // Row-level presentation hook (table: <tr>, cards/feed: <article>)
+  rowPresent: (ctx, record, index) => ({
+    attrs: { row: { 'data-id': record?.id || '' } }
+  }),
+};
+```
+
+### Column
+
+```js
+{
+  field: 'name',
+  label: 'Name',
+  renderer: 'default',
+  present: (ctx, record, index) => ({
+    attrs: {
+      header: { 'data-tenant': ctx.tenant },                  // applied to <th>
+      cell: { 'data-variant': `primary-${ctx.role}` },        // applied to <td>
+      row: { 'data-has-id': !!record?.id },                   // optional: applied to <tr>
+    }
+  }),
+}
+```
+
+---
+
+## Table UI view schema (`blinxTable`)
+
+`blinxTable(...)` resolves the same **collection view**, then forces `layout: 'table'`.
+All collection/table schema rules apply.
+

--- a/lib/blinx.adapters.default.js
+++ b/lib/blinx.adapters.default.js
@@ -88,6 +88,12 @@ export class BlinxDefaultUI {
 
     return {
       el: wrapper,
+      parts: {
+        wrapper,
+        label,
+        input,
+        error: errorEl,
+      },
       getValue: () => this.readValue(input, def),
       setError,
     };

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -1,6 +1,7 @@
 import { EventTypes } from './blinx.store.js';
 import { RegisteredUI } from './blinx.registered-ui.js';
 import { resolveComponentUIView } from './blinx.ui-views.js';
+import { applyAttrs, resolvePresent } from './blinx.present.js';
 import {
   normalizeControlSpecEntry,
   resolveElementByIdWithinRoot,
@@ -103,16 +104,10 @@ function resolveLayout(layout, builtins, customLayouts) {
 
 function createTableLayout() {
   return {
-    mount({ root, model, view, getUI, controller, onItemClick }) {
+    mount({ root, model, view, getUI, controller, onItemClick, ctx }) {
       const table = document.createElement('table');
       const thead = document.createElement('thead');
       const thr = document.createElement('tr');
-      const thSel = document.createElement('th'); thSel.textContent = 'Sel'; thr.appendChild(thSel);
-      (view.columns || []).forEach(col => {
-        const th = document.createElement('th');
-        th.textContent = col.label;
-        thr.appendChild(th);
-      });
       thead.appendChild(thr);
       table.appendChild(thead);
       const tbody = document.createElement('tbody');
@@ -120,11 +115,37 @@ function createTableLayout() {
       root.appendChild(table);
 
       function update() {
+        // Rebuild header so present(ctx, null, null) can be re-evaluated safely.
+        thr.innerHTML = '';
+        const thSel = document.createElement('th');
+        thSel.textContent = 'Sel';
+        thr.appendChild(thSel);
+        (view.columns || []).forEach(col => {
+          const th = document.createElement('th');
+          th.textContent = col.label;
+          const p = resolvePresent(col?.present, ctx, null, null);
+          if (p?.attrs) {
+            applyAttrs(th, p.attrs.header);
+            // Fallback alias (useful for simple cases).
+            applyAttrs(th, p.attrs.root);
+          }
+          thr.appendChild(th);
+        });
+
         tbody.innerHTML = '';
         const { items } = controller.getState();
         const frag = document.createDocumentFragment();
         for (const { index, record } of items) {
           const tr = document.createElement('tr');
+
+          // Row-level present hook (attrs only).
+          const rowP = resolvePresent(view?.rowPresent, ctx, record, index);
+          if (rowP?.attrs) {
+            applyAttrs(tr, rowP.attrs.row);
+            // Fallback alias (useful for simple cases).
+            applyAttrs(tr, rowP.attrs.root);
+          }
+
           const tdSel = document.createElement('td');
           const cb = document.createElement('input');
           cb.type = 'checkbox';
@@ -144,6 +165,17 @@ function createTableLayout() {
             const rendererName = col?.renderer || view?.renderer || 'default';
             const ui = getUI(rendererName);
             td.textContent = ui.formatCell(record?.[col.field], model.fields[col.field]);
+
+            // Column-level present hook (attrs only).
+            const cellP = resolvePresent(col?.present, ctx, record, index);
+            if (cellP?.attrs) {
+              applyAttrs(td, cellP.attrs.cell);
+              // Allow column-level augmentation of the row too (optional).
+              applyAttrs(tr, cellP.attrs.row);
+              // Fallback aliases.
+              applyAttrs(td, cellP.attrs.root);
+            }
+
             tr.appendChild(td);
           });
           frag.appendChild(tr);
@@ -161,7 +193,7 @@ function createTableLayout() {
 
 function createCardsLayout() {
   return {
-    mount({ root, view, controller, onItemClick }) {
+    mount({ root, view, controller, onItemClick, ctx }) {
       const grid = document.createElement('div');
       grid.className = 'blinx-grid';
       root.appendChild(grid);
@@ -173,6 +205,12 @@ function createCardsLayout() {
         for (const { index, record } of items) {
           const card = document.createElement('article');
           card.className = 'blinx-card';
+
+          const rowP = resolvePresent(view?.rowPresent, ctx, record, index);
+          if (rowP?.attrs) {
+            applyAttrs(card, rowP.attrs.row);
+            applyAttrs(card, rowP.attrs.root);
+          }
 
           const titleField = view.item?.titleField;
           if (titleField) {
@@ -195,7 +233,7 @@ function createCardsLayout() {
 
 function createFeedLayout() {
   return {
-    mount({ root, view, controller, onItemClick }) {
+    mount({ root, view, controller, onItemClick, ctx }) {
       const list = document.createElement('div');
       list.className = 'blinx-feed';
       root.appendChild(list);
@@ -207,6 +245,13 @@ function createFeedLayout() {
         for (const { index, record } of items) {
           const item = document.createElement('article');
           item.className = 'blinx-feedItem';
+
+          const rowP = resolvePresent(view?.rowPresent, ctx, record, index);
+          if (rowP?.attrs) {
+            applyAttrs(item, rowP.attrs.row);
+            applyAttrs(item, rowP.attrs.root);
+          }
+
           const titleField = view.item?.titleField;
           const bodyField = view.item?.bodyField;
           if (titleField) {
@@ -252,6 +297,7 @@ export function blinxCollection({
   controls,
   layouts = {},
   onItemClick,
+  context,
 } = {}) {
   // Resolve declarative data view (if requested).
   if (dataView && typeof dataView === 'string') {
@@ -316,6 +362,9 @@ export function blinxCollection({
   const contentRoot = document.createElement('div');
   contentRoot.className = 'blinx-collection__content';
   root.appendChild(contentRoot);
+
+  const baseCtx = { store, model, view, kind: 'collection' };
+  const ctx = (context && typeof context === 'object') ? { ...baseCtx, ...context } : baseCtx;
 
   const layoutKey = typeof view.layout === 'string' ? view.layout : (view.layout ? 'custom' : 'table');
   const builtins = {
@@ -743,6 +792,7 @@ export function blinxCollection({
     view,
     ui: getUI(defaultRendererName),
     getUI,
+    ctx,
     controller,
     onItemClick,
   });

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -4,6 +4,7 @@ import { EventTypes } from './blinx.store.js';
 import { RegisteredUI } from './blinx.registered-ui.js';
 import { resolveComponentUIView, resolveModelUIView } from './blinx.ui-views.js';
 import { BlinxConfig } from './blinx.config.js';
+import { applyAttrs, bestEffortFindPart, resolvePresent } from './blinx.present.js';
 import {
   normalizeControlSpecEntry,
   resolveElementByIdWithinRoot,
@@ -101,6 +102,7 @@ export function blinxForm({
   dataView,
   recordIndex = 0,
   controls,
+  context,
 }) {
   // Resolve declarative data view (if requested).
   if (dataView && typeof dataView === 'string') {
@@ -172,6 +174,9 @@ export function blinxForm({
   let pendingResetSync = null;
   const cleanupFns = [];
   let fieldCleanupFns = [];
+
+  const baseCtx = { store, model, view, kind: 'form' };
+  const ctx = (context && typeof context === 'object') ? { ...baseCtx, ...context } : baseCtx;
 
   const trackedStoreEvents = new Set([
     EventTypes.add,
@@ -366,6 +371,13 @@ export function blinxForm({
       const grid = document.createElement('div');
       grid.className = `grid ${section.columns === 3 ? 'grid-cols-3' : 'grid-cols-2'}`;
 
+      // Section-level present hook (attrs only).
+      const sectionPresent = resolvePresent(section?.present, ctx, record, currentIndex);
+      if (sectionPresent?.attrs) {
+        applyAttrs(sectionEl, sectionPresent.attrs.root);
+        applyAttrs(grid, sectionPresent.attrs.wrapper);
+      }
+
       section.fields.forEach(f => {
         const key = typeof f === 'string' ? f : f.field;
         const def = model.fields[key];
@@ -375,6 +387,7 @@ export function blinxForm({
 
         const value = record ? record[key] : undefined;
         const rendererName = (f && typeof f === 'object' && f.renderer) ? f.renderer : defaultRendererName;
+        const fieldPresent = resolvePresent((f && typeof f === 'object') ? f.present : null, ctx, record, currentIndex);
 
         // Nested model rendering (Option A registry + nested overrides)
         // - def.type === 'model': render nested blinxForm using the nested model's default view (or override via { view })
@@ -438,6 +451,11 @@ export function blinxForm({
 
             const cell = document.createElement('div');
             if (typeof f === 'object' && f.span === 2) cell.style.gridColumn = 'span 2';
+            if (fieldPresent?.attrs) {
+              applyAttrs(cell, fieldPresent.attrs.cell);
+              applyAttrs(nestedRoot, fieldPresent.attrs.wrapper);
+              applyAttrs(nestedRoot, fieldPresent.attrs.root);
+            }
             cell.appendChild(nestedRoot);
             grid.appendChild(cell);
             return;
@@ -510,6 +528,11 @@ export function blinxForm({
 
           const cell = document.createElement('div');
           if (typeof f === 'object' && f.span === 2) cell.style.gridColumn = 'span 2';
+          if (fieldPresent?.attrs) {
+            applyAttrs(cell, fieldPresent.attrs.cell);
+            applyAttrs(list, fieldPresent.attrs.wrapper);
+            applyAttrs(list, fieldPresent.attrs.root);
+          }
           cell.appendChild(list);
           grid.appendChild(cell);
           return;
@@ -528,6 +551,26 @@ export function blinxForm({
 
         const cell = document.createElement('div');
         if (typeof f === 'object' && f.span === 2) cell.style.gridColumn = 'span 2';
+
+        // Field-level present hook (attrs only).
+        if (fieldPresent?.attrs) {
+          applyAttrs(cell, fieldPresent.attrs.cell);
+
+          const parts = widget?.parts || {};
+          const widgetWrapperEl = parts.wrapper || widget?.el;
+          applyAttrs(widgetWrapperEl, fieldPresent.attrs.wrapper);
+          applyAttrs(widget?.el, fieldPresent.attrs.root);
+
+          const labelEl = parts.label || bestEffortFindPart(widget?.el, 'label');
+          const inputEl = parts.input || bestEffortFindPart(widget?.el, 'input');
+          const errorEl = parts.error || bestEffortFindPart(widget?.el, 'error');
+
+          applyAttrs(labelEl, fieldPresent.attrs.label);
+          applyAttrs(inputEl, fieldPresent.attrs.input);
+          applyAttrs(errorEl, fieldPresent.attrs.error);
+          applyAttrs(bestEffortFindPart(widget?.el, 'help'), fieldPresent.attrs.help);
+        }
+
         cell.appendChild(widget.el);
         grid.appendChild(cell);
       });

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -446,6 +446,7 @@ export function blinxForm({
               view: nestedView,
               recordIndex: 0,
               controls: false,
+              context,
             });
             fieldCleanupFns.push(() => { try { formApi?.destroy?.(); } catch { /* ignore */ } });
 
@@ -521,6 +522,7 @@ export function blinxForm({
               view: itemView,
               recordIndex: 0,
               controls: false,
+              context,
             });
             fieldCleanupFns.push(() => { try { formApi?.destroy?.(); } catch { /* ignore */ } });
             list.appendChild(itemRoot);

--- a/lib/blinx.present.js
+++ b/lib/blinx.present.js
@@ -58,7 +58,8 @@ function removeAttr(el, attrName) {
   if (attrName === 'disabled' && 'disabled' in el) el.disabled = false;
   if (attrName === 'required' && 'required' in el) el.required = false;
   if ((attrName === 'readonly' || attrName === 'readOnly' || attrName === 'read-only') && 'readOnly' in el) el.readOnly = false;
-  try { el.removeAttribute(attrName === 'readOnly' ? 'readonly' : attrName); } catch { /* ignore */ }
+  const normalized = (attrName === 'readOnly' || attrName === 'read-only') ? 'readonly' : attrName;
+  try { el.removeAttribute(normalized); } catch { /* ignore */ }
 }
 
 export function applyAttrs(el, attrs) {

--- a/lib/blinx.present.js
+++ b/lib/blinx.present.js
@@ -1,0 +1,103 @@
+// Minimal, schema-driven "present" helpers.
+//
+// This module intentionally stays tiny:
+// - It only deals in DOM attributes/properties ("attrs")
+// - It does NOT attempt to cache present() results (safer; avoids staleness bugs)
+// - It provides best-effort mapping for common HTML boolean attributes
+
+function isPlainObject(v) {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function normalizeAttrsBag(bag) {
+  return isPlainObject(bag) ? bag : null;
+}
+
+export function resolvePresent(presentFn, ctx, record, index) {
+  if (typeof presentFn !== 'function') return null;
+  const res = presentFn(ctx, record, index);
+  if (!res || !isPlainObject(res)) return null;
+  const attrs = normalizeAttrsBag(res.attrs);
+  if (!attrs) return null;
+  return { attrs };
+}
+
+function setBooleanAttr(el, attrName, enabled) {
+  if (!el) return;
+  if (attrName === 'hidden') {
+    el.hidden = !!enabled;
+    return;
+  }
+  if (attrName === 'disabled') {
+    if ('disabled' in el) el.disabled = !!enabled;
+    if (enabled) el.setAttribute('disabled', '');
+    else el.removeAttribute('disabled');
+    return;
+  }
+  if (attrName === 'required') {
+    if ('required' in el) el.required = !!enabled;
+    if (enabled) el.setAttribute('required', '');
+    else el.removeAttribute('required');
+    return;
+  }
+  if (attrName === 'readonly' || attrName === 'readOnly' || attrName === 'read-only') {
+    // Property uses camelCase, attribute uses lowercase.
+    if ('readOnly' in el) el.readOnly = !!enabled;
+    if (enabled) el.setAttribute('readonly', '');
+    else el.removeAttribute('readonly');
+    return;
+  }
+  // Generic boolean attribute.
+  if (enabled) el.setAttribute(attrName, '');
+  else el.removeAttribute(attrName);
+}
+
+function removeAttr(el, attrName) {
+  if (!el) return;
+  if (attrName === 'hidden') { el.hidden = false; return; }
+  if (attrName === 'disabled' && 'disabled' in el) el.disabled = false;
+  if (attrName === 'required' && 'required' in el) el.required = false;
+  if ((attrName === 'readonly' || attrName === 'readOnly' || attrName === 'read-only') && 'readOnly' in el) el.readOnly = false;
+  try { el.removeAttribute(attrName === 'readOnly' ? 'readonly' : attrName); } catch { /* ignore */ }
+}
+
+export function applyAttrs(el, attrs) {
+  const bag = normalizeAttrsBag(attrs);
+  if (!el || !bag) return;
+  for (const [rawKey, rawVal] of Object.entries(bag)) {
+    const key = String(rawKey);
+    const val = rawVal;
+    if (val === undefined || val === null || val === false) {
+      removeAttr(el, key);
+      continue;
+    }
+    const isDataOrAria = key.startsWith('data-') || key.startsWith('aria-');
+    const isKebab = key.includes('-');
+    if (val === true) {
+      // For data-/aria- attributes, boolean true should serialize as "true"
+      // (not an empty boolean attribute).
+      if (isDataOrAria) {
+        try { el.setAttribute(key, 'true'); } catch { /* ignore */ }
+      } else {
+        setBooleanAttr(el, key, true);
+      }
+      continue;
+    }
+    // Prefer setting as a property when it exists and the key is camelCase,
+    // but always set attributes for kebab-case (data-*, aria-*, etc.).
+    if (!isDataOrAria && !isKebab && key in el) {
+      try { el[key] = val; } catch { /* ignore */ }
+    }
+    try { el.setAttribute(isDataOrAria || isKebab ? key : key.toLowerCase(), String(val)); } catch { /* ignore */ }
+  }
+}
+
+export function bestEffortFindPart(root, part) {
+  if (!root || typeof root.querySelector !== 'function') return null;
+  if (part === 'input') return root.querySelector('input, textarea, select');
+  if (part === 'label') return root.querySelector('label');
+  if (part === 'error') return root.querySelector('.error');
+  if (part === 'help') return root.querySelector('.help, .hint, [data-help]');
+  return null;
+}
+

--- a/lib/blinx.table.js
+++ b/lib/blinx.table.js
@@ -7,6 +7,7 @@ export function blinxTable({
   pageSize = 20,
   onRowClick,
   controls,
+  context,
 }) {
   if (!store || typeof store.getModel !== 'function') {
     throw new Error('blinxTable requires a store that exposes getModel().');
@@ -35,6 +36,7 @@ export function blinxTable({
     actions: { create: true, deleteSelected: true },
     onItemClick: onRowClick ? ({ index }) => onRowClick(index) : null,
   };
+  if (Object.prototype.hasOwnProperty.call(args, 'context')) opts.context = context;
   if (Object.prototype.hasOwnProperty.call(args, 'controls')) opts.controls = controls;
 
   const { api } = blinxCollection(opts);


### PR DESCRIPTION
Adds `present()` and `rowPresent` hooks to the view schema to enable declarative, data-driven conditional DOM attributes for UI elements.

This implements a minimal abstraction for conditional UI behavior, addressing concerns about Blinx becoming a bloated policy engine. Instead of a large DSL, it provides hooks for adapters to apply standard HTML attributes (e.g., `hidden`, `readonly`) or custom `data-*` attributes, allowing browsers to enforce behavior where possible. `present()` functions are re-computed on record changes without caching to prevent staleness.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3ab9ff5-4313-41ae-987d-4c561a5315e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3ab9ff5-4313-41ae-987d-4c561a5315e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables declarative, attrs-only presentation for UI views with re-computation on refresh/record changes.
> 
> - Add `lib/blinx.present.js` with `resolvePresent`, `applyAttrs`, `bestEffortFindPart` and boolean-attr handling
> - Integrate `present()`/`rowPresent` across `blinxForm` and `blinxCollection` (table/cards/feed) to apply `attrs` to `section`, `field` parts (`cell/wrapper/root/label/input/error/help`), headers, cells, and rows; no caching
> - Add optional `context` arg propagated as `ctx` (`{ store, model, view, kind, ...context }`) to form/collection/table
> - Expose `parts: { wrapper, label, input, error }` from default adapter to support field-level `present()`
> - Update `blinxTable` to pass through resolved collection view and `context`
> - Tests: unit tests for `applyAttrs`; integration tests validating header/cell/row attrs and `readonly/hidden` behavior with record switching
> - Docs: new specs for model, data views, and UI views detailing view resolution and `present`/`rowPresent` semantics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6c022b40e9370baacb21c727474f5af1f247a6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->