### PR TITLE
Schema validation enhancements

### DIFF
--- a/__tests__/blinx.validate.test.js
+++ b/__tests__/blinx.validate.test.js
@@ -1,4 +1,4 @@
-import { validateField } from '../lib/blinx.validate.js';
+import { coerceField, seedRecord, validateField, validateFieldAsync } from '../lib/blinx.validate.js';
 
 describe('validateField', () => {
   test('required: flags empty values including empty arrays', () => {
@@ -6,6 +6,11 @@ describe('validateField', () => {
     expect(validateField(null, { type: 'string', required: true })).toEqual(['This field is required.']);
     expect(validateField(undefined, { type: 'string', required: true })).toEqual(['This field is required.']);
     expect(validateField([], { type: 'array', required: true })).toEqual(['This field is required.']);
+  });
+
+  test('nullable: allows null when required', () => {
+    expect(validateField(null, { type: 'string', required: true, nullable: true })).toEqual([]);
+    expect(validateField(null, { type: 'number', required: true, nullable: true })).toEqual([]);
   });
 
   test('number: validates NaN and min/max bounds', () => {
@@ -17,11 +22,47 @@ describe('validateField', () => {
     expect(validateField('', { type: 'number', min: 0 })).toEqual([]);
   });
 
+  test('number: validates multipleOf/step, integerOnly, precision/scale', () => {
+    expect(validateField(1.5, { type: 'number', multipleOf: 1 })).toEqual(['Must be a multiple of 1.']);
+    expect(validateField(2, { type: 'number', step: 0.5 })).toEqual([]);
+    expect(validateField(2.25, { type: 'number', step: 0.5 })).toEqual(['Must be a multiple of 0.5.']);
+    expect(validateField(1.1, { type: 'number', integerOnly: true })).toEqual(['Must be an integer.']);
+    expect(validateField(12.345, { type: 'number', scale: 2 })).toEqual(['Max 2 decimal place(s).']);
+    expect(validateField(1234.56, { type: 'number', precision: 5, scale: 2 })).toEqual(['Max precision 5.']);
+  });
+
   test('string: validates length and pattern', () => {
     expect(validateField('a', { type: 'string', length: { min: 2 } })).toEqual(['Min length 2.']);
     expect(validateField('abcd', { type: 'string', length: { max: 3 } })).toEqual(['Max length 3.']);
     expect(validateField('abc', { type: 'string', pattern: '^[0-9]+$' })).toEqual(['Invalid format.']);
     expect(validateField('123', { type: 'string', pattern: '^[0-9]+$' })).toEqual([]);
+  });
+
+  test('string: validates exactLength/minLength/maxLength synonyms', () => {
+    expect(validateField('abc', { type: 'string', exactLength: 4 })).toEqual(['Length must be 4.']);
+    expect(validateField('a', { type: 'string', minLength: 2 })).toEqual(['Min length 2.']);
+    expect(validateField('abcd', { type: 'string', maxLength: 3 })).toEqual(['Max length 3.']);
+  });
+
+  test('string: validates built-in formats', () => {
+    expect(validateField('a@b.com', { type: 'string', format: 'email' })).toEqual([]);
+    expect(validateField('not-an-email', { type: 'string', format: 'email' })).toEqual(['Invalid format.']);
+    expect(validateField('https://example.com', { type: 'string', format: 'url' })).toEqual([]);
+    expect(validateField('example.com', { type: 'string', format: 'url' })).toEqual(['Invalid format.']);
+    expect(validateField('550e8400-e29b-41d4-a716-446655440000', { type: 'string', format: 'uuid' })).toEqual([]);
+    expect(validateField('not-a-uuid', { type: 'string', format: 'uuid' })).toEqual(['Invalid format.']);
+    expect(validateField('hello-world-1', { type: 'string', format: 'slug' })).toEqual([]);
+    expect(validateField('Hello World', { type: 'string', format: 'slug' })).toEqual(['Invalid format.']);
+  });
+
+  test('array: validates minItems/maxItems/uniqueItems and itemType recursively', () => {
+    expect(validateField(['a'], { type: 'array', minItems: 2 })).toEqual(['Must have at least 2 item(s).']);
+    expect(validateField(['a', 'b', 'c'], { type: 'array', maxItems: 2 })).toEqual(['Must have at most 2 item(s).']);
+    expect(validateField(['a', 'a'], { type: 'array', uniqueItems: true })).toEqual(['Items must be unique.']);
+    expect(validateField(['a', 1], { type: 'array', itemType: 'string' })[0]).toMatch(/^Item 2:/);
+    expect(
+      validateField([[1, 2], [3, 'x']], { type: 'array', itemType: { type: 'array', itemType: 'number' } })[0]
+    ).toMatch(/^Item 2:/);
   });
 
   test('enum: validates choices (truthy values only)', () => {
@@ -38,5 +79,41 @@ describe('validateField', () => {
 
     // Falsy values are treated as "unset".
     expect(validateField('', { type: 'date' })).toEqual([]);
+  });
+
+  test('date: validates minDate/maxDate and pastOnly/futureOnly', () => {
+    expect(validateField('2025-01-01', { type: 'date', minDate: '2025-02-01' })).toEqual(['Must be on/after 2025-02-01.']);
+    expect(validateField('2025-03-01', { type: 'date', maxDate: '2025-02-01' })).toEqual(['Must be on/before 2025-02-01.']);
+    expect(validateField('2999-01-01', { type: 'date', pastOnly: true })).toEqual(['Must be in the past.']);
+    expect(validateField('1999-01-01', { type: 'date', futureOnly: true })).toEqual(['Must be in the future.']);
+  });
+});
+
+describe('coerceField / seedRecord / custom validators', () => {
+  test('coerceField: trims and lowercases strings', () => {
+    expect(coerceField('  AbC  ', { type: 'string', trim: true, lowercase: true })).toBe('abc');
+  });
+
+  test('seedRecord: uses defaultValue/nullable and skips computed', () => {
+    const model = {
+      fields: {
+        a: { type: 'string', defaultValue: 'x' },
+        b: { type: 'string', nullable: true },
+        c: { type: 'number' },
+        d: { type: 'string', computed: true },
+      }
+    };
+    expect(seedRecord(model)).toEqual({ a: 'x', b: null, c: '' });
+  });
+
+  test('validateFieldAsync: supports sync validators and asyncValidators', async () => {
+    const def = {
+      type: 'string',
+      validators: [(v) => (v === 'bad' ? 'Nope.' : null)],
+      asyncValidators: [async (v) => (v === 'worse' ? 'Still nope.' : null)],
+    };
+    await expect(validateFieldAsync('bad', def)).resolves.toEqual(['Nope.']);
+    await expect(validateFieldAsync('worse', def)).resolves.toEqual(['Still nope.']);
+    await expect(validateFieldAsync('ok', def)).resolves.toEqual([]);
   });
 });

--- a/docs/spec/model.md
+++ b/docs/spec/model.md
@@ -44,15 +44,90 @@ In UI rendering, two additional structural types are supported:
 ### Validation / constraints (consumed by validation + default UI adapter)
 
 - **`required: boolean`**
+- **`nullable?: boolean`**  
+  If `true`, the value may explicitly be `null` even when `required: true`.  
+  (This distinguishes “must be present” from “may be empty/null”.)
 - **`readonly: boolean`**
-- **`length?: { max?: number, min?: number }`** (mostly used for strings)
-- **`min?: number` / `max?: number` / `step?: number`** (numbers)
-- **`values?: string[]`** (enums)
+- **`defaultValue?: any | (def)=>any`**  
+  Used when creating new records (see `seedRecord(...)` below).
+- **`coerce?: (value, def)=>any`**  
+  Runs before validation and before persisting UI values (default adapter also applies coercion on change/blur).
 - **`css?: string`** (default adapter uses this on the field wrapper)
+
+#### Strings (`type: DataTypes.string | DataTypes.longText | DataTypes.secret`)
+
+- **`length?: { max?: number, min?: number }`** (legacy shape; still supported)
+- **`minLength?: number` / `maxLength?: number`** (synonyms)
+- **`exactLength?: number`** (identifiers that must be a specific size)
+- **`pattern?: string | RegExp`** (regex validation)
+- **`format?: 'email' | 'url' | 'uuid' | 'slug'`** (built-in patterns to avoid inline regex)
+- **`trim?: boolean` / `lowercase?: boolean`** (string normalization, applied via coercion)
+
+#### Numbers (`type: DataTypes.number`)
+
+- **`min?: number` / `max?: number`**
+- **`step?: number` / `multipleOf?: number`** (data validation; not just HTML attributes)
+- **`integerOnly?: boolean`**
+- **`precision?: number` / `scale?: number`** (decimal precision + decimal places)
+
+#### Dates (`type: DataTypes.date` or `type: 'datetime'`)
+
+- **`minDate?: string | Date` / `maxDate?: string | Date`**
+- **`pastOnly?: boolean` / `futureOnly?: boolean`**
+
+#### Arrays (`type: DataTypes.array`)
+
+- **`minItems?: number` / `maxItems?: number`**
+- **`uniqueItems?: boolean`**
+- **`itemType?: string | FieldDef`**  
+  Enforced **recursively** so arrays stay homogeneous (supports nested arrays too).
+
+#### Enums (`type: DataTypes.enum`)
+
+- **`values?: string[]`**
+
+#### Custom validation hooks
+
+- **`validators?: Array<(value, def)=> (string | string[] | null | undefined)>`**  
+  Synchronous, domain-specific rules.
+- **`asyncValidators?: Array<(value, def)=> (Promise<string|string[]|null|undefined> | string | string[] | null | undefined)>`**  
+  Async checks (e.g. uniqueness against a service). Used by `validateFieldAsync(...)` and by form save validation.
 
 Notes:
 - Validation runs through `validateField(value, def)` in `lib/blinx.validate.js`.
+- Async validation runs through `validateFieldAsync(value, def)` in `lib/blinx.validate.js`.
 - Computed fields are always treated as read-only by the store (cannot be set via `setField`).
+
+### Seeding new records (defaults)
+
+When `blinxForm` creates a new record, it uses `seedRecord(model)` from `lib/blinx.validate.js`.
+This seeds every non-computed field using:
+
+- `defaultValue` (if present; function is called)
+- otherwise `null` for `nullable: true`
+- otherwise a type default (e.g. `[]` for arrays, `false` for booleans, `''` for most others)
+
+Example:
+
+```js
+import { DataTypes } from '../../lib/blinx.store.js';
+
+const ProductModel = {
+  id: 'Product',
+  fields: {
+    id: { type: DataTypes.string, required: true, exactLength: 6 },
+    email: { type: DataTypes.string, format: 'email', trim: true, lowercase: true },
+    tags: { type: DataTypes.array, itemType: DataTypes.string, minItems: 0, uniqueItems: true },
+    price: { type: DataTypes.number, min: 0, multipleOf: 0.01, precision: 10, scale: 2 },
+    releaseDate: { type: DataTypes.date, pastOnly: true, nullable: true },
+    sku: {
+      type: DataTypes.string,
+      validators: [(v) => (v && v.startsWith('SKU-') ? null : 'SKU must start with "SKU-".')],
+      asyncValidators: [async (v) => (await isUniqueSku(v) ? null : 'SKU already exists.')],
+    },
+  },
+};
+```
 
 ### Computed fields
 

--- a/lib/blinx.adapters.default.js
+++ b/lib/blinx.adapters.default.js
@@ -1,5 +1,5 @@
 
-import { validateField } from './blinx.validate.js';
+import { coerceField, validateField, validateFieldAsync } from './blinx.validate.js';
 
 export class BlinxDefaultUI {
   createField({ fieldKey, def, value, onChange }) {
@@ -36,15 +36,23 @@ export class BlinxDefaultUI {
       if (def.readonly || def.computed) el.setAttribute('readonly', 'true');
       if (def.required) el.setAttribute('required', 'true');
       el.addEventListener('change', () => {
-        const v = this.readValue(el, def);
+        const raw = this.readValue(el, def);
+        const v = coerceField(raw, def);
         const errs = validateField(v, def);
         setError(errs);
         onChange(v, errs);
+        // Best-effort async validation (does not block UI).
+        if (Array.isArray(def?.asyncValidators) && def.asyncValidators.length) {
+          validateFieldAsync(v, def).then(nextErrs => setError(nextErrs)).catch(() => {});
+        }
       });
       el.addEventListener('blur', () => {
-        const v = this.readValue(el, def);
+        const v = coerceField(this.readValue(el, def), def);
         const errs = validateField(v, def);
         setError(errs);
+        if (Array.isArray(def?.asyncValidators) && def.asyncValidators.length) {
+          validateFieldAsync(v, def).then(nextErrs => setError(nextErrs)).catch(() => {});
+        }
       });
     };
 

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -1,5 +1,5 @@
 
-import { validateField } from './blinx.validate.js';
+import { seedRecord, validateField, validateFieldAsync } from './blinx.validate.js';
 import { EventTypes } from './blinx.store.js';
 import { RegisteredUI } from './blinx.registered-ui.js';
 import { resolveComponentUIView, resolveModelUIView } from './blinx.ui-views.js';
@@ -616,17 +616,20 @@ export function blinxForm({
   async function validateAll() {
     const rec = store.getRecord(currentIndex);
     if (!rec) return true;
-    return view.sections.every(section =>
-      section.fields.every(f => {
+    for (const section of (view.sections || [])) {
+      for (const f of (section.fields || [])) {
         const key = typeof f === 'string' ? f : f.field;
         const def = model.fields[key];
-        if (!def) return true;
+        if (!def) continue;
         // Nested types are validated by their own sub-forms (if any).
-        if (def.type === 'model' || def.type === 'collection') return true;
-        if (def.computed) return true;
-        return validateField(rec[key], def).length === 0;
-      })
-    );
+        if (def.type === 'model' || def.type === 'collection') continue;
+        if (def.computed) continue;
+        const needsAsync = Array.isArray(def?.asyncValidators) && def.asyncValidators.length > 0;
+        const errs = needsAsync ? await validateFieldAsync(rec[key], def) : validateField(rec[key], def);
+        if (errs.length) return false;
+      }
+    }
+    return true;
   }
 
   function rebind(newIndex, options = {}) {
@@ -702,8 +705,7 @@ export function blinxForm({
 
   async function doReset() { await runInternalChange(() => store.reset()); buildSections(); updateIndicator(); setStatus('Reset done.', '#4a5568'); }
   async function doCreate() {
-    const keys = Object.keys(model.fields || {}).filter(k => !model?.fields?.[k]?.computed);
-    const idx = runInternalChange(() => store.addRecord(Object.fromEntries(keys.map(k => [k, '']))));
+    const idx = runInternalChange(() => store.addRecord(seedRecord(model)));
     rebind(idx);
     setStatus('New record created.', '#2f855a');
   }

--- a/lib/blinx.validate.js
+++ b/lib/blinx.validate.js
@@ -1,23 +1,314 @@
 
-export function validateField(value, def) {
+function isPromiseLike(v) {
+  return v && (typeof v === 'object' || typeof v === 'function') && typeof v.then === 'function';
+}
+
+function isUnsetValue(value) {
+  return value === undefined || value === '';
+}
+
+function stableStringify(value) {
+  if (value === null) return 'null';
+  const t = typeof value;
+  if (t === 'string') return JSON.stringify(value);
+  if (t === 'number') return Number.isFinite(value) ? `n:${String(value)}` : `n:${String(value)}`;
+  if (t === 'boolean') return `b:${value ? '1' : '0'}`;
+  if (t === 'bigint') return `bi:${String(value)}`;
+  if (t === 'undefined') return 'u:';
+  if (Array.isArray(value)) return `a:[${value.map(stableStringify).join(',')}]`;
+  if (t === 'object') {
+    const keys = Object.keys(value).sort();
+    return `o:{${keys.map(k => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(',')}}`;
+  }
+  return `x:${String(value)}`;
+}
+
+function toPlainDecimalString(n) {
+  // Converts number to non-exponent form for digit counting.
+  if (!Number.isFinite(n)) return String(n);
+  const s = String(n);
+  if (!/e/i.test(s)) return s;
+  const sign = n < 0 ? '-' : '';
+  const [coeffRaw, expRaw] = s.replace('-', '').split(/e/i);
+  const exp = Number(expRaw);
+  const [intPart, fracPart = ''] = coeffRaw.split('.');
+  const digits = (intPart + fracPart).replace(/^0+/, '') || '0';
+  const dotPos = intPart.length;
+  const newDot = dotPos + exp;
+  if (newDot <= 0) {
+    return `${sign}0.${'0'.repeat(Math.abs(newDot))}${digits}`;
+  }
+  if (newDot >= digits.length) {
+    return `${sign}${digits}${'0'.repeat(newDot - digits.length)}`;
+  }
+  return `${sign}${digits.slice(0, newDot)}.${digits.slice(newDot)}`;
+}
+
+function isMultipleOf(n, step) {
+  if (!Number.isFinite(n) || !Number.isFinite(step) || step === 0) return false;
+  const q = n / step;
+  const nearest = Math.round(q);
+  return Math.abs(q - nearest) <= 1e-12;
+}
+
+function parseDateLike(value) {
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isNaN(t) ? null : t;
+  }
+  const d = new Date(value);
+  const t = d.getTime();
+  return Number.isNaN(t) ? null : t;
+}
+
+const FORMAT_CHECKS = {
+  email: v => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v),
+  url: v => { try { new URL(v); return true; } catch { return false; } },
+  uuid: v => /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v),
+  slug: v => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(v),
+};
+
+function normalizeStringLength(def = {}) {
+  const min = def.minLength ?? def.length?.min;
+  const max = def.maxLength ?? def.length?.max;
+  const exact = def.exactLength ?? def.length?.exact;
+  return { min, max, exact };
+}
+
+function normalizeItemDef(def = {}) {
+  const it = def.itemType;
+  if (!it) return null;
+  if (typeof it === 'string') return { type: it };
+  if (it && typeof it === 'object') return it;
+  return null;
+}
+
+export function coerceField(value, def = {}) {
+  let v = value;
+  if (!def || typeof def !== 'object') return v;
+
+  if (v === null || v === undefined) return v;
+
+  if ((def.type === 'string' || def.type === 'longText' || def.type === 'secret') && typeof v === 'string') {
+    if (def.trim) v = v.trim();
+    if (def.lowercase) v = v.toLowerCase();
+  }
+
+  if (typeof def.coerce === 'function') {
+    try { v = def.coerce(v, def); } catch { /* ignore coercion errors */ }
+  }
+
+  // Optional, lightweight built-in coercions by type.
+  if (def.type === 'number' && typeof v === 'string' && v !== '') {
+    const n = Number(v);
+    if (!Number.isNaN(n)) v = n;
+  }
+
+  return v;
+}
+
+function runCustomValidatorsSync(value, def, errors) {
+  const validators = Array.isArray(def?.validators) ? def.validators : [];
+  for (const fn of validators) {
+    if (typeof fn !== 'function') continue;
+    try {
+      const res = fn(value, def);
+      if (typeof res === 'string' && res) errors.push(res);
+      else if (Array.isArray(res)) errors.push(...res.filter(Boolean).map(String));
+    } catch (e) {
+      errors.push('Invalid value.');
+    }
+  }
+}
+
+async function runCustomValidatorsAsync(value, def, errors) {
+  const validators = Array.isArray(def?.asyncValidators) ? def.asyncValidators : [];
+  for (const fn of validators) {
+    if (typeof fn !== 'function') continue;
+    try {
+      const res = fn(value, def);
+      const out = isPromiseLike(res) ? await res : res;
+      if (typeof out === 'string' && out) errors.push(out);
+      else if (Array.isArray(out)) errors.push(...out.filter(Boolean).map(String));
+    } catch (e) {
+      errors.push('Invalid value.');
+    }
+  }
+}
+
+export function validateField(value, def = {}) {
   const errors = [];
-  if (def.required) {
-    const empty = value === null || value === undefined || value === '' || (Array.isArray(value) && value.length === 0);
+  const d = def && typeof def === 'object' ? def : {};
+  const v = coerceField(value, d);
+
+  // Required / nullable
+  if (d.required) {
+    const emptyArray = Array.isArray(v) && v.length === 0;
+    const empty = isUnsetValue(v) || emptyArray || (v === null && d.nullable !== true);
     if (empty) errors.push('This field is required.');
   }
-  if (def.type === 'number' && value !== '' && value !== null && value !== undefined) {
-    const n = Number(value);
+
+  // Treat null/undefined/'' as "unset" for constraint checks (unless required already failed).
+  if (v === null || isUnsetValue(v)) {
+    runCustomValidatorsSync(v, d, errors);
+    return errors;
+  }
+
+  // Array constraints + recursive itemType
+  if (d.type === 'array') {
+    if (!Array.isArray(v)) {
+      errors.push('Must be an array.');
+      runCustomValidatorsSync(v, d, errors);
+      return errors;
+    }
+    if (d.minItems !== undefined && v.length < d.minItems) errors.push(`Must have at least ${d.minItems} item(s).`);
+    if (d.maxItems !== undefined && v.length > d.maxItems) errors.push(`Must have at most ${d.maxItems} item(s).`);
+    if (d.uniqueItems) {
+      const seen = new Set();
+      for (const item of v) {
+        const key = stableStringify(item);
+        if (seen.has(key)) { errors.push('Items must be unique.'); break; }
+        seen.add(key);
+      }
+    }
+    const itemDef = normalizeItemDef(d);
+    if (itemDef) {
+      for (let i = 0; i < v.length; i++) {
+        const itemErrs = validateField(v[i], itemDef);
+        if (itemErrs.length) errors.push(`Item ${i + 1}: ${itemErrs.join(' ')}`);
+      }
+    }
+    runCustomValidatorsSync(v, d, errors);
+    return errors;
+  }
+
+  // Number constraints (step/multipleOf, integerOnly, precision/scale)
+  if (d.type === 'number') {
+    const n = (typeof v === 'number') ? v : Number(v);
     if (Number.isNaN(n)) errors.push('Must be a number.');
-    if (def.min !== undefined && n < def.min) errors.push(`Must be ≥ ${def.min}.`);
-    if (def.max !== undefined && n > def.max) errors.push(`Must be ≤ ${def.max}.`);
+    else {
+      if (d.min !== undefined && n < d.min) errors.push(`Must be ≥ ${d.min}.`);
+      if (d.max !== undefined && n > d.max) errors.push(`Must be ≤ ${d.max}.`);
+      if (d.integerOnly && !Number.isInteger(n)) errors.push('Must be an integer.');
+      const step = d.multipleOf ?? d.step;
+      if (step !== undefined && !Number.isNaN(Number(step))) {
+        const s = Number(step);
+        if (!isMultipleOf(n, s)) errors.push(`Must be a multiple of ${s}.`);
+      }
+      if (d.scale !== undefined || d.precision !== undefined) {
+        const str = toPlainDecimalString(n).replace(/^-/, '');
+        const [ip, fp = ''] = str.split('.');
+        const digitsBefore = (ip || '0').replace(/^0+/, '') || '0';
+        const digitsAfter = fp.replace(/0+$/, ''); // value-normalized
+        const scale = d.scale !== undefined ? Number(d.scale) : undefined;
+        const precision = d.precision !== undefined ? Number(d.precision) : undefined;
+        if (scale !== undefined && Number.isFinite(scale) && digitsAfter.length > scale) {
+          errors.push(`Max ${scale} decimal place(s).`);
+        }
+        if (precision !== undefined && Number.isFinite(precision)) {
+          const totalDigits = (digitsBefore === '0' ? 1 : digitsBefore.length) + digitsAfter.length;
+          if (totalDigits > precision) errors.push(`Max precision ${precision}.`);
+        }
+      }
+    }
+    runCustomValidatorsSync(v, d, errors);
+    return errors;
   }
-  if (def.type === 'string' && typeof value === 'string') {
-    const len = value.length;
-    if (def.length?.min !== undefined && len < def.length.min) errors.push(`Min length ${def.length.min}.`);
-    if (def.length?.max !== undefined && len > def.length.max) errors.push(`Max length ${def.length.max}.`);
-    if (def.pattern && !new RegExp(def.pattern).test(value)) errors.push('Invalid format.');
+
+  // Boolean type check
+  if (d.type === 'boolean') {
+    if (typeof v !== 'boolean') errors.push('Must be true/false.');
+    runCustomValidatorsSync(v, d, errors);
+    return errors;
   }
-  if (def.type === 'enum' && value && !def.values?.includes(value)) errors.push('Invalid choice.');
-  if (def.type === 'date' && value && isNaN(new Date(value).getTime())) errors.push('Invalid date.');
+
+  // Enum
+  if (d.type === 'enum') {
+    // Keep historic "falsy means unset" behavior for enums, unless explicitly required (handled above).
+    if (v && !d.values?.includes(v)) errors.push('Invalid choice.');
+    runCustomValidatorsSync(v, d, errors);
+    return errors;
+  }
+
+  // Date / datetime constraints
+  if (d.type === 'date' || d.type === 'datetime') {
+    // Keep historic "falsy means unset" behavior for date, unless required (handled above).
+    if (!v) {
+      runCustomValidatorsSync(v, d, errors);
+      return errors;
+    }
+    const t = parseDateLike(v);
+    if (t === null) errors.push('Invalid date.');
+    else {
+      const minT = d.minDate !== undefined ? parseDateLike(d.minDate) : null;
+      const maxT = d.maxDate !== undefined ? parseDateLike(d.maxDate) : null;
+      if (minT !== null && t < minT) errors.push(`Must be on/after ${String(d.minDate)}.`);
+      if (maxT !== null && t > maxT) errors.push(`Must be on/before ${String(d.maxDate)}.`);
+      const now = Date.now();
+      if (d.pastOnly && !(t < now)) errors.push('Must be in the past.');
+      if (d.futureOnly && !(t > now)) errors.push('Must be in the future.');
+    }
+    runCustomValidatorsSync(v, d, errors);
+    return errors;
+  }
+
+  // String constraints (format helpers, exactLength/minLength/maxLength)
+  if (d.type === 'string' || d.type === 'longText' || d.type === 'secret') {
+    if (typeof v !== 'string') {
+      errors.push('Must be a string.');
+      runCustomValidatorsSync(v, d, errors);
+      return errors;
+    }
+    const { min, max, exact } = normalizeStringLength(d);
+    if (exact !== undefined && v.length !== exact) errors.push(`Length must be ${exact}.`);
+    if (min !== undefined && v.length < min) errors.push(`Min length ${min}.`);
+    if (max !== undefined && v.length > max) errors.push(`Max length ${max}.`);
+
+    if (d.format && FORMAT_CHECKS[d.format]) {
+      if (!FORMAT_CHECKS[d.format](v)) errors.push('Invalid format.');
+    } else if (d.pattern) {
+      const re = d.pattern instanceof RegExp ? d.pattern : new RegExp(d.pattern);
+      if (!re.test(v)) errors.push('Invalid format.');
+    }
+
+    runCustomValidatorsSync(v, d, errors);
+    return errors;
+  }
+
+  // Default: custom validators only
+  runCustomValidatorsSync(v, d, errors);
   return errors;
+}
+
+export async function validateFieldAsync(value, def = {}) {
+  const errors = validateField(value, def);
+  await runCustomValidatorsAsync(coerceField(value, def), def, errors);
+  return errors;
+}
+
+export function defaultValueForField(def = {}) {
+  if (!def || typeof def !== 'object') return '';
+  if (Object.prototype.hasOwnProperty.call(def, 'defaultValue')) {
+    const dv = def.defaultValue;
+    if (typeof dv === 'function') {
+      try { return dv(def); } catch { return ''; }
+    }
+    return dv;
+  }
+  if (def.nullable) return null;
+  switch (def.type) {
+    case 'boolean': return false;
+    case 'array': return [];
+    default: return '';
+  }
+}
+
+export function seedRecord(model) {
+  const fields = model?.fields || {};
+  const rec = {};
+  for (const [k, def] of Object.entries(fields)) {
+    if (def?.computed) continue;
+    rec[k] = coerceField(defaultValueForField(def), def);
+  }
+  return rec;
 }


### PR DESCRIPTION
Implement comprehensive validation and coercion for arrays, numbers, dates, and strings, and add custom sync/async validator hooks.

This significantly enhances data integrity by enforcing detailed rules (e.g., `minItems`, `multipleOf`, `minDate`, `format`, `precision`, `nullable`) and providing extensible custom validation, moving beyond basic HTML attribute checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-482c074a-e6c7-4196-86b2-a28643f2c5df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-482c074a-e6c7-4196-86b2-a28643f2c5df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a richer validation + normalization layer and wires it through the UI and form lifecycle.
> 
> - **Validation engine (`lib/blinx.validate.js`)**: adds `coerceField`, `validateFieldAsync`, `seedRecord`, type-specific rules (string formats/patterns/lengths, number `min/max/multipleOf/step/integerOnly/precision/scale`, date `minDate/maxDate/pastOnly/futureOnly`, arrays `minItems/maxItems/uniqueItems/itemType` with recursive checks), `nullable`, and custom `validators`/`asyncValidators`.
> - **Default UI adapter**: applies `coerceField` on change/blur, performs immediate sync validation and best-effort async validation, shows errors inline.
> - **Form behavior**: `validateAll` awaits async validators where defined; `Create` now seeds new records via `seedRecord(model)`.
> - **Docs**: expands model spec with new constraints, coercion, async validation, and seeding semantics.
> - **Tests**: comprehensive unit tests covering new rules, coercion, seeding, and async validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c67d6c9cbf8b63c4768e0c62577cbae5d3338641. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->