### PR TITLE
Validation module refactor

### DIFF
--- a/__tests__/validate.modules.test.js
+++ b/__tests__/validate.modules.test.js
@@ -1,0 +1,42 @@
+import { validateArray } from '../lib/validate/array.js';
+import { validateDate } from '../lib/validate/date.js';
+import { validateNumber } from '../lib/validate/number.js';
+import { validateString } from '../lib/validate/string.js';
+import { validators } from '../lib/blinx.validate.js';
+
+describe('validate modules (direct imports)', () => {
+  test('validateString: enum behavior is preserved (truthy only)', () => {
+    expect(validateString('', { type: 'enum', values: ['A'] })).toEqual([]);
+    expect(validateString(0, { type: 'enum', values: ['A'] })).toEqual([]); // historic: falsy treated as unset
+    expect(validateString('X', { type: 'enum', values: ['A'] })).toEqual(['Invalid choice.']);
+  });
+
+  test('validateString: format/pattern checks', () => {
+    expect(validateString('a@b.com', { type: 'string', format: 'email' })).toEqual([]);
+    expect(validateString('abc', { type: 'string', pattern: '^[0-9]+$' })).toEqual(['Invalid format.']);
+  });
+
+  test('validateNumber: min/max and precision/scale', () => {
+    expect(validateNumber('abc', { type: 'number' })).toEqual(['Must be a number.']);
+    expect(validateNumber(1234.56, { type: 'number', precision: 5, scale: 2 })).toEqual(['Max precision 5.']);
+  });
+
+  test('validateDate: invalid and falsy-unset behavior', () => {
+    expect(validateDate('not-a-date', { type: 'date' })).toEqual(['Invalid date.']);
+    expect(validateDate(0, { type: 'date' })).toEqual([]); // historic: falsy treated as unset
+  });
+
+  test('validateArray: constraints and itemType recursion via callback', () => {
+    const validateItem = (v, d) => (d.type === 'string' && typeof v !== 'string' ? ['Must be a string.'] : []);
+    expect(validateArray(['a', 'a'], { type: 'array', uniqueItems: true }, validateItem)).toEqual(['Items must be unique.']);
+    expect(validateArray([1], { type: 'array', itemType: 'string' }, validateItem)).toEqual(['Item 1: Must be a string.']);
+  });
+});
+
+describe('blinx.validate façade exports', () => {
+  test('exports validators map with {string, number, date, array}', () => {
+    expect(Object.keys(validators).sort()).toEqual(['array', 'date', 'number', 'string']);
+    expect(validators.string('x', { type: 'string', minLength: 2 })).toEqual(['Min length 2.']);
+  });
+});
+

--- a/lib/blinx.validate.js
+++ b/lib/blinx.validate.js
@@ -1,140 +1,11 @@
-
-function isPromiseLike(v) {
-  return v && (typeof v === 'object' || typeof v === 'function') && typeof v.then === 'function';
-}
-
-function isUnsetValue(value) {
-  return value === undefined || value === '';
-}
-
-function stableStringify(value) {
-  if (value === null) return 'null';
-  const t = typeof value;
-  if (t === 'string') return JSON.stringify(value);
-  if (t === 'number') return Number.isFinite(value) ? `n:${String(value)}` : `n:${String(value)}`;
-  if (t === 'boolean') return `b:${value ? '1' : '0'}`;
-  if (t === 'bigint') return `bi:${String(value)}`;
-  if (t === 'undefined') return 'u:';
-  if (Array.isArray(value)) return `a:[${value.map(stableStringify).join(',')}]`;
-  if (t === 'object') {
-    const keys = Object.keys(value).sort();
-    return `o:{${keys.map(k => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(',')}}`;
-  }
-  return `x:${String(value)}`;
-}
-
-function toPlainDecimalString(n) {
-  // Converts number to non-exponent form for digit counting.
-  if (!Number.isFinite(n)) return String(n);
-  const s = String(n);
-  if (!/e/i.test(s)) return s;
-  const sign = n < 0 ? '-' : '';
-  const [coeffRaw, expRaw] = s.replace('-', '').split(/e/i);
-  const exp = Number(expRaw);
-  const [intPart, fracPart = ''] = coeffRaw.split('.');
-  const digits = (intPart + fracPart).replace(/^0+/, '') || '0';
-  const dotPos = intPart.length;
-  const newDot = dotPos + exp;
-  if (newDot <= 0) {
-    return `${sign}0.${'0'.repeat(Math.abs(newDot))}${digits}`;
-  }
-  if (newDot >= digits.length) {
-    return `${sign}${digits}${'0'.repeat(newDot - digits.length)}`;
-  }
-  return `${sign}${digits.slice(0, newDot)}.${digits.slice(newDot)}`;
-}
-
-function isMultipleOf(n, step) {
-  if (!Number.isFinite(n) || !Number.isFinite(step) || step === 0) return false;
-  const q = n / step;
-  const nearest = Math.round(q);
-  return Math.abs(q - nearest) <= 1e-12;
-}
-
-function parseDateLike(value) {
-  if (value instanceof Date) {
-    const t = value.getTime();
-    return Number.isNaN(t) ? null : t;
-  }
-  const d = new Date(value);
-  const t = d.getTime();
-  return Number.isNaN(t) ? null : t;
-}
-
-const FORMAT_CHECKS = {
-  email: v => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v),
-  url: v => { try { new URL(v); return true; } catch { return false; } },
-  uuid: v => /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(v),
-  slug: v => /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(v),
-};
-
-function normalizeStringLength(def = {}) {
-  const min = def.minLength ?? def.length?.min;
-  const max = def.maxLength ?? def.length?.max;
-  const exact = def.exactLength ?? def.length?.exact;
-  return { min, max, exact };
-}
-
-function normalizeItemDef(def = {}) {
-  const it = def.itemType;
-  if (!it) return null;
-  if (typeof it === 'string') return { type: it };
-  if (it && typeof it === 'object') return it;
-  return null;
-}
-
-export function coerceField(value, def = {}) {
-  let v = value;
-  if (!def || typeof def !== 'object') return v;
-
-  if (v === null || v === undefined) return v;
-
-  if ((def.type === 'string' || def.type === 'longText' || def.type === 'secret') && typeof v === 'string') {
-    if (def.trim) v = v.trim();
-    if (def.lowercase) v = v.toLowerCase();
-  }
-
-  if (typeof def.coerce === 'function') {
-    try { v = def.coerce(v, def); } catch { /* ignore coercion errors */ }
-  }
-
-  // Optional, lightweight built-in coercions by type.
-  if (def.type === 'number' && typeof v === 'string' && v !== '') {
-    const n = Number(v);
-    if (!Number.isNaN(n)) v = n;
-  }
-
-  return v;
-}
-
-function runCustomValidatorsSync(value, def, errors) {
-  const validators = Array.isArray(def?.validators) ? def.validators : [];
-  for (const fn of validators) {
-    if (typeof fn !== 'function') continue;
-    try {
-      const res = fn(value, def);
-      if (typeof res === 'string' && res) errors.push(res);
-      else if (Array.isArray(res)) errors.push(...res.filter(Boolean).map(String));
-    } catch (e) {
-      errors.push('Invalid value.');
-    }
-  }
-}
-
-async function runCustomValidatorsAsync(value, def, errors) {
-  const validators = Array.isArray(def?.asyncValidators) ? def.asyncValidators : [];
-  for (const fn of validators) {
-    if (typeof fn !== 'function') continue;
-    try {
-      const res = fn(value, def);
-      const out = isPromiseLike(res) ? await res : res;
-      if (typeof out === 'string' && out) errors.push(out);
-      else if (Array.isArray(out)) errors.push(...out.filter(Boolean).map(String));
-    } catch (e) {
-      errors.push('Invalid value.');
-    }
-  }
-}
+import { MUST_BE_BOOLEAN_MESSAGE } from './validate/constants.js';
+import { isUnsetValue, runCustomValidatorsAsync, runCustomValidatorsSync, validateRequired } from './validate/base.js';
+import { coerceField } from './validate/coerce.js';
+import { validateArray } from './validate/array.js';
+import { validateDate } from './validate/date.js';
+import { validateNumber } from './validate/number.js';
+import { validateString } from './validate/string.js';
+import { defaultValueForField, seedRecord } from './validate/seed.js';
 
 export function validateField(value, def = {}) {
   const errors = [];
@@ -142,11 +13,7 @@ export function validateField(value, def = {}) {
   const v = coerceField(value, d);
 
   // Required / nullable
-  if (d.required) {
-    const emptyArray = Array.isArray(v) && v.length === 0;
-    const empty = isUnsetValue(v) || emptyArray || (v === null && d.nullable !== true);
-    if (empty) errors.push('This field is required.');
-  }
+  errors.push(...validateRequired(v, d));
 
   // Treat null/undefined/'' as "unset" for constraint checks (unless required already failed).
   if (v === null || isUnsetValue(v)) {
@@ -154,128 +21,14 @@ export function validateField(value, def = {}) {
     return errors;
   }
 
-  // Array constraints + recursive itemType
-  if (d.type === 'array') {
-    if (!Array.isArray(v)) {
-      errors.push('Must be an array.');
-      runCustomValidatorsSync(v, d, errors);
-      return errors;
-    }
-    if (d.minItems !== undefined && v.length < d.minItems) errors.push(`Must have at least ${d.minItems} item(s).`);
-    if (d.maxItems !== undefined && v.length > d.maxItems) errors.push(`Must have at most ${d.maxItems} item(s).`);
-    if (d.uniqueItems) {
-      const seen = new Set();
-      for (const item of v) {
-        const key = stableStringify(item);
-        if (seen.has(key)) { errors.push('Items must be unique.'); break; }
-        seen.add(key);
-      }
-    }
-    const itemDef = normalizeItemDef(d);
-    if (itemDef) {
-      for (let i = 0; i < v.length; i++) {
-        const itemErrs = validateField(v[i], itemDef);
-        if (itemErrs.length) errors.push(`Item ${i + 1}: ${itemErrs.join(' ')}`);
-      }
-    }
-    runCustomValidatorsSync(v, d, errors);
-    return errors;
-  }
+  // Type dispatch
+  if (d.type === 'array') errors.push(...validateArray(v, d, validateField));
+  else if (d.type === 'number') errors.push(...validateNumber(v, d));
+  else if (d.type === 'boolean') { if (typeof v !== 'boolean') errors.push(MUST_BE_BOOLEAN_MESSAGE); }
+  else if (d.type === 'enum') errors.push(...validateString(v, d));
+  else if (d.type === 'date' || d.type === 'datetime') errors.push(...validateDate(v, d));
+  else if (d.type === 'string' || d.type === 'longText' || d.type === 'secret') errors.push(...validateString(v, d));
 
-  // Number constraints (step/multipleOf, integerOnly, precision/scale)
-  if (d.type === 'number') {
-    const n = (typeof v === 'number') ? v : Number(v);
-    if (Number.isNaN(n)) errors.push('Must be a number.');
-    else {
-      if (d.min !== undefined && n < d.min) errors.push(`Must be ≥ ${d.min}.`);
-      if (d.max !== undefined && n > d.max) errors.push(`Must be ≤ ${d.max}.`);
-      if (d.integerOnly && !Number.isInteger(n)) errors.push('Must be an integer.');
-      const step = d.multipleOf ?? d.step;
-      if (step !== undefined && !Number.isNaN(Number(step))) {
-        const s = Number(step);
-        if (!isMultipleOf(n, s)) errors.push(`Must be a multiple of ${s}.`);
-      }
-      if (d.scale !== undefined || d.precision !== undefined) {
-        const str = toPlainDecimalString(n).replace(/^-/, '');
-        const [ip, fp = ''] = str.split('.');
-        const digitsBefore = (ip || '0').replace(/^0+/, '') || '0';
-        const digitsAfter = fp.replace(/0+$/, ''); // value-normalized
-        const scale = d.scale !== undefined ? Number(d.scale) : undefined;
-        const precision = d.precision !== undefined ? Number(d.precision) : undefined;
-        if (scale !== undefined && Number.isFinite(scale) && digitsAfter.length > scale) {
-          errors.push(`Max ${scale} decimal place(s).`);
-        }
-        if (precision !== undefined && Number.isFinite(precision)) {
-          const totalDigits = (digitsBefore === '0' ? 1 : digitsBefore.length) + digitsAfter.length;
-          if (totalDigits > precision) errors.push(`Max precision ${precision}.`);
-        }
-      }
-    }
-    runCustomValidatorsSync(v, d, errors);
-    return errors;
-  }
-
-  // Boolean type check
-  if (d.type === 'boolean') {
-    if (typeof v !== 'boolean') errors.push('Must be true/false.');
-    runCustomValidatorsSync(v, d, errors);
-    return errors;
-  }
-
-  // Enum
-  if (d.type === 'enum') {
-    // Keep historic "falsy means unset" behavior for enums, unless explicitly required (handled above).
-    if (v && !d.values?.includes(v)) errors.push('Invalid choice.');
-    runCustomValidatorsSync(v, d, errors);
-    return errors;
-  }
-
-  // Date / datetime constraints
-  if (d.type === 'date' || d.type === 'datetime') {
-    // Keep historic "falsy means unset" behavior for date, unless required (handled above).
-    if (!v) {
-      runCustomValidatorsSync(v, d, errors);
-      return errors;
-    }
-    const t = parseDateLike(v);
-    if (t === null) errors.push('Invalid date.');
-    else {
-      const minT = d.minDate !== undefined ? parseDateLike(d.minDate) : null;
-      const maxT = d.maxDate !== undefined ? parseDateLike(d.maxDate) : null;
-      if (minT !== null && t < minT) errors.push(`Must be on/after ${String(d.minDate)}.`);
-      if (maxT !== null && t > maxT) errors.push(`Must be on/before ${String(d.maxDate)}.`);
-      const now = Date.now();
-      if (d.pastOnly && !(t < now)) errors.push('Must be in the past.');
-      if (d.futureOnly && !(t > now)) errors.push('Must be in the future.');
-    }
-    runCustomValidatorsSync(v, d, errors);
-    return errors;
-  }
-
-  // String constraints (format helpers, exactLength/minLength/maxLength)
-  if (d.type === 'string' || d.type === 'longText' || d.type === 'secret') {
-    if (typeof v !== 'string') {
-      errors.push('Must be a string.');
-      runCustomValidatorsSync(v, d, errors);
-      return errors;
-    }
-    const { min, max, exact } = normalizeStringLength(d);
-    if (exact !== undefined && v.length !== exact) errors.push(`Length must be ${exact}.`);
-    if (min !== undefined && v.length < min) errors.push(`Min length ${min}.`);
-    if (max !== undefined && v.length > max) errors.push(`Max length ${max}.`);
-
-    if (d.format && FORMAT_CHECKS[d.format]) {
-      if (!FORMAT_CHECKS[d.format](v)) errors.push('Invalid format.');
-    } else if (d.pattern) {
-      const re = d.pattern instanceof RegExp ? d.pattern : new RegExp(d.pattern);
-      if (!re.test(v)) errors.push('Invalid format.');
-    }
-
-    runCustomValidatorsSync(v, d, errors);
-    return errors;
-  }
-
-  // Default: custom validators only
   runCustomValidatorsSync(v, d, errors);
   return errors;
 }
@@ -286,29 +39,11 @@ export async function validateFieldAsync(value, def = {}) {
   return errors;
 }
 
-export function defaultValueForField(def = {}) {
-  if (!def || typeof def !== 'object') return '';
-  if (Object.prototype.hasOwnProperty.call(def, 'defaultValue')) {
-    const dv = def.defaultValue;
-    if (typeof dv === 'function') {
-      try { return dv(def); } catch { return ''; }
-    }
-    return dv;
-  }
-  if (def.nullable) return null;
-  switch (def.type) {
-    case 'boolean': return false;
-    case 'array': return [];
-    default: return '';
-  }
-}
+export { coerceField, defaultValueForField, seedRecord };
 
-export function seedRecord(model) {
-  const fields = model?.fields || {};
-  const rec = {};
-  for (const [k, def] of Object.entries(fields)) {
-    if (def?.computed) continue;
-    rec[k] = coerceField(defaultValueForField(def), def);
-  }
-  return rec;
-}
+export const validators = {
+  string: (value, def = {}) => validateString(value, def),
+  number: (value, def = {}) => validateNumber(value, def),
+  date: (value, def = {}) => validateDate(value, def),
+  array: (value, def = {}) => validateArray(value, def, validateField),
+};

--- a/lib/validate/array.js
+++ b/lib/validate/array.js
@@ -1,0 +1,56 @@
+import { ITEMS_MUST_BE_UNIQUE_MESSAGE, MUST_BE_ARRAY_MESSAGE } from './constants.js';
+
+function stableStringify(value) {
+  if (value === null) return 'null';
+  const t = typeof value;
+  if (t === 'string') return JSON.stringify(value);
+  if (t === 'number') return Number.isFinite(value) ? `n:${String(value)}` : `n:${String(value)}`;
+  if (t === 'boolean') return `b:${value ? '1' : '0'}`;
+  if (t === 'bigint') return `bi:${String(value)}`;
+  if (t === 'undefined') return 'u:';
+  if (Array.isArray(value)) return `a:[${value.map(stableStringify).join(',')}]`;
+  if (t === 'object') {
+    const keys = Object.keys(value).sort();
+    return `o:{${keys.map(k => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(',')}}`;
+  }
+  return `x:${String(value)}`;
+}
+
+function normalizeItemDef(def = {}) {
+  const it = def.itemType;
+  if (!it) return null;
+  if (typeof it === 'string') return { type: it };
+  if (it && typeof it === 'object') return it;
+  return null;
+}
+
+export function validateArray(value, def = {}, validateField) {
+  const errors = [];
+  if (!Array.isArray(value)) {
+    errors.push(MUST_BE_ARRAY_MESSAGE);
+    return errors;
+  }
+
+  if (def.minItems !== undefined && value.length < def.minItems) errors.push(`Must have at least ${def.minItems} item(s).`);
+  if (def.maxItems !== undefined && value.length > def.maxItems) errors.push(`Must have at most ${def.maxItems} item(s).`);
+
+  if (def.uniqueItems) {
+    const seen = new Set();
+    for (const item of value) {
+      const key = stableStringify(item);
+      if (seen.has(key)) { errors.push(ITEMS_MUST_BE_UNIQUE_MESSAGE); break; }
+      seen.add(key);
+    }
+  }
+
+  const itemDef = normalizeItemDef(def);
+  if (itemDef && typeof validateField === 'function') {
+    for (let i = 0; i < value.length; i++) {
+      const itemErrs = validateField(value[i], itemDef);
+      if (itemErrs.length) errors.push(`Item ${i + 1}: ${itemErrs.join(' ')}`);
+    }
+  }
+
+  return errors;
+}
+

--- a/lib/validate/base.js
+++ b/lib/validate/base.js
@@ -1,0 +1,46 @@
+import { REQUIRED_MESSAGE } from './constants.js';
+
+export function isPromiseLike(v) {
+  return v && (typeof v === 'object' || typeof v === 'function') && typeof v.then === 'function';
+}
+
+export function isUnsetValue(value) {
+  return value === undefined || value === '';
+}
+
+export function validateRequired(value, def = {}) {
+  if (!def?.required) return [];
+  const emptyArray = Array.isArray(value) && value.length === 0;
+  const empty = isUnsetValue(value) || emptyArray || (value === null && def.nullable !== true);
+  return empty ? [REQUIRED_MESSAGE] : [];
+}
+
+export function runCustomValidatorsSync(value, def, errors) {
+  const validators = Array.isArray(def?.validators) ? def.validators : [];
+  for (const fn of validators) {
+    if (typeof fn !== 'function') continue;
+    try {
+      const res = fn(value, def);
+      if (typeof res === 'string' && res) errors.push(res);
+      else if (Array.isArray(res)) errors.push(...res.filter(Boolean).map(String));
+    } catch {
+      errors.push('Invalid value.');
+    }
+  }
+}
+
+export async function runCustomValidatorsAsync(value, def, errors) {
+  const validators = Array.isArray(def?.asyncValidators) ? def.asyncValidators : [];
+  for (const fn of validators) {
+    if (typeof fn !== 'function') continue;
+    try {
+      const res = fn(value, def);
+      const out = isPromiseLike(res) ? await res : res;
+      if (typeof out === 'string' && out) errors.push(out);
+      else if (Array.isArray(out)) errors.push(...out.filter(Boolean).map(String));
+    } catch {
+      errors.push('Invalid value.');
+    }
+  }
+}
+

--- a/lib/validate/coerce.js
+++ b/lib/validate/coerce.js
@@ -1,0 +1,48 @@
+export function coerceString(value, def = {}) {
+  let v = value;
+  if (typeof v !== 'string') return v;
+  if (def.trim) v = v.trim();
+  if (def.lowercase) v = v.toLowerCase();
+  return v;
+}
+
+export function coerceNumber(value) {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string' && value !== '') {
+    const n = Number(value);
+    if (!Number.isNaN(n)) return n;
+  }
+  return value;
+}
+
+// Scaffold helpers for future use; not applied unless def.coerce does it.
+export function coerceDate(value) {
+  return value;
+}
+
+export function coerceArray(value) {
+  return value;
+}
+
+export function coerceField(value, def = {}) {
+  let v = value;
+  if (!def || typeof def !== 'object') return v;
+
+  if (v === null || v === undefined) return v;
+
+  if (def.type === 'string' || def.type === 'longText' || def.type === 'secret') {
+    v = coerceString(v, def);
+  }
+
+  if (typeof def.coerce === 'function') {
+    try { v = def.coerce(v, def); } catch { /* ignore coercion errors */ }
+  }
+
+  // Optional, lightweight built-in coercions by type.
+  if (def.type === 'number') {
+    v = coerceNumber(v);
+  }
+
+  return v;
+}
+

--- a/lib/validate/constants.js
+++ b/lib/validate/constants.js
@@ -1,0 +1,13 @@
+export const REQUIRED_MESSAGE = 'This field is required.';
+
+export const MUST_BE_ARRAY_MESSAGE = 'Must be an array.';
+export const MUST_BE_NUMBER_MESSAGE = 'Must be a number.';
+export const MUST_BE_INTEGER_MESSAGE = 'Must be an integer.';
+export const MUST_BE_BOOLEAN_MESSAGE = 'Must be true/false.';
+export const MUST_BE_STRING_MESSAGE = 'Must be a string.';
+
+export const INVALID_CHOICE_MESSAGE = 'Invalid choice.';
+export const INVALID_DATE_MESSAGE = 'Invalid date.';
+export const INVALID_FORMAT_MESSAGE = 'Invalid format.';
+
+export const ITEMS_MUST_BE_UNIQUE_MESSAGE = 'Items must be unique.';

--- a/lib/validate/date.js
+++ b/lib/validate/date.js
@@ -1,0 +1,36 @@
+import { INVALID_DATE_MESSAGE } from './constants.js';
+
+function parseDateLike(value) {
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isNaN(t) ? null : t;
+  }
+  const d = new Date(value);
+  const t = d.getTime();
+  return Number.isNaN(t) ? null : t;
+}
+
+export function validateDate(value, def = {}) {
+  const errors = [];
+
+  // Keep historic "falsy means unset" behavior for date/datetime (unless required already failed upstream).
+  if (!value) return errors;
+
+  const t = parseDateLike(value);
+  if (t === null) {
+    errors.push(INVALID_DATE_MESSAGE);
+    return errors;
+  }
+
+  const minT = def.minDate !== undefined ? parseDateLike(def.minDate) : null;
+  const maxT = def.maxDate !== undefined ? parseDateLike(def.maxDate) : null;
+  if (minT !== null && t < minT) errors.push(`Must be on/after ${String(def.minDate)}.`);
+  if (maxT !== null && t > maxT) errors.push(`Must be on/before ${String(def.maxDate)}.`);
+
+  const now = Date.now();
+  if (def.pastOnly && !(t < now)) errors.push('Must be in the past.');
+  if (def.futureOnly && !(t > now)) errors.push('Must be in the future.');
+
+  return errors;
+}
+

--- a/lib/validate/formats.js
+++ b/lib/validate/formats.js
@@ -1,0 +1,25 @@
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const FORMAT_CHECKS = {
+  email: v => EMAIL_RE.test(v),
+  url: v => { try { new URL(v); return true; } catch { return false; } },
+  uuid: v => UUID_RE.test(v),
+  slug: v => SLUG_RE.test(v),
+};
+
+const PATTERN_CACHE = new Map();
+
+export function compilePattern(pattern) {
+  if (pattern instanceof RegExp) return pattern;
+  if (typeof pattern !== 'string') return null;
+
+  if (PATTERN_CACHE.has(pattern)) return PATTERN_CACHE.get(pattern);
+
+  // Keep historic behavior: invalid patterns throw.
+  const re = new RegExp(pattern);
+  PATTERN_CACHE.set(pattern, re);
+  return re;
+}
+

--- a/lib/validate/number.js
+++ b/lib/validate/number.js
@@ -1,0 +1,63 @@
+import { MUST_BE_INTEGER_MESSAGE, MUST_BE_NUMBER_MESSAGE } from './constants.js';
+
+function toPlainDecimalString(n) {
+  // Converts number to non-exponent form for digit counting.
+  if (!Number.isFinite(n)) return String(n);
+  const s = String(n);
+  if (!/e/i.test(s)) return s;
+  const sign = n < 0 ? '-' : '';
+  const [coeffRaw, expRaw] = s.replace('-', '').split(/e/i);
+  const exp = Number(expRaw);
+  const [intPart, fracPart = ''] = coeffRaw.split('.');
+  const digits = (intPart + fracPart).replace(/^0+/, '') || '0';
+  const dotPos = intPart.length;
+  const newDot = dotPos + exp;
+  if (newDot <= 0) return `${sign}0.${'0'.repeat(Math.abs(newDot))}${digits}`;
+  if (newDot >= digits.length) return `${sign}${digits}${'0'.repeat(newDot - digits.length)}`;
+  return `${sign}${digits.slice(0, newDot)}.${digits.slice(newDot)}`;
+}
+
+function isMultipleOf(n, step) {
+  if (!Number.isFinite(n) || !Number.isFinite(step) || step === 0) return false;
+  const q = n / step;
+  const nearest = Math.round(q);
+  return Math.abs(q - nearest) <= 1e-12;
+}
+
+export function validateNumber(value, def = {}) {
+  const errors = [];
+  const n = (typeof value === 'number') ? value : Number(value);
+  if (Number.isNaN(n)) {
+    errors.push(MUST_BE_NUMBER_MESSAGE);
+    return errors;
+  }
+
+  if (def.min !== undefined && n < def.min) errors.push(`Must be ≥ ${def.min}.`);
+  if (def.max !== undefined && n > def.max) errors.push(`Must be ≤ ${def.max}.`);
+  if (def.integerOnly && !Number.isInteger(n)) errors.push(MUST_BE_INTEGER_MESSAGE);
+
+  const step = def.multipleOf ?? def.step;
+  if (step !== undefined && !Number.isNaN(Number(step))) {
+    const s = Number(step);
+    if (!isMultipleOf(n, s)) errors.push(`Must be a multiple of ${s}.`);
+  }
+
+  if (def.scale !== undefined || def.precision !== undefined) {
+    const str = toPlainDecimalString(n).replace(/^-/, '');
+    const [ip, fp = ''] = str.split('.');
+    const digitsBefore = (ip || '0').replace(/^0+/, '') || '0';
+    const digitsAfter = fp.replace(/0+$/, ''); // value-normalized
+    const scale = def.scale !== undefined ? Number(def.scale) : undefined;
+    const precision = def.precision !== undefined ? Number(def.precision) : undefined;
+    if (scale !== undefined && Number.isFinite(scale) && digitsAfter.length > scale) {
+      errors.push(`Max ${scale} decimal place(s).`);
+    }
+    if (precision !== undefined && Number.isFinite(precision)) {
+      const totalDigits = (digitsBefore === '0' ? 1 : digitsBefore.length) + digitsAfter.length;
+      if (totalDigits > precision) errors.push(`Max precision ${precision}.`);
+    }
+  }
+
+  return errors;
+}
+

--- a/lib/validate/seed.js
+++ b/lib/validate/seed.js
@@ -1,0 +1,29 @@
+import { coerceField } from './coerce.js';
+
+export function defaultValueForField(def = {}) {
+  if (!def || typeof def !== 'object') return '';
+  if (Object.prototype.hasOwnProperty.call(def, 'defaultValue')) {
+    const dv = def.defaultValue;
+    if (typeof dv === 'function') {
+      try { return dv(def); } catch { return ''; }
+    }
+    return dv;
+  }
+  if (def.nullable) return null;
+  switch (def.type) {
+    case 'boolean': return false;
+    case 'array': return [];
+    default: return '';
+  }
+}
+
+export function seedRecord(model) {
+  const fields = model?.fields || {};
+  const rec = {};
+  for (const [k, def] of Object.entries(fields)) {
+    if (def?.computed) continue;
+    rec[k] = coerceField(defaultValueForField(def), def);
+  }
+  return rec;
+}
+

--- a/lib/validate/string.js
+++ b/lib/validate/string.js
@@ -1,0 +1,39 @@
+import { INVALID_CHOICE_MESSAGE, INVALID_FORMAT_MESSAGE, MUST_BE_STRING_MESSAGE } from './constants.js';
+import { compilePattern, FORMAT_CHECKS } from './formats.js';
+
+function normalizeStringLength(def = {}) {
+  const min = def.minLength ?? def.length?.min;
+  const max = def.maxLength ?? def.length?.max;
+  const exact = def.exactLength ?? def.length?.exact;
+  return { min, max, exact };
+}
+
+export function validateString(value, def = {}) {
+  const errors = [];
+
+  if (def.type === 'enum') {
+    // Keep historic "falsy means unset" behavior for enums (unless required already failed upstream).
+    if (value && !def.values?.includes(value)) errors.push(INVALID_CHOICE_MESSAGE);
+    return errors;
+  }
+
+  if (typeof value !== 'string') {
+    errors.push(MUST_BE_STRING_MESSAGE);
+    return errors;
+  }
+
+  const { min, max, exact } = normalizeStringLength(def);
+  if (exact !== undefined && value.length !== exact) errors.push(`Length must be ${exact}.`);
+  if (min !== undefined && value.length < min) errors.push(`Min length ${min}.`);
+  if (max !== undefined && value.length > max) errors.push(`Max length ${max}.`);
+
+  if (def.format && FORMAT_CHECKS[def.format]) {
+    if (!FORMAT_CHECKS[def.format](value)) errors.push(INVALID_FORMAT_MESSAGE);
+  } else if (def.pattern) {
+    const re = compilePattern(def.pattern);
+    if (re && !re.test(value)) errors.push(INVALID_FORMAT_MESSAGE);
+  }
+
+  return errors;
+}
+


### PR DESCRIPTION
Refactor `blinx.validate.js` into a modular structure with type-specific validators and helper modules.

This change isolates validation concerns per type (string, number, date, array, enum) and separates coercion/seeding logic, making the validation system easier to extend and maintain without touching unrelated code. The public API of `blinx.validate.js` remains identical, acting as a thin dispatcher to the new `lib/validate/*` modules, with all existing behaviors preserved and verified by passing tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-f30e1d86-b189-4e8a-abcb-ab4b6b4304d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f30e1d86-b189-4e8a-abcb-ab4b6b4304d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors validation into composable modules while keeping the facade API stable.
> 
> - Extracts type-specific validators and helpers into `lib/validate/{string,number,date,array}.js`, `coerce.js`, `base.js`, `formats.js`, `seed.js`, and `constants.js`
> - Updates `lib/blinx.validate.js` to dispatch by `type`, reuse shared logic (`validateRequired`, custom validators), and re-export `coerceField`, `defaultValueForField`, `seedRecord`
> - Adds `validators` map export with `{string, number, date, array}` and wires array item recursion via callback
> - Introduces `__tests__/validate.modules.test.js` validating enum/string/number/date/array behaviors and facade exports
> - Preserves historic behaviors (e.g., enum/date treat falsy as unset) and standardizes error messages via `constants`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f40f6338b436254ea429066ee0cad80907c7618f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->