### PR TITLE
Data type exploration and additions

### DIFF
--- a/__tests__/blinx.validate.test.js
+++ b/__tests__/blinx.validate.test.js
@@ -53,6 +53,14 @@ describe('validateField', () => {
     expect(validateField('not-a-uuid', { type: 'string', format: 'uuid' })).toEqual(['Invalid format.']);
     expect(validateField('hello-world-1', { type: 'string', format: 'slug' })).toEqual([]);
     expect(validateField('Hello World', { type: 'string', format: 'slug' })).toEqual(['Invalid format.']);
+    expect(validateField('+14155552671', { type: 'string', format: 'phone' })).toEqual([]);
+    expect(validateField('14155552671', { type: 'string', format: 'phone' })).toEqual(['Invalid format.']);
+    expect(validateField('+0123', { type: 'string', format: 'phone' })).toEqual(['Invalid format.']);
+  });
+
+  test('string: unknown format does not suppress pattern validation', () => {
+    expect(validateField('abc', { type: 'string', format: 'not-registered', pattern: '^[0-9]+$' })).toEqual(['Invalid format.']);
+    expect(validateField('123', { type: 'string', format: 'not-registered', pattern: '^[0-9]+$' })).toEqual([]);
   });
 
   test('array: validates minItems/maxItems/uniqueItems and itemType recursively', () => {

--- a/__tests__/validate.modules.test.js
+++ b/__tests__/validate.modules.test.js
@@ -2,7 +2,7 @@ import { validateArray } from '../lib/validate/array.js';
 import { validateDate } from '../lib/validate/date.js';
 import { validateNumber } from '../lib/validate/number.js';
 import { validateString } from '../lib/validate/string.js';
-import { validators } from '../lib/blinx.validate.js';
+import { registerFormat, validators } from '../lib/blinx.validate.js';
 
 describe('validate modules (direct imports)', () => {
   test('validateString: enum behavior is preserved (truthy only)', () => {
@@ -37,6 +37,13 @@ describe('blinx.validate façade exports', () => {
   test('exports validators map with {string, number, date, array}', () => {
     expect(Object.keys(validators).sort()).toEqual(['array', 'date', 'number', 'string']);
     expect(validators.string('x', { type: 'string', minLength: 2 })).toEqual(['Min length 2.']);
+  });
+
+  test('registerFormat: supports custom formats and trims keys', () => {
+    registerFormat('  __test_format_trim__  ', (v) => v === 'ok', { override: true });
+    expect(validators.string('ok', { type: 'string', format: '__test_format_trim__' })).toEqual([]);
+    expect(validators.string('ok', { type: 'string', format: '  __test_format_trim__  ' })).toEqual([]);
+    expect(validators.string('nope', { type: 'string', format: '__test_format_trim__' })).toEqual(['Invalid format.']);
   });
 });
 

--- a/docs/spec/model.md
+++ b/docs/spec/model.md
@@ -60,7 +60,7 @@ In UI rendering, two additional structural types are supported:
 - **`minLength?: number` / `maxLength?: number`** (synonyms)
 - **`exactLength?: number`** (identifiers that must be a specific size)
 - **`pattern?: string | RegExp`** (regex validation)
-- **`format?: 'email' | 'url' | 'uuid' | 'slug'`** (built-in patterns to avoid inline regex)
+- **`format?: 'email' | 'url' | 'uuid' | 'slug' | 'phone'`** (built-in patterns to avoid inline regex)
 - **`trim?: boolean` / `lowercase?: boolean`** (string normalization, applied via coercion)
 
 #### Numbers (`type: DataTypes.number`)

--- a/lib/blinx.validate.js
+++ b/lib/blinx.validate.js
@@ -6,6 +6,7 @@ import { validateDate } from './validate/date.js';
 import { validateNumber } from './validate/number.js';
 import { validateString } from './validate/string.js';
 import { defaultValueForField, seedRecord } from './validate/seed.js';
+import { registerFormat, getFormatCheck, FORMAT_CHECKS } from './validate/formats.js';
 
 export function validateField(value, def = {}) {
   const errors = [];
@@ -40,6 +41,7 @@ export async function validateFieldAsync(value, def = {}) {
 }
 
 export { coerceField, defaultValueForField, seedRecord };
+export { registerFormat, getFormatCheck, FORMAT_CHECKS };
 
 export const validators = {
   string: (value, def = {}) => validateString(value, def),

--- a/lib/validate/formats.js
+++ b/lib/validate/formats.js
@@ -14,7 +14,7 @@ export const FORMAT_CHECKS = {
 };
 
 export function getFormatCheck(name) {
-  const key = typeof name === 'string' ? name : null;
+  const key = typeof name === 'string' ? name.trim() : '';
   if (!key) return null;
   return FORMAT_CHECKS[key] || null;
 }

--- a/lib/validate/formats.js
+++ b/lib/validate/formats.js
@@ -1,13 +1,32 @@
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+// E.164: "+" followed by 2–15 digits; first digit cannot be 0.
+// Examples: +14155552671, +442071838750
+const PHONE_E164_RE = /^\+[1-9]\d{1,14}$/;
 
 export const FORMAT_CHECKS = {
   email: v => EMAIL_RE.test(v),
   url: v => { try { new URL(v); return true; } catch { return false; } },
   uuid: v => UUID_RE.test(v),
   slug: v => SLUG_RE.test(v),
+  phone: v => PHONE_E164_RE.test(v),
 };
+
+export function getFormatCheck(name) {
+  const key = typeof name === 'string' ? name : null;
+  if (!key) return null;
+  return FORMAT_CHECKS[key] || null;
+}
+
+export function registerFormat(name, check, { override = false } = {}) {
+  const key = typeof name === 'string' ? name.trim() : '';
+  if (!key) throw new Error('registerFormat: name must be a non-empty string.');
+  if (typeof check !== 'function') throw new Error('registerFormat: check must be a function.');
+  if (!override && FORMAT_CHECKS[key]) throw new Error(`registerFormat: format "${key}" is already registered.`);
+  FORMAT_CHECKS[key] = check;
+  return true;
+}
 
 const PATTERN_CACHE = new Map();
 

--- a/lib/validate/string.js
+++ b/lib/validate/string.js
@@ -1,5 +1,5 @@
 import { INVALID_CHOICE_MESSAGE, INVALID_FORMAT_MESSAGE, MUST_BE_STRING_MESSAGE } from './constants.js';
-import { compilePattern, FORMAT_CHECKS } from './formats.js';
+import { compilePattern, getFormatCheck } from './formats.js';
 
 function normalizeStringLength(def = {}) {
   const min = def.minLength ?? def.length?.min;
@@ -27,8 +27,9 @@ export function validateString(value, def = {}) {
   if (min !== undefined && value.length < min) errors.push(`Min length ${min}.`);
   if (max !== undefined && value.length > max) errors.push(`Max length ${max}.`);
 
-  if (def.format && FORMAT_CHECKS[def.format]) {
-    if (!FORMAT_CHECKS[def.format](value)) errors.push(INVALID_FORMAT_MESSAGE);
+  if (def.format) {
+    const check = getFormatCheck(def.format);
+    if (check && !check(value)) errors.push(INVALID_FORMAT_MESSAGE);
   } else if (def.pattern) {
     const re = compilePattern(def.pattern);
     if (re && !re.test(value)) errors.push(INVALID_FORMAT_MESSAGE);

--- a/lib/validate/string.js
+++ b/lib/validate/string.js
@@ -29,7 +29,13 @@ export function validateString(value, def = {}) {
 
   if (def.format) {
     const check = getFormatCheck(def.format);
-    if (check && !check(value)) errors.push(INVALID_FORMAT_MESSAGE);
+    if (check) {
+      if (!check(value)) errors.push(INVALID_FORMAT_MESSAGE);
+    } else if (def.pattern) {
+      // Preserve historic behavior: unknown format names should not suppress `pattern` validation.
+      const re = compilePattern(def.pattern);
+      if (re && !re.test(value)) errors.push(INVALID_FORMAT_MESSAGE);
+    }
   } else if (def.pattern) {
     const re = compilePattern(def.pattern);
     if (re && !re.test(value)) errors.push(INVALID_FORMAT_MESSAGE);


### PR DESCRIPTION
Add `string.format: 'phone'` and an extensible format registry to support E.164 validation and custom format definitions.

The extensible format registry allows teams to define custom string and number formats (e.g., `id`, `currency`, `markdown`) for validation and UI hints, preventing the need to add new primitive `DataTypes` for every specific intent.

---
<a href="https://cursor.com/background-agent?bcId=bc-f83e2d78-d946-49b0-b2c1-289dfd41ef67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f83e2d78-d946-49b0-b2c1-289dfd41ef67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces extensible format validation and a new built-in phone format.
> 
> - Adds E.164 `phone` check in `validate/formats.js` and updates docs to include `format: 'phone'`
> - Implements a pluggable format registry: `registerFormat`, `getFormatCheck`, and exposes `FORMAT_CHECKS`
> - Updates `validate/string.js` to resolve format checks via `getFormatCheck`, enabling custom formats
> - Re-exports registry APIs from `blinx.validate.js` for external use
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fd8805480f5116aae0e0ef2dd5fc195cbfc606f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->