### PR TITLE
Custom action management strategy

### DIFF
--- a/__tests__/blinx.action-registry.test.js
+++ b/__tests__/blinx.action-registry.test.js
@@ -1,0 +1,136 @@
+/** @jest-environment jsdom */
+
+import { blinxStore } from '../lib/blinx.store.js';
+import { blinxForm } from '../lib/blinx.form.js';
+import { blinxCollection } from '../lib/blinx.collection.js';
+
+function getToolbarButton(root, label) {
+  const toolbar = root.querySelector('.blinx-controls');
+  if (!toolbar) return null;
+  return Array.from(toolbar.querySelectorAll('button')).find(b => b.textContent === label) || null;
+}
+
+function getToolbarText(root) {
+  const toolbar = root.querySelector('.blinx-controls');
+  return toolbar ? toolbar.textContent : '';
+}
+
+describe('ActionRegistry + validation chain (custom controls)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('blinxForm: declarative action id runs validation chain and blocks handler on first failure', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+
+    const validate1 = jest.fn(async () => ({ ok: true }));
+    const validate2 = jest.fn(() => ({ ok: false, code: 'NOPE' }));
+    const handler = jest.fn(async () => {});
+
+    const actionRegistry = {
+      'external.ok': { validate: [validate1, validate2], handler },
+    };
+
+    blinxForm({
+      root,
+      store,
+      recordIndex: 0,
+      actionRegistry,
+      view: {
+        sections: [{ title: 'Main', columns: 1, fields: ['name'] }],
+        controls: {
+          // Provide a status area so blocked actions can show feedback.
+          saveStatus: true,
+          customInternal: {
+            label: 'Do',
+            action: { id: 'external.ok', payload: { result: 'ok' } },
+          },
+        },
+      },
+    });
+
+    getToolbarButton(root, 'Do')?.click();
+    // Click handlers are async; wait a tick for validation + status update.
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(validate1).toHaveBeenCalledTimes(1);
+    expect(validate2).toHaveBeenCalledTimes(1);
+    expect(handler).not.toHaveBeenCalled();
+    expect(getToolbarText(root)).toContain('Action "customInternal" blocked.');
+  });
+
+  test('blinxForm: declarative action id calls handler with payload when validation passes', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+
+    const validate1 = jest.fn(() => true);
+    const handler = jest.fn(async (_ctx, payload) => {
+      expect(payload).toEqual({ result: 'ok' });
+      return 'done';
+    });
+
+    const actionRegistry = {
+      'external.ok': { validate: [validate1], handler },
+    };
+
+    blinxForm({
+      root,
+      store,
+      recordIndex: 0,
+      actionRegistry,
+      view: {
+        sections: [{ title: 'Main', columns: 1, fields: ['name'] }],
+        controls: {
+          customInternal: {
+            label: 'Do',
+            action: { id: 'external.ok', payload: { result: 'ok' } },
+          },
+        },
+      },
+    });
+
+    getToolbarButton(root, 'Do')?.click();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(validate1).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('blinxCollection: declarative action id blocks handler and writes status when validation fails', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+
+    const validate = jest.fn(() => 'blocked');
+    const handler = jest.fn(async () => {});
+    const actionRegistry = {
+      'external.ok': { validate: [validate], handler },
+    };
+
+    blinxCollection({
+      root,
+      store,
+      paging: { pageSize: 20 },
+      actionRegistry,
+      view: {
+        layout: 'table',
+        columns: [{ field: 'name', label: 'Name' }],
+        controls: {
+          status: true,
+          customInternal: { label: 'Do', action: 'external.ok' },
+        },
+      },
+    });
+
+    getToolbarButton(root, 'Do')?.click();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(validate).toHaveBeenCalledTimes(1);
+    expect(handler).not.toHaveBeenCalled();
+    expect(getToolbarText(root)).toContain('Action "customInternal" blocked.');
+  });
+});
+

--- a/docs/spec/ui-views.md
+++ b/docs/spec/ui-views.md
@@ -28,6 +28,25 @@ Registry/resolution logic lives in `lib/blinx.ui-views.js`.
 
 ## Shared concepts
 
+### Controls and custom actions (`view.controls`)
+
+UI views may declare controls via `view.controls`. This can bind built-in controls (save/next/etc.) and also define custom controls (external DOM via `domId`, or auto-rendered buttons).
+
+For **custom controls**, `action` supports a tiered approach:
+
+- **Inline function** (quick / simple):
+  - `action: async (ctx) => { ... }`
+- **Declarative reference** (recommended for centralized logic):
+  - `action: "external.ok"`
+  - `action: { id: "external.ok", payload: { ... } }`
+
+To execute declarative action ids, pass an optional `actionRegistry` (and optionally `actionRunner`) to `blinxForm(...)` / `blinxCollection(...)` / `blinxTable(...)`.
+
+- If `actionRunner` is omitted, Blinx uses a small default runner:
+  - resolves `id` from `actionRegistry`
+  - runs an optional `validate: []` chain (first failure blocks)
+  - then calls `handler(ctx, payload)`
+
 ### Renderer selection
 
 UI views can reference a named renderer:

--- a/lib/blinx.actions.js
+++ b/lib/blinx.actions.js
@@ -16,7 +16,7 @@
 //
 // This module is intentionally tiny; richer workflow/cancellation can be layered
 // by providing a custom runner via the parent component.
-+
+
 function normalizeActionRef(action) {
   if (typeof action === 'string') return { id: action, payload: undefined };
   if (action && typeof action === 'object' && typeof action.id === 'string') {

--- a/lib/blinx.actions.js
+++ b/lib/blinx.actions.js
@@ -1,0 +1,97 @@
+// Minimal action execution helpers:
+// - Supports inline function actions (existing behavior)
+// - Supports declarative action references via an ActionRegistry:
+//    - action: "namespace.id"
+//    - action: { id: "namespace.id", payload: {...} }
+//
+// The registry can be either:
+// - { get(id) => handler | { handler, validate? } }
+// - a plain object map: { [id]: handler | { handler, validate? } }
+//
+// Validation chain:
+// - validate: [fn, fn, ...]
+// - each validator may return:
+//    - true / undefined / { ok: true } => pass
+//    - false / string / { ok: false, ... } => fail (stop)
+//
+// This module is intentionally tiny; richer workflow/cancellation can be layered
+// by providing a custom runner via the parent component.
++
+function normalizeActionRef(action) {
+  if (typeof action === 'string') return { id: action, payload: undefined };
+  if (action && typeof action === 'object' && typeof action.id === 'string') {
+    return { id: action.id, payload: action.payload };
+  }
+  return null;
+}
+
+function normalizeModule(mod) {
+  if (typeof mod === 'function') return { handler: mod, validate: [] };
+  if (mod && typeof mod === 'object' && typeof mod.handler === 'function') {
+    return {
+      handler: mod.handler,
+      validate: Array.isArray(mod.validate) ? mod.validate : [],
+    };
+  }
+  return null;
+}
+
+function resolveFromRegistry(registry, id) {
+  if (!registry) return null;
+  if (typeof registry.get === 'function') return registry.get(id);
+  if (typeof registry === 'object') return registry[id];
+  return null;
+}
+
+function normalizeValidationResult(r) {
+  if (r === undefined) return { ok: true };
+  if (r === true) return { ok: true };
+  if (r === false) return { ok: false, code: 'INVALID' };
+  if (typeof r === 'string') return { ok: false, code: 'INVALID', message: r };
+  if (r && typeof r === 'object' && typeof r.ok === 'boolean') return r;
+  // Unknown return value => treat as invalid (defensive)
+  return { ok: false, code: 'INVALID' };
+}
+
+/**
+ * Execute an action spec.
+ *
+ * @param {object} args
+ * @param {any} args.action - action spec (function | string | {id,payload})
+ * @param {object} args.ctx - action context passed to validators/handler
+ * @param {any} [args.registry] - action registry
+ * @param {Function} [args.runner] - custom runner override
+ * @param {object} [args.meta] - optional metadata (viewId/controlName/etc.)
+ * @returns {Promise<{status: 'success', value: any} | {status: 'invalid', reason: any}>}
+ */
+export async function executeActionSpec({ action, ctx, registry, runner, meta } = {}) {
+  if (typeof action === 'function') {
+    const value = await action(ctx);
+    return { status: 'success', value };
+  }
+
+  const ref = normalizeActionRef(action);
+  if (!ref) {
+    // Nothing to do (unsupported/empty action spec)
+    return { status: 'invalid', reason: { ok: false, code: 'NO_ACTION' } };
+  }
+
+  if (typeof runner === 'function') {
+    return await runner({ ctx, action: ref, registry, meta });
+  }
+
+  const raw = resolveFromRegistry(registry, ref.id);
+  const mod = normalizeModule(raw);
+  if (!mod) throw new Error(`Unknown action id "${ref.id}" (missing registry entry).`);
+
+  for (const validate of mod.validate) {
+    if (typeof validate !== 'function') continue;
+    // NOTE: no cancellation plumbing here by design (can be added by custom runner)
+    const r = normalizeValidationResult(await validate(ctx, ref.payload));
+    if (!r.ok) return { status: 'invalid', reason: r };
+  }
+
+  const value = await mod.handler(ctx, ref.payload);
+  return { status: 'success', value };
+}
+

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -7,6 +7,7 @@ import {
   resolveElementByIdWithinRoot,
   applyControlPresentation,
 } from './blinx.controls.js';
+import { executeActionSpec } from './blinx.actions.js';
 
 const ROOT_CLEANUP = Symbol('blinxCollectionCleanup');
 
@@ -305,6 +306,8 @@ export function blinxCollection({
   layouts = {},
   onItemClick,
   context,
+  actionRegistry,
+  actionRunner,
 } = {}) {
   // Resolve declarative data view (if requested).
   if (dataView && typeof dataView === 'string') {
@@ -842,7 +845,7 @@ export function blinxCollection({
   // Bind custom control actions (if any)
   for (const [name, { el, spec }] of Object.entries(dom.custom || {})) {
     const action = spec?.action;
-    if (!el || typeof action !== 'function') continue;
+    if (!el || !action) continue;
     const onClick = async () => {
       const ctx = {
         api,
@@ -850,7 +853,16 @@ export function blinxCollection({
         getState: () => controller.getState(),
         setStatus: (msg, color) => setStatus(dom, msg, color),
       };
-      await action(ctx);
+      const res = await executeActionSpec({
+        action,
+        ctx,
+        registry: actionRegistry,
+        runner: actionRunner,
+        meta: { kind: 'collection', controlName: name, viewId: view?.id },
+      });
+      if (res?.status === 'invalid') {
+        ctx.setStatus(`Action "${name}" blocked.`, '#e53e3e');
+      }
     };
     el.addEventListener('click', onClick);
     cleanupFns.push(() => el.removeEventListener('click', onClick));

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -853,15 +853,20 @@ export function blinxCollection({
         getState: () => controller.getState(),
         setStatus: (msg, color) => setStatus(dom, msg, color),
       };
-      const res = await executeActionSpec({
-        action,
-        ctx,
-        registry: actionRegistry,
-        runner: actionRunner,
-        meta: { kind: 'collection', controlName: name, viewId: view?.id },
-      });
-      if (res?.status === 'invalid') {
-        ctx.setStatus(`Action "${name}" blocked.`, '#e53e3e');
+      try {
+        const res = await executeActionSpec({
+          action,
+          ctx,
+          registry: actionRegistry,
+          runner: actionRunner,
+          meta: { kind: 'collection', controlName: name, viewId: view?.id },
+        });
+        if (res?.status === 'invalid') {
+          ctx.setStatus(`Action "${name}" blocked.`, '#e53e3e');
+        }
+      } catch (e) {
+        // Best-effort feedback; avoid unhandled rejections from async click handlers.
+        ctx.setStatus(`Action "${name}" failed.`, '#e53e3e');
       }
     };
     el.addEventListener('click', onClick);

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -10,6 +10,7 @@ import {
   resolveElementByIdWithinRoot,
   applyControlPresentation,
 } from './blinx.controls.js';
+import { executeActionSpec } from './blinx.actions.js';
 
 // Prevent handler accumulation when blinxForm is called multiple times
 // with the same DOM controls (common in tests and re-renders).
@@ -110,6 +111,8 @@ export function blinxForm({
   recordIndex = 0,
   controls,
   context,
+  actionRegistry,
+  actionRunner,
 }) {
   // Resolve declarative data view (if requested).
   if (dataView && typeof dataView === 'string') {
@@ -730,7 +733,7 @@ export function blinxForm({
   // Bind custom control actions (if any)
   for (const [name, { el, spec }] of Object.entries(dom.custom || {})) {
     const action = spec?.action;
-    if (!el || typeof action !== 'function') continue;
+    if (!el || !action) continue;
     cleanupFns.push(bindClick(el, `custom:${name}`, async () => {
       const ctx = {
         formApi: api,
@@ -741,7 +744,18 @@ export function blinxForm({
         clearStatus,
       };
       try {
-        await action(ctx);
+        const res = await executeActionSpec({
+          action,
+          ctx,
+          registry: actionRegistry,
+          runner: actionRunner,
+          meta: { kind: 'form', controlName: name, viewId: view?.id },
+        });
+        if (res?.status === 'invalid') {
+          // Best-effort feedback; do not throw.
+          setStatus(`Action "${name}" blocked.`, '#e53e3e');
+          return;
+        }
       } catch (e) {
         setStatus(`Action "${name}" failed.`, '#e53e3e');
         throw e;

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -758,7 +758,8 @@ export function blinxForm({
         }
       } catch (e) {
         setStatus(`Action "${name}" failed.`, '#e53e3e');
-        throw e;
+        // Avoid unhandled rejections from async click handlers.
+        return;
       }
     }));
   }

--- a/lib/blinx.table.js
+++ b/lib/blinx.table.js
@@ -8,6 +8,8 @@ export function blinxTable({
   onRowClick,
   controls,
   context,
+  actionRegistry,
+  actionRunner,
 }) {
   if (!store || typeof store.getModel !== 'function') {
     throw new Error('blinxTable requires a store that exposes getModel().');
@@ -38,6 +40,8 @@ export function blinxTable({
   };
   if (Object.prototype.hasOwnProperty.call(args, 'context')) opts.context = context;
   if (Object.prototype.hasOwnProperty.call(args, 'controls')) opts.controls = controls;
+  if (Object.prototype.hasOwnProperty.call(args, 'actionRegistry')) opts.actionRegistry = actionRegistry;
+  if (Object.prototype.hasOwnProperty.call(args, 'actionRunner')) opts.actionRunner = actionRunner;
 
   const { api } = blinxCollection(opts);
 


### PR DESCRIPTION
Introduce support for declarative actions with an optional validation chain via an `ActionRegistry`.

This change allows action logic to be centralized and separated from view definitions, improving readability and testability, while still supporting inline functions for simple cases.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae53ce17-b298-41b0-821b-a24392c23aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae53ce17-b298-41b0-821b-a24392c23aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a minimal action execution layer and wires it into custom controls for forms/collections.
> 
> - New `lib/blinx.actions.js` with `executeActionSpec(...)` supporting inline functions and declarative `action` refs (`"ns.id"` or `{ id, payload }`) with an optional `validate: []` chain; pluggable via `runner`
> - `blinxForm(...)` and `blinxCollection(...)` now accept `actionRegistry` and `actionRunner`; custom controls call `executeActionSpec` and set status when validation blocks execution
> - Tests cover validation blocking/passing and payload propagation for declarative actions in both form and collection
> - Docs (`docs/spec/ui-views.md`) updated to describe `view.controls` custom actions, registry usage, and default runner behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 975dfb256a1f267ad05dd90ad53e184664c0173e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->