### PR TITLE
Data filtering investigation

### DIFF
--- a/__tests__/blinx.collection.test.js
+++ b/__tests__/blinx.collection.test.js
@@ -229,5 +229,37 @@ describe('blinxCollection', () => {
     // Create should remain available so the user can add the first row.
     expect(btn('Create').disabled).toBe(false);
   });
+
+  test('localView: immutable local view disables create/deleteSelected by default', async () => {
+    const model = { fields: { id: { type: 'string' }, status: { type: 'string' }, version: { type: 'string' } } };
+    const store = blinxStore({
+      model,
+      dataSource: [{ id: '1', status: 'open', version: '1' }],
+      view: {
+        name: 'orders',
+        resource: 'orders',
+        entityType: 'Order',
+        keyField: 'id',
+        versionField: 'version',
+        cache: { completeness: 'loaded', maxEntities: 100 },
+      }
+    });
+    await store.loadFirst();
+
+    const root = document.createElement('div');
+    blinxCollection({
+      root,
+      store,
+      dataView: 'orders',
+      localView: 'search', // read-only local view
+      view: { layout: 'table', columns: [{ field: 'id', label: 'ID' }] },
+      // controls omitted => auto toolbar
+    });
+
+    const toolbar = root.querySelector('.blinx-controls');
+    const btn = (label) => Array.from(toolbar.querySelectorAll('button')).find(b => b.textContent === label);
+    expect(btn('Create').disabled).toBe(true);
+    expect(btn('Delete Selected').disabled).toBe(true);
+  });
 });
 

--- a/__tests__/blinx.store.criteria.local.test.js
+++ b/__tests__/blinx.store.criteria.local.test.js
@@ -1,0 +1,112 @@
+import { blinxStore, EventTypes } from '../lib/blinx.store.js';
+
+describe('blinxStore criteria + cache (local mode)', () => {
+  const model = { fields: { id: {}, category: {}, price: {}, version: {} } };
+
+  function makeStore(data, { cacheCompleteness = 'loaded' } = {}) {
+    return blinxStore({
+      model,
+      dataSource: data, // convenience: wrapped into BlinxArrayDataSource
+      defaultView: 'default',
+      views: {
+        default: {
+          resource: 'products',
+          entityType: 'Product',
+          keyField: 'id',
+          versionField: 'version',
+          defaultPage: { mode: 'cursor', after: null, limit: 2 },
+          cache: {
+            completeness: cacheCompleteness,
+            maxEntities: 1000,
+            eviction: { policy: 'lru' },
+            fields: { include: ['id', 'category', 'price', 'version'] },
+          },
+        }
+      }
+    });
+  }
+
+  test('local criteria filters over loaded working-set cache (multi-page)', async () => {
+    const store = makeStore([
+      { id: '1', category: 'mens', price: 10 },
+      { id: '2', category: 'womens', price: 20 },
+      { id: '3', category: 'mens', price: 30 },
+      { id: '4', category: 'kitchen', price: 40 },
+      { id: '5', category: 'mens', price: 50 },
+      { id: '6', category: 'womens', price: 60 },
+    ]);
+
+    await store.loadFirst(); // caches 1-2
+    await store.pageNext();  // caches 3-4
+
+    await store.setCriteria({
+      purpose: 'productSearch',
+      mode: 'local',
+      scope: 'cached',
+      filter: { field: 'category', op: 'eq', value: 'mens' },
+      sort: [{ field: 'price', dir: 'asc' }],
+      page: { limit: 50 },
+    });
+
+    // Only records 1 and 3 match in the loaded cache (5 not yet loaded).
+    expect(store.getLength()).toBe(2);
+    expect(store.toJSON().map(r => r.id)).toEqual(['1', '3']);
+  });
+
+  test('local criteria with scope=all warms all pages and filters across full cache', async () => {
+    const store = makeStore([
+      { id: '1', category: 'mens', price: 10 },
+      { id: '2', category: 'womens', price: 20 },
+      { id: '3', category: 'mens', price: 30 },
+      { id: '4', category: 'kitchen', price: 40 },
+      { id: '5', category: 'mens', price: 50 },
+      { id: '6', category: 'womens', price: 60 },
+    ], { cacheCompleteness: 'all' });
+
+    await store.setCriteria({
+      purpose: 'productSearch',
+      mode: 'local',
+      scope: 'all',
+      filter: { field: 'category', op: 'eq', value: 'mens' },
+      sort: [{ field: 'price', dir: 'desc' }],
+      page: { limit: 50 },
+    });
+
+    expect(store.getLength()).toBe(3);
+    expect(store.toJSON().map(r => r.id)).toEqual(['5', '3', '1']);
+  });
+
+  test('predicate filter is treated as local escape hatch and criteriaChanged is serializable', async () => {
+    const store = makeStore([
+      { id: '1', category: 'mens', price: 999 },
+      { id: '2', category: 'mens', price: 1000 },
+      { id: '3', category: 'mens', price: 5000 },
+      { id: '4', category: 'mens', price: 5001 },
+    ], { cacheCompleteness: 'all' });
+
+    const events = [];
+    store.subscribe(ev => events.push(ev));
+
+    await store.setCriteria({
+      purpose: 'productSearch',
+      mode: 'remote', // should normalize to local because filter is a function
+      scope: 'all',
+      filter: (rec) => rec.category === 'mens' && rec.price >= 1000 && rec.price <= 5000,
+      sort: [{ field: 'price', dir: 'asc' }],
+      page: { limit: 50 },
+      meta: { label: 'mens:1000-5000' },
+    });
+
+    expect(store.toJSON().map(r => r.id)).toEqual(['2', '3']);
+
+    const ce = events.find(e => e?.path?.[0] === EventTypes.criteriaChanged);
+    expect(ce).toBeDefined();
+    expect(ce.value).toEqual(expect.objectContaining({
+      purpose: 'productSearch',
+      filterType: 'fn',
+      filter: null,
+      meta: { label: 'mens:1000-5000' },
+    }));
+  });
+});
+

--- a/__tests__/blinx.store.criteria.local.test.js
+++ b/__tests__/blinx.store.criteria.local.test.js
@@ -116,5 +116,14 @@ describe('blinxStore criteria + cache (local mode)', () => {
     // Criteria changes should NOT be emitted on the base store event bus.
     expect(baseEvents.some(e => e?.path?.[0] === EventTypes.criteriaChanged)).toBe(false);
   });
+
+  test('localView mutability can be enabled via options', async () => {
+    const store = makeStore([{ id: '1', category: 'x', price: 1 }], { cacheCompleteness: 'all' });
+    const base = store.collection('default');
+    const ro = base.localView('search');
+    expect(ro.isMutable()).toBe(false);
+    const rw = base.localView('search', { mutable: true });
+    expect(rw.isMutable()).toBe(true);
+  });
 });
 

--- a/__tests__/blinx.store.criteria.local.test.js
+++ b/__tests__/blinx.store.criteria.local.test.js
@@ -125,5 +125,29 @@ describe('blinxStore criteria + cache (local mode)', () => {
     const rw = base.localView('search', { mutable: true });
     expect(rw.isMutable()).toBe(true);
   });
+
+  test('immutable localView commit/reset do not recurse and emit events', async () => {
+    const store = makeStore([
+      { id: '1', category: 'mens', price: 10 },
+      { id: '2', category: 'womens', price: 20 },
+    ], { cacheCompleteness: 'all' });
+
+    const lv = store.collection('default').localView('search'); // read-only by default
+    const events = [];
+    lv.subscribe(ev => events.push(ev));
+
+    await lv.setCriteria({
+      scope: 'all',
+      filter: { field: 'category', op: 'eq', value: 'mens' },
+      page: { limit: 50 },
+    });
+
+    events.length = 0;
+    expect(() => lv.commit()).not.toThrow();
+    expect(() => lv.reset()).not.toThrow();
+
+    expect(events.some(e => e?.path?.[0] === EventTypes.commit)).toBe(true);
+    expect(events.some(e => e?.path?.[0] === EventTypes.reset)).toBe(true);
+  });
 });
 

--- a/__tests__/blinx.store.criteria.local.test.js
+++ b/__tests__/blinx.store.criteria.local.test.js
@@ -39,9 +39,10 @@ describe('blinxStore criteria + cache (local mode)', () => {
     await store.loadFirst(); // caches 1-2
     await store.pageNext();  // caches 3-4
 
-    await store.setCriteria({
-      purpose: 'productSearch',
-      mode: 'local',
+    const base = store.collection('default');
+    const lv = base.localView('productSearch');
+
+    await lv.setCriteria({
       scope: 'cached',
       filter: { field: 'category', op: 'eq', value: 'mens' },
       sort: [{ field: 'price', dir: 'asc' }],
@@ -49,8 +50,11 @@ describe('blinxStore criteria + cache (local mode)', () => {
     });
 
     // Only records 1 and 3 match in the loaded cache (5 not yet loaded).
-    expect(store.getLength()).toBe(2);
-    expect(store.toJSON().map(r => r.id)).toEqual(['1', '3']);
+    expect(lv.getLength()).toBe(2);
+    expect(lv.toJSON().map(r => r.id)).toEqual(['1', '3']);
+
+    // Remote view store remains unchanged (still on page 2 => ids 3,4).
+    expect(base.toJSON().map(r => r.id)).toEqual(['3', '4']);
   });
 
   test('local criteria with scope=all warms all pages and filters across full cache', async () => {
@@ -63,17 +67,16 @@ describe('blinxStore criteria + cache (local mode)', () => {
       { id: '6', category: 'womens', price: 60 },
     ], { cacheCompleteness: 'all' });
 
-    await store.setCriteria({
-      purpose: 'productSearch',
-      mode: 'local',
+    const lv = store.collection('default').localView('productSearch');
+    await lv.setCriteria({
       scope: 'all',
       filter: { field: 'category', op: 'eq', value: 'mens' },
       sort: [{ field: 'price', dir: 'desc' }],
       page: { limit: 50 },
     });
 
-    expect(store.getLength()).toBe(3);
-    expect(store.toJSON().map(r => r.id)).toEqual(['5', '3', '1']);
+    expect(lv.getLength()).toBe(3);
+    expect(lv.toJSON().map(r => r.id)).toEqual(['5', '3', '1']);
   });
 
   test('predicate filter is treated as local escape hatch and criteriaChanged is serializable', async () => {
@@ -84,12 +87,14 @@ describe('blinxStore criteria + cache (local mode)', () => {
       { id: '4', category: 'mens', price: 5001 },
     ], { cacheCompleteness: 'all' });
 
-    const events = [];
-    store.subscribe(ev => events.push(ev));
+    const base = store.collection('default');
+    const lv = base.localView('productSearch');
+    const baseEvents = [];
+    const localEvents = [];
+    base.subscribe(ev => baseEvents.push(ev));
+    lv.subscribe(ev => localEvents.push(ev));
 
-    await store.setCriteria({
-      purpose: 'productSearch',
-      mode: 'remote', // should normalize to local because filter is a function
+    await lv.setCriteria({
       scope: 'all',
       filter: (rec) => rec.category === 'mens' && rec.price >= 1000 && rec.price <= 5000,
       sort: [{ field: 'price', dir: 'asc' }],
@@ -97,9 +102,9 @@ describe('blinxStore criteria + cache (local mode)', () => {
       meta: { label: 'mens:1000-5000' },
     });
 
-    expect(store.toJSON().map(r => r.id)).toEqual(['2', '3']);
+    expect(lv.toJSON().map(r => r.id)).toEqual(['2', '3']);
 
-    const ce = events.find(e => e?.path?.[0] === EventTypes.criteriaChanged);
+    const ce = localEvents.find(e => e?.path?.[0] === EventTypes.criteriaChanged);
     expect(ce).toBeDefined();
     expect(ce.value).toEqual(expect.objectContaining({
       purpose: 'productSearch',
@@ -107,6 +112,9 @@ describe('blinxStore criteria + cache (local mode)', () => {
       filter: null,
       meta: { label: 'mens:1000-5000' },
     }));
+
+    // Criteria changes should NOT be emitted on the base store event bus.
+    expect(baseEvents.some(e => e?.path?.[0] === EventTypes.criteriaChanged)).toBe(false);
   });
 });
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -9,8 +9,33 @@ This folder documents the **supported shapes** (syntax) and **semantics** (behav
 Docs:
 
 - [`model.md`](model.md)
-- [`data-views.md`](data-view.md)
-- [`ui-views.md`](ui-view.md)
+- [`data-views.md`](data-views.md)
+- [`ui-views.md`](ui-views.md)
+
+## Spec Index (all schema/DSL surfaces)
+
+Use this as a quick “map” of the declarative shapes Blinx supports:
+
+- **Model schema** (`model.md`)
+  - **field definitions / validation constraints**
+  - **computed fields**: `computed`, `dependsOn`, `compute`
+- **Data view schema** (`data-views.md`)
+  - **remote view config**: `resource/entityType/keyField/versionField/defaultFilter/defaultSort/defaultPage`
+  - **cache strategy**: `cache.{completeness,maxEntities,eviction,fields,persist}` (including `fields.include/exclude` precedence)
+  - **local views**: `remoteView.localView(localViewKey[, { mutable }])`
+  - **local criteria**: `setCriteria({ filter, sort, page, meta })`
+    - **filter DSL**: `and/or`, `{field,op,value}`, plus predicate escape hatch
+- **UI view schema** (`ui-views.md`)
+  - **form view** (`sections/fields`)
+  - **collection/table views** (`layout/columns/item/searchFields/defaultSort`)
+  - **controls spec**: built-in + custom controls, `action`, and dynamic `disabled/visible: (ctx)=>boolean`
+  - **selection config**: `selection.mode` + `selection.isRowSelectable(ctx, record, index)`
+  - **presentation hooks**: `present()` / `rowPresent()` returning `{ attrs: ... }`
+
+Protocol-like shapes (implemented in code, consumed by the store/data sources):
+
+- **DataSource query spec** (`lib/blinx.datasource.js`): `querySpec = { resource, entityType, filter, sort, page, params }`
+- **Mutation op spec** (`lib/blinx.datasource.js`): ops for `create/update/delete` and conflict handling payloads
 
 
 

--- a/docs/spec/data-views.md
+++ b/docs/spec/data-views.md
@@ -119,28 +119,29 @@ The manager also proxies common store APIs to the active view:
 `getRecord/getLength/setField/addRecord/removeRecords/update/updateIndex/toJSON/diff/commit/reset`
 and remote APIs: `loadFirst/pageNext/pagePrev/search/save/getStatus/getPagingState`.
 
-## Criteria API (remote + local)
+## Local view criteria (per-consumer projections)
 
-Per-view stores also support criteria changes through a single entry point:
+To avoid “one criteria change affects all components”, Blinx supports **local views**: derived, store-compatible projections of a remote view that have their **own event bus** and their **own criteria**.
 
-- **`store.setCriteria(criteria)`**: applies either local or remote criteria and emits `EventTypes.criteriaChanged`
-- **`store.getCriteria()`**: returns the last applied criteria (serializable summary; predicate bodies are not included)
+- **`remoteView.localView(localViewKey)`** returns a derived store for that consumer key.
+- **`localView.setCriteria(criteria)`** applies local criteria (from the shared per-view cache) and emits `EventTypes.criteriaChanged` + `EventTypes.reset` on the **local view** bus only.
 
-Criteria shape:
+Example:
 
 ```js
-await store.setCriteria({
-  purpose: 'productSearch',              // string label (for routing/debugging)
-  mode: 'local' | 'remote' | 'auto',
-  scope: 'cached' | 'all',               // local correctness scope
-  filter: null | { /* DSL or equality */ } | ((record, ctx) => boolean), // predicate is local-only escape hatch
+const remoteView = store.view('default');               // per-view remote store (shared cache)
+const productSearch = remoteView.localView('search');   // per-consumer local view store
+
+await productSearch.setCriteria({
+  scope: 'cached' | 'all',
+  filter: null | { /* DSL or equality */ } | ((record, ctx) => boolean), // escape hatch supported
   sort: [{ field: 'price', dir: 'asc' }],
-  page: { limit: 50 },                   // used by local paging (offset-mode) for remote stores
+  page: { limit: 50 },                   // local paging uses offset mode
   meta: { label: 'Men + 1000-5000' },    // optional debugging/UI metadata
 });
 ```
 
-Predicate (`(record, ctx) => boolean`) is supported as an **escape hatch** for advanced logic:
-- it is treated as **local-only** (remote mode will fall back / be rejected by implementations)
-- it is **not serialized** in `criteriaChanged` payloads
+Notes:
+- Local criteria does **not** mutate the remote view store’s `toJSON()` dataset.
+- Predicate filters are supported as an escape hatch and are **not serialized** in event payloads.
 

--- a/docs/spec/data-views.md
+++ b/docs/spec/data-views.md
@@ -157,3 +157,25 @@ editableSearch.isMutable(); // => true
 All stores also expose:
 - **`store.isMutable() => boolean`**
 
+### Example: Orders search local view (search + delete-from-results)
+
+This pattern supports “search over cached data, but still allow deleting from the results” (email-like behavior):
+
+```js
+const orders = store.view('orders'); // remote view store (shared cache)
+
+// Local view is its own event bus + criteria, but mutations proxy to `orders` when mutable:true.
+const search = orders.localView('search', { mutable: true });
+
+await search.setCriteria({
+  filter: { field: 'status', op: 'in', value: ['open', 'pending'] },
+  page: { limit: 50 },
+});
+
+// Mutations can be invoked on the local view (proxied by id+version):
+// - delete selected orders found by search
+// - update a field from the search result
+//
+// (UI should still gate these actions via view.controls disabled(ctx) predicates.)
+```
+

--- a/docs/spec/data-views.md
+++ b/docs/spec/data-views.md
@@ -145,6 +145,64 @@ Notes:
 - Local criteria does **not** mutate the remote view store’s `toJSON()` dataset.
 - Predicate filters are supported as an escape hatch and are **not serialized** in event payloads.
 
+### Filter DSL (local criteria)
+
+`criteria.filter` supports four forms:
+
+1) **`null` / `undefined`**  
+   Matches all records.
+
+2) **Predicate function** (escape hatch): `(record, ctx) => boolean`  
+   Runs locally only. Prefer the DSL when you need a serializable filter.
+
+3) **Shallow equality object** (legacy/simple):
+
+```js
+filter: { status: 'open', customerId: 'c1' }
+```
+
+4) **DSL node** (recommended for structured filters):
+
+#### Boolean composition
+
+```js
+filter: { and: [Filter, Filter, ...] }
+filter: { or:  [Filter, Filter, ...] }
+```
+
+#### Field condition
+
+```js
+filter: { field: 'status', op: 'eq', value: 'open' }
+```
+
+If `op` is omitted, it defaults to `eq`.
+
+Supported operators (current implementation):
+- **`eq`** / **`ne`**: strict equality / inequality
+- **`in`**: `value` must be an array; matches when `value.includes(record[field])`
+- **`contains`**: string match (case-insensitive); arrays are joined by `", "` first
+- **`gt`**, **`gte`**, **`lt`**, **`lte`**: numeric comparisons (both sides must coerce to finite numbers)
+- **`between`**: `value` must be `[min, max]` (order doesn’t matter)
+
+Examples:
+
+```js
+// Orders in a set of statuses
+filter: { field: 'status', op: 'in', value: ['open', 'pending'] }
+
+// Price between 1000 and 5000
+filter: { field: 'price', op: 'between', value: [1000, 5000] }
+
+// Combined
+filter: {
+  and: [
+    { field: 'status', op: 'in', value: ['open', 'pending'] },
+    { field: 'total', op: 'gte', value: 100 },
+  ]
+}
+```
+
 ### Mutability
 
 Local views are **read-only by default**. To allow mutations through a local view (proxied to the upstream remote view store), opt in:

--- a/docs/spec/data-views.md
+++ b/docs/spec/data-views.md
@@ -78,6 +78,35 @@ Pagination defaults (one of):
 - **`defaultPage?: { mode: 'cursor'|'page'|'offset', limit?: number, after?: string|null, page?: number, offset?: number }`**
 - alias: **`page`** (same shape as `defaultPage`)
 
+## Optional: per-view cache strategy (multi-page / working-set / full)
+
+Remote view stores can optionally maintain an **entity cache** across multiple pages/queries. This enables **local criteria** (client-side filtering) over:
+
+- the **loaded working set** (default when enabled), or
+- a best-effort **full cache** (warm all pages; bounded by configured caps).
+
+Declare cache config per data view:
+
+```js
+views: {
+  default: {
+    resource: 'products',
+    entityType: 'Product',
+    cache: {
+      completeness: 'loaded' | 'all',        // 'loaded' caches what you fetched; 'all' can warm all pages
+      maxEntities: 20000,                    // optional safety cap (recommended)
+      eviction: { policy: 'lru'|'ttl'|'lru+ttl', ttlMs?: number },
+      fields: { include?: string[], exclude?: string[] }, // avoid caching heavy fields unless needed
+      persist: { adapter: 'memory'|'indexeddb' },         // adapter-driven (indexeddb optional)
+    }
+  }
+}
+```
+
+Notes:
+- This cache is **deduped by id** (keyed by `keyField`).
+- Local criteria is only guaranteed correct over the cached subset unless `completeness: 'all'` is used (and the warm succeeds).
+
 ## Multi-view manager API surface (important bits)
 
 - **`store.view(name)` / `store.collection(name)`**
@@ -89,4 +118,29 @@ Pagination defaults (one of):
 The manager also proxies common store APIs to the active view:
 `getRecord/getLength/setField/addRecord/removeRecords/update/updateIndex/toJSON/diff/commit/reset`
 and remote APIs: `loadFirst/pageNext/pagePrev/search/save/getStatus/getPagingState`.
+
+## Criteria API (remote + local)
+
+Per-view stores also support criteria changes through a single entry point:
+
+- **`store.setCriteria(criteria)`**: applies either local or remote criteria and emits `EventTypes.criteriaChanged`
+- **`store.getCriteria()`**: returns the last applied criteria (serializable summary; predicate bodies are not included)
+
+Criteria shape:
+
+```js
+await store.setCriteria({
+  purpose: 'productSearch',              // string label (for routing/debugging)
+  mode: 'local' | 'remote' | 'auto',
+  scope: 'cached' | 'all',               // local correctness scope
+  filter: null | { /* DSL or equality */ } | ((record, ctx) => boolean), // predicate is local-only escape hatch
+  sort: [{ field: 'price', dir: 'asc' }],
+  page: { limit: 50 },                   // used by local paging (offset-mode) for remote stores
+  meta: { label: 'Men + 1000-5000' },    // optional debugging/UI metadata
+});
+```
+
+Predicate (`(record, ctx) => boolean`) is supported as an **escape hatch** for advanced logic:
+- it is treated as **local-only** (remote mode will fall back / be rejected by implementations)
+- it is **not serialized** in `criteriaChanged` payloads
 

--- a/docs/spec/data-views.md
+++ b/docs/spec/data-views.md
@@ -130,7 +130,7 @@ Example:
 
 ```js
 const remoteView = store.view('default');               // per-view remote store (shared cache)
-const productSearch = remoteView.localView('search');   // per-consumer local view store
+const productSearch = remoteView.localView('search');   // per-consumer local view store (read-only by default)
 
 await productSearch.setCriteria({
   scope: 'cached' | 'all',
@@ -144,4 +144,16 @@ await productSearch.setCriteria({
 Notes:
 - Local criteria does **not** mutate the remote view store’s `toJSON()` dataset.
 - Predicate filters are supported as an escape hatch and are **not serialized** in event payloads.
+
+### Mutability
+
+Local views are **read-only by default**. To allow mutations through a local view (proxied to the upstream remote view store), opt in:
+
+```js
+const editableSearch = remoteView.localView('search', { mutable: true });
+editableSearch.isMutable(); // => true
+```
+
+All stores also expose:
+- **`store.isMutable() => boolean`**
 

--- a/docs/spec/data-views.md
+++ b/docs/spec/data-views.md
@@ -106,6 +106,10 @@ views: {
 Notes:
 - This cache is **deduped by id** (keyed by `keyField`).
 - Local criteria is only guaranteed correct over the cached subset unless `completeness: 'all'` is used (and the warm succeeds).
+- **Fields precedence**:
+  - if `fields.include` is provided and non-empty, Blinx caches **only** those fields and **ignores** `fields.exclude`
+  - otherwise, Blinx caches all fields except those in `fields.exclude`
+  - note: avoid setting both; if both are provided, **include wins**
 
 ## Multi-view manager API surface (important bits)
 

--- a/docs/spec/ui-views.md
+++ b/docs/spec/ui-views.md
@@ -114,6 +114,33 @@ For both built-in and custom controls, `visible` and `disabled` may be either:
 
 This supports cases like disabling destructive actions when a view is read-only, when a filter is active, or when selected records do not meet a condition.
 
+Example: disable “Delete Selected” unless all selected orders are deletable:
+
+```js
+controls: {
+  deleteSelectedButton: {
+    label: 'Delete Selected',
+    // Keep the built-in action; only gate availability.
+    disabled: (ctx) => {
+      // Built-in guard: read-only views should not mutate.
+      if (!ctx.store?.isMutable?.()) return true;
+
+      const state = ctx.getState?.();
+      const selected = state?.selected || new Set();
+      const items = state?.items || [];
+      if (selected.size === 0) return true;
+
+      for (const idx of selected) {
+        const row = items.find(x => x.index === idx);
+        const status = row?.record?.status;
+        if (status === 'complete' || status === 'cancelled') return true;
+      }
+      return false;
+    },
+  },
+}
+```
+
 - If `actionRunner` is omitted, Blinx uses a small default runner:
   - resolves `id` from `actionRegistry`
   - runs an optional `validate: []` chain (first failure blocks)
@@ -294,6 +321,19 @@ Selection is configured on `blinxCollection(...)` / `blinxTable(...)` via the `s
 selection: {
   mode: 'multi' | 'single' | 'none',
   isRowSelectable: (ctx, record, index) => boolean,
+}
+```
+
+Example: disallow selecting orders that are complete/cancelled:
+
+```js
+selection: {
+  mode: 'multi',
+  isRowSelectable: (ctx, record) => {
+    void ctx;
+    const s = record?.status;
+    return s !== 'complete' && s !== 'cancelled';
+  }
 }
 ```
 

--- a/docs/spec/ui-views.md
+++ b/docs/spec/ui-views.md
@@ -106,6 +106,14 @@ For **custom controls**, `action` supports a tiered approach:
 
 To execute declarative action ids, pass an optional `actionRegistry` (and optionally `actionRunner`) to `blinxForm(...)` / `blinxCollection(...)` / `blinxTable(...)`.
 
+#### Dynamic control state (optional)
+
+For both built-in and custom controls, `visible` and `disabled` may be either:
+- a boolean (static), or
+- a function: `(ctx) => boolean` (dynamic)
+
+This supports cases like disabling destructive actions when a view is read-only, when a filter is active, or when selected records do not meet a condition.
+
 - If `actionRunner` is omitted, Blinx uses a small default runner:
   - resolves `id` from `actionRegistry`
   - runs an optional `validate: []` chain (first failure blocks)
@@ -276,6 +284,17 @@ const collectionView = {
     attrs: { row: { 'data-id': record?.id || '' } }
   }),
 };
+```
+
+### Selection (optional)
+
+Selection is configured on `blinxCollection(...)` / `blinxTable(...)` via the `selection` option. In addition to `mode`, a predicate can be used to disable selection per row:
+
+```js
+selection: {
+  mode: 'multi' | 'single' | 'none',
+  isRowSelectable: (ctx, record, index) => boolean,
+}
 ```
 
 ### Column

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -327,6 +327,9 @@ export function blinxCollection({
   root,
   view,
   store,
+  // Optional: per-consumer local view (derived store with its own criteria + event bus).
+  // When provided, Blinx will bind this collection to `store.localView(localView)`.
+  localView,
   // Optional: declarative data-view selection when a multi-view store manager is provided.
   // - "active": bind to the manager's active view (proxy behavior).
   // - any other string: resolves to store.view(name) / store.collection(name).
@@ -341,12 +344,29 @@ export function blinxCollection({
   actionRegistry,
   actionRunner,
 } = {}) {
+  const args = arguments?.[0] || {};
+  const localViewProvided = Object.prototype.hasOwnProperty.call(args, 'localView');
+  const actionsProvided = Object.prototype.hasOwnProperty.call(args, 'actions');
+  const selectionProvided = Object.prototype.hasOwnProperty.call(args, 'selection');
+
   // Resolve declarative data view (if requested).
   if (dataView && typeof dataView === 'string') {
     if (dataView !== 'active') {
       if (store && typeof store.view === 'function') store = store.view(dataView);
       else if (store && typeof store.collection === 'function') store = store.collection(dataView);
       else throw new Error('blinxCollection: dataView requires a multi-view store (with view()/collection()).');
+    }
+  }
+
+  // Resolve per-consumer local view (if requested).
+  if (localViewProvided && typeof localView === 'string' && localView) {
+    if (store && typeof store.localView === 'function') {
+      store = store.localView(localView);
+      // Safety defaults: local views are intended for browsing/search projections.
+      if (!actionsProvided) actions = { create: false, deleteSelected: false };
+      if (!selectionProvided) selection = { mode: 'none' };
+    } else {
+      throw new Error('blinxCollection: localView requires a store that implements localView(localViewKey).');
     }
   }
 

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -159,6 +159,11 @@ function createTableLayout() {
           cb.type = 'checkbox';
           cb.className = 'blx-checkbox';
           cb.checked = controller.isSelected(index);
+          if (typeof controller.isRowSelectable === 'function') {
+            const selectable = !!controller.isRowSelectable(index, record);
+            cb.disabled = !selectable;
+            cb.setAttribute('aria-disabled', selectable ? 'false' : 'true');
+          }
           cb.addEventListener('change', () => controller.toggleSelected(index, cb.checked));
           tdSel.appendChild(cb);
           tr.appendChild(tdSel);
@@ -346,8 +351,6 @@ export function blinxCollection({
 } = {}) {
   const args = arguments?.[0] || {};
   const localViewProvided = Object.prototype.hasOwnProperty.call(args, 'localView');
-  const actionsProvided = Object.prototype.hasOwnProperty.call(args, 'actions');
-  const selectionProvided = Object.prototype.hasOwnProperty.call(args, 'selection');
 
   // Resolve declarative data view (if requested).
   if (dataView && typeof dataView === 'string') {
@@ -359,14 +362,17 @@ export function blinxCollection({
   }
 
   // Resolve per-consumer local view (if requested).
-  if (localViewProvided && typeof localView === 'string' && localView) {
-    if (store && typeof store.localView === 'function') {
-      store = store.localView(localView);
-      // Safety defaults: local views are intended for browsing/search projections.
-      if (!actionsProvided) actions = { create: false, deleteSelected: false };
-      if (!selectionProvided) selection = { mode: 'none' };
-    } else {
-      throw new Error('blinxCollection: localView requires a store that implements localView(localViewKey).');
+  if (localViewProvided) {
+    const lv =
+      (typeof localView === 'string' && localView) ? localView :
+      (localView && typeof localView === 'object') ? localView :
+      null;
+    if (lv) {
+      if (store && typeof store.localView === 'function') {
+        store = store.localView(lv);
+      } else {
+        throw new Error('blinxCollection: localView requires a store that implements localView(localViewKey).');
+      }
     }
   }
 
@@ -463,6 +469,9 @@ export function blinxCollection({
   let internalChangeDepth = 0;
   let pendingResetSync = null;
   const cleanupFns = [];
+  const isStoreMutable = () => (store && typeof store.isMutable === 'function') ? !!store.isMutable() : true;
+  const selectionMode = selection?.mode || 'multi';
+  const rowSelectablePredicate = (typeof selection?.isRowSelectable === 'function') ? selection.isRowSelectable : null;
 
   // Resolve controls:
   // - Declarative view controls: view.controls (or explicit `controls` param)
@@ -482,6 +491,7 @@ export function blinxCollection({
     searchBtn: null,
     custom: {},
   };
+  const builtinSpecs = {}; // key -> meta/spec (including disabled/visible functions)
   let internalToolbar = null;
 
   function ensureToolbar() {
@@ -503,7 +513,12 @@ export function blinxCollection({
     if (!entry) return null; // not declared
     const meta = { ...defaultBuiltinControlMeta(key), ...entry };
     meta.visible = (typeof meta.visible === 'boolean') ? meta.visible : true;
+    // Allow disabled to be a function(ctx) => boolean (evaluated by this adapter).
+    meta.__disabledFn = (typeof meta.disabled === 'function') ? meta.disabled : null;
     meta.disabled = (typeof meta.disabled === 'boolean') ? meta.disabled : false;
+    meta.__visibleFn = (typeof meta.visible === 'function') ? meta.visible : null;
+    meta.visible = (typeof meta.visible === 'boolean') ? meta.visible : true;
+    builtinSpecs[key] = meta;
 
     if (typeof meta.domId === 'string' && meta.domId) {
       const existing = resolveElementByIdWithinRoot(root, meta.domId);
@@ -559,8 +574,10 @@ export function blinxCollection({
       const entry = normalizeControlSpecEntry(raw);
       if (!entry) continue;
       const meta = { label: key, ...entry };
-      meta.visible = (typeof meta.visible === 'boolean') ? meta.visible : true;
+      meta.__disabledFn = (typeof meta.disabled === 'function') ? meta.disabled : null;
       meta.disabled = (typeof meta.disabled === 'boolean') ? meta.disabled : false;
+      meta.__visibleFn = (typeof meta.visible === 'function') ? meta.visible : null;
+      meta.visible = (typeof meta.visible === 'boolean') ? meta.visible : true;
 
       let el = null;
       if (typeof meta.domId === 'string' && meta.domId) {
@@ -710,19 +727,72 @@ export function blinxCollection({
   function syncEmptyStateControls() {
     const total = store.getLength();
     const empty = total === 0;
+    const mutable = isStoreMutable();
     // When there are no records, keep Create enabled but disable navigation + delete-selected.
     setDisabled(dom.prevBtn, empty);
     setDisabled(dom.nextBtn, empty);
-    setDisabled(dom.deleteSelectedBtn, empty);
+    setDisabled(dom.createBtn, !mutable);
+    setDisabled(dom.deleteSelectedBtn, empty || !mutable);
   }
 
   function refresh() {
     const data = getDataSnapshot();
     const { items } = getItemsForCurrentPage(data);
     layoutApi.update();
+    syncDynamicControls();
     updatePagerLabel();
     syncEmptyStateControls();
     return items;
+  }
+
+  function syncDynamicControls() {
+    const state = controller.getState();
+    const controlCtx = {
+      api,
+      store,
+      model,
+      view,
+      kind: 'collection',
+      getState: () => state,
+      controls: dom,
+      context: ctx,
+    };
+
+    // Builtins declared via view.controls / controls param.
+    for (const [key, spec] of Object.entries(builtinSpecs)) {
+      const el =
+        key === 'createButton' ? dom.createBtn :
+        key === 'deleteSelectedButton' ? dom.deleteSelectedBtn :
+        key === 'prevButton' ? dom.prevBtn :
+        key === 'nextButton' ? dom.nextBtn :
+        key === 'pageLabel' ? dom.pageLabel :
+        key === 'searchInput' ? dom.searchInput :
+        key === 'searchButton' ? dom.searchBtn :
+        key === 'status' ? dom.status :
+        null;
+      if (!el || !spec) continue;
+      const next = { ...spec };
+      if (spec.__visibleFn) {
+        try { next.visible = !!spec.__visibleFn(controlCtx); } catch { next.visible = false; }
+      }
+      if (spec.__disabledFn) {
+        try { next.disabled = !!spec.__disabledFn(controlCtx); } catch { next.disabled = true; }
+      }
+      applyControlPresentation(el, next);
+    }
+
+    // Custom controls declared in view.controls / controls param.
+    for (const { el, spec } of Object.values(dom.custom || {})) {
+      if (!el || !spec) continue;
+      const next = { ...spec };
+      if (spec.__visibleFn) {
+        try { next.visible = !!spec.__visibleFn(controlCtx); } catch { next.visible = false; }
+      }
+      if (spec.__disabledFn) {
+        try { next.disabled = !!spec.__disabledFn(controlCtx); } catch { next.disabled = true; }
+      }
+      applyControlPresentation(el, next);
+    }
   }
 
   function isSelected(index) {
@@ -730,8 +800,18 @@ export function blinxCollection({
   }
 
   function toggleSelected(index, checked) {
-    if (selection?.mode === 'none') return;
-    const needsRefresh = selection?.mode === 'single';
+    if (selectionMode === 'none') return;
+    const data = getDataSnapshot();
+    const record = data[index];
+    if (rowSelectablePredicate) {
+      try {
+        const ok = !!rowSelectablePredicate(ctx, record, index);
+        if (!ok) return;
+      } catch {
+        return;
+      }
+    }
+    const needsRefresh = selectionMode === 'single';
     if (needsRefresh) selected.clear();
     if (checked) selected.add(index);
     else selected.delete(index);
@@ -766,6 +846,7 @@ export function blinxCollection({
   }
 
   async function doCreate() {
+    if (!isStoreMutable()) return setStatus(dom, 'Create is disabled for this view.', '#e53e3e');
     const keys = Object.keys(model.fields || {}).filter(k => !model?.fields?.[k]?.computed);
     runInternalChange(() => store.addRecord(Object.fromEntries(keys.map(k => [k, '']))));
     refresh();
@@ -773,6 +854,7 @@ export function blinxCollection({
   }
 
   async function doDeleteSelected() {
+    if (!isStoreMutable()) return setStatus(dom, 'Delete is disabled for this view.', '#e53e3e');
     if (selected.size === 0) return setStatus(dom, 'No rows selected.', '#e53e3e');
     runInternalChange(() => store.removeRecords(Array.from(selected)));
     selected.clear();
@@ -879,6 +961,11 @@ export function blinxCollection({
     },
     isSelected,
     toggleSelected,
+    isRowSelectable: (index, record) => {
+      if (selectionMode === 'none') return false;
+      if (!rowSelectablePredicate) return true;
+      try { return !!rowSelectablePredicate(ctx, record, index); } catch { return false; }
+    },
     clearSelection: () => { selected.clear(); refresh(); },
     runInternalChange,
   };

--- a/lib/blinx.controls.js
+++ b/lib/blinx.controls.js
@@ -38,6 +38,9 @@ export function applyControlPresentation(el, spec) {
     if ('disabled' in el) el.disabled = !!spec.disabled;
     el.setAttribute('aria-disabled', spec.disabled ? 'true' : 'false');
   }
+  // Note: spec.disabled may also be a function, but it must be evaluated by callers
+  // (e.g. UI adapters) because it depends on runtime context. We intentionally do
+  // not evaluate functions here to keep this module DOM-only and context-free.
   if (typeof spec.css === 'string' && spec.css.trim()) {
     el.className = `${el.className || ''} ${spec.css}`.trim();
   }

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -942,6 +942,16 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
       baseUnsub = null;
     }
 
+    function lvCommitLocal() {
+      lvOriginal = clone(lvCurrent);
+      lvNotify([EventTypes.commit], lvCurrent.map(r => cloneWithComputed(model, r, { clone })));
+    }
+
+    function lvResetLocal() {
+      lvCurrent = clone(lvOriginal);
+      lvNotify([EventTypes.reset, 0], lvCurrent[0] || null);
+    }
+
     lvApi = {
       // Internal: allow upgrading mutability for the same localViewKey.
       __internal_setMutable: (next) => { mutable = !!next; },
@@ -981,8 +991,16 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
         }
         return changes;
       },
-      commit: () => { lvOriginal = clone(lvCurrent); lvNotify([EventTypes.commit], lvCurrent.map(r => cloneWithComputed(model, r, { clone }))); },
-      reset: () => { lvCurrent = clone(lvOriginal); lvNotify([EventTypes.reset, 0], lvCurrent[0] || null); },
+      commit: () => {
+        if (!mutable) return lvCommitLocal();
+        storeApi.commit();
+        return materialize({ resetOffset: false });
+      },
+      reset: () => {
+        if (!mutable) return lvResetLocal();
+        storeApi.reset();
+        return materialize({ resetOffset: false });
+      },
 
       // Local criteria API (per-consumer)
       async setCriteria(nextCriteria) {
@@ -1048,16 +1066,6 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
       save: () => {
         if (!mutable) throw new Error('localView is read-only. Create it with { mutable: true } to allow mutations.');
         return storeApi.save();
-      },
-      commit: () => {
-        if (!mutable) return lvApi.commit();
-        storeApi.commit();
-        return materialize({ resetOffset: false });
-      },
-      reset: () => {
-        if (!mutable) return lvApi.reset();
-        storeApi.reset();
-        return materialize({ resetOffset: false });
       },
 
       // Convenience: allow nested local views to be stable

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -312,6 +312,7 @@ function createLegacyArrayStore(initialArray, dataModel) {
   }
 
   storeApi = {
+    isMutable: () => true,
     getRecord,
     getLength,
     setField,
@@ -495,6 +496,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   function subscribe(fn) { subs.add(fn); return () => subs.delete(fn); }
   function toJSON() { return current.map(r => cloneWithComputed(model, r, { clone })); }
   function getStatus() { return { status, error, pageInfo, pageState: { ...pageState }, criteria: clone(criteria) }; }
+  function isMutable() { return true; }
 
   function getCacheStatus() {
     if (!cacheConfig || !cacheState) return { enabled: false };
@@ -655,6 +657,78 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     return removed.length;
   }
 
+  function deleteById(id, { baseVersion = null } = {}) {
+    const sid = id === undefined || id === null ? null : String(id);
+    if (!sid) return false;
+    const idx = current.findIndex(r => String(r?.[keyField]) === sid);
+    if (idx >= 0) {
+      // Inline a single-record delete so we can override baseVersion when provided.
+      const [record] = current.splice(idx, 1);
+      const bv = (baseVersion !== null && baseVersion !== undefined) ? String(baseVersion) : (record?.[versionField] !== undefined ? String(record[versionField]) : null);
+      enqueue({
+        opId: `op-${viewName}-${opSeq++}`,
+        type: 'delete',
+        entity: { type: entityType, id: sid },
+        baseVersion: bv,
+      });
+      notify([EventTypes.remove, [idx]], [record]);
+      cacheRemoveById(sid);
+      return true;
+    }
+    // Not in the current page: still enqueue delete and evict from cache.
+    enqueue({
+      opId: `op-${viewName}-${opSeq++}`,
+      type: 'delete',
+      entity: { type: entityType, id: sid },
+      baseVersion: (baseVersion !== null && baseVersion !== undefined) ? String(baseVersion) : null,
+    });
+    cacheRemoveById(sid);
+    // Best-effort refresh signal for local views and UIs.
+    notify([EventTypes.reset, 0], current[0] || null);
+    return true;
+  }
+
+  function updateById(id, patch, { baseVersion = null } = {}) {
+    const sid = id === undefined || id === null ? null : String(id);
+    if (!sid) return false;
+    const p = (patch && typeof patch === 'object') ? patch : null;
+    if (!p) return false;
+    const idx = current.findIndex(r => String(r?.[keyField]) === sid);
+
+    const applyPatchToRecord = (rec) => {
+      if (!rec || typeof rec !== 'object') return rec;
+      for (const [k, v] of Object.entries(p)) {
+        if (isComputedField(model, k)) continue;
+        rec[k] = v;
+        invalidateComputedForField(model, rec, k);
+      }
+      return rec;
+    };
+
+    if (idx >= 0 && current[idx]) {
+      applyPatchToRecord(current[idx]);
+      notify([EventTypes.update, idx], cloneWithComputed(model, current[idx], { clone }));
+      const bv = (baseVersion !== null && baseVersion !== undefined)
+        ? String(baseVersion)
+        : ((original[idx] && original[idx][versionField] !== undefined) ? String(original[idx][versionField]) : (current[idx][versionField] !== undefined ? String(current[idx][versionField]) : null));
+      enqueueUpdate(sid, bv, p);
+      cacheIngest([current[idx]]);
+      return true;
+    }
+
+    // Not in the current page: enqueue update and best-effort update cache snapshot.
+    const bv = (baseVersion !== null && baseVersion !== undefined) ? String(baseVersion) : null;
+    enqueueUpdate(sid, bv, p);
+    // Update cache if present.
+    const existing = cacheConfig && cacheState ? cacheState.entities.get(sid) : null;
+    if (existing && typeof existing === 'object') {
+      const merged = { ...existing, ...p, [keyField]: sid };
+      cacheIngest([merged]);
+    }
+    notify([EventTypes.reset, 0], current[0] || null);
+    return true;
+  }
+
   function updateIndex(index) {
     if (index < 0 || index >= current.length) return null;
     const record = current[index];
@@ -759,8 +833,24 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   }
 
   function localView(localViewKey) {
-    const key = (localViewKey === undefined || localViewKey === null || localViewKey === '') ? 'default' : String(localViewKey);
-    if (localViews.has(key)) return localViews.get(key);
+    let key;
+    let opts;
+    if (isPlainObject(localViewKey)) {
+      // Allow shorthand: localView({ key, mutable })
+      key = String(localViewKey?.key || localViewKey?.name || 'default');
+      opts = localViewKey;
+    } else {
+      key = (localViewKey === undefined || localViewKey === null || localViewKey === '') ? 'default' : String(localViewKey);
+      opts = arguments?.[1];
+    }
+    const options = isPlainObject(opts) ? opts : {};
+    if (localViews.has(key)) {
+      const existing = localViews.get(key);
+      if (options && options.mutable === true && existing && typeof existing.__internal_setMutable === 'function') {
+        existing.__internal_setMutable(true);
+      }
+      return existing;
+    }
 
     const lvSubs = new Set();
     let lvApi;
@@ -773,6 +863,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     let lvStatus = 'idle';
     let lvError = null;
     let lvCriteria = { purpose: key, mode: 'local', scope: 'cached', filter: null, sort: null, page: null, meta: null };
+    let mutable = !!options.mutable;
     let baseUnsub = null;
 
     function lvNotify(path, value) {
@@ -852,6 +943,9 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     }
 
     lvApi = {
+      // Internal: allow upgrading mutability for the same localViewKey.
+      __internal_setMutable: (next) => { mutable = !!next; },
+      isMutable: () => !!mutable,
       // Store-like API (read-first)
       getModel: () => model,
       getRecord: (idx) => decorateRecordWithComputed(model, lvCurrent[idx]),
@@ -905,6 +999,64 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
       },
       async pagePrev() {
         lvPageState = { ...lvPageState, offset: Math.max(0, (lvPageState.offset || 0) - (lvPageState.limit || 20)) };
+        return materialize({ resetOffset: false });
+      },
+
+      // Mutations (opt-in)
+      addRecord: (record, atIndex) => {
+        if (!mutable) throw new Error('localView is read-only. Create it with { mutable: true } to allow mutations.');
+        return storeApi.addRecord(record, atIndex);
+      },
+      setField: (idx, field, value) => {
+        if (!mutable) throw new Error('localView is read-only. Create it with { mutable: true } to allow mutations.');
+        const rec = lvCurrent[idx];
+        const id = rec?.[keyField];
+        const bv = rec?.[versionField] !== undefined ? String(rec[versionField]) : null;
+        return storeApi.updateById ? storeApi.updateById(id, { [field]: value }, { baseVersion: bv }) : storeApi.setField(idx, field, value);
+      },
+      removeRecords: (indexes) => {
+        if (!mutable) throw new Error('localView is read-only. Create it with { mutable: true } to allow mutations.');
+        const unique = Array.from(new Set(indexes || [])).filter(i => Number.isFinite(i));
+        let removed = 0;
+        for (const i of unique) {
+          const rec = lvCurrent[i];
+          const id = rec?.[keyField];
+          const bv = rec?.[versionField] !== undefined ? String(rec[versionField]) : null;
+          if (storeApi.deleteById && id !== undefined && id !== null) {
+            if (storeApi.deleteById(id, { baseVersion: bv })) removed += 1;
+          }
+        }
+        return removed;
+      },
+      update: (idx, record) => {
+        if (!mutable) throw new Error('localView is read-only. Create it with { mutable: true } to allow mutations.');
+        const rec = lvCurrent[idx];
+        const id = rec?.[keyField];
+        const bv = rec?.[versionField] !== undefined ? String(rec[versionField]) : null;
+        if (storeApi.updateById && id !== undefined && id !== null) {
+          // Replace semantics: treat as patch (best-effort).
+          const patch = (record && typeof record === 'object') ? record : {};
+          return storeApi.updateById(id, patch, { baseVersion: bv });
+        }
+        return null;
+      },
+      updateIndex: (idx) => {
+        // For projections, re-materialize is the safe refresh.
+        void idx;
+        return materialize({ resetOffset: false });
+      },
+      save: () => {
+        if (!mutable) throw new Error('localView is read-only. Create it with { mutable: true } to allow mutations.');
+        return storeApi.save();
+      },
+      commit: () => {
+        if (!mutable) return lvApi.commit();
+        storeApi.commit();
+        return materialize({ resetOffset: false });
+      },
+      reset: () => {
+        if (!mutable) return lvApi.reset();
+        storeApi.reset();
         return materialize({ resetOffset: false });
       },
 
@@ -988,6 +1140,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   }
 
   storeApi = {
+    isMutable,
     getModel,
     getRecord,
     getLength,
@@ -1007,6 +1160,8 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     pageNext,
     pagePrev,
     search,
+    deleteById,
+    updateById,
     save,
     getStatus,
     getPagingState: () => ({ pageInfo, pageState: { ...pageState } }),
@@ -1148,6 +1303,7 @@ export function blinxStore(arg1, arg2) {
     subscribe(fn) { subs.add(fn); return () => subs.delete(fn); },
 
     // ---- View-store compatible API (proxied to active view) ----
+    isMutable: () => proxy('isMutable'),
     getModel: () => model,
     getRecord: (idx) => proxy('getRecord', idx),
     getLength: () => proxy('getLength'),
@@ -1166,6 +1322,8 @@ export function blinxStore(arg1, arg2) {
     pageNext: () => proxy('pageNext'),
     pagePrev: () => proxy('pagePrev'),
     search: (criteria) => proxy('search', criteria),
+    deleteById: (id, opts) => proxy('deleteById', id, opts),
+    updateById: (id, patch, opts) => proxy('updateById', id, patch, opts),
     save: () => proxy('save'),
     getStatus: () => proxy('getStatus'),
     getPagingState: () => proxy('getPagingState'),

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -34,6 +34,181 @@ export const EventTypes = {
 
 const clone = value => JSON.parse(JSON.stringify(value));
 
+function isPlainObject(v) {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function normalizeCacheConfig(raw, { keyField = 'id', versionField = 'version' } = {}) {
+  if (!raw || raw === true) {
+    // Default: off (explicit opt-in). `true` enables safe defaults.
+    if (raw !== true) return null;
+  }
+  const cfg = isPlainObject(raw) ? raw : {};
+  const completeness = (cfg.completeness === 'all') ? 'all' : 'loaded';
+  const maxEntities = Number.isFinite(cfg.maxEntities) ? Math.max(0, cfg.maxEntities) : null;
+  const evictionRaw = isPlainObject(cfg.eviction) ? cfg.eviction : {};
+  const policy = (evictionRaw.policy === 'ttl' || evictionRaw.policy === 'lru+ttl' || evictionRaw.policy === 'lru')
+    ? evictionRaw.policy
+    : (evictionRaw.ttlMs ? 'lru+ttl' : 'lru');
+  const ttlMs = Number.isFinite(evictionRaw.ttlMs) ? Math.max(0, evictionRaw.ttlMs) : null;
+  const fields = isPlainObject(cfg.fields) ? cfg.fields : null;
+  const include = Array.isArray(fields?.include) ? fields.include.filter(f => typeof f === 'string' && f) : null;
+  const exclude = Array.isArray(fields?.exclude) ? fields.exclude.filter(f => typeof f === 'string' && f) : null;
+  const persist = isPlainObject(cfg.persist) ? cfg.persist : null;
+  const persistAdapter = persist?.adapter ? String(persist.adapter) : 'memory';
+
+  return {
+    mode: 'entity',
+    completeness,
+    maxEntities,
+    eviction: { policy, ttlMs },
+    fields: { include, exclude },
+    persist: { adapter: persistAdapter },
+    keyField,
+    versionField,
+  };
+}
+
+function pickRecordFields(record, { include, exclude } = {}) {
+  if (!record || typeof record !== 'object') return record;
+  const inc = Array.isArray(include) && include.length ? new Set(include) : null;
+  const exc = Array.isArray(exclude) && exclude.length ? new Set(exclude) : null;
+  if (!inc && !exc) return record;
+  const out = {};
+  if (inc) {
+    for (const k of inc) {
+      if (Object.prototype.hasOwnProperty.call(record, k)) out[k] = record[k];
+    }
+    // Keep unknown keys out by default when include is provided.
+    return out;
+  }
+  for (const [k, v] of Object.entries(record)) {
+    if (exc && exc.has(k)) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+function normalizeCriteriaInput(input) {
+  const raw = isPlainObject(input) ? input : {};
+  const mode = (raw.mode === 'local' || raw.mode === 'remote' || raw.mode === 'auto') ? raw.mode : 'auto';
+  const scope = (raw.scope === 'all') ? 'all' : 'cached';
+  const purpose = (typeof raw.purpose === 'string' && raw.purpose) ? raw.purpose : 'default';
+  const filter = raw.filter === undefined ? null : raw.filter;
+  const sort = Array.isArray(raw.sort) ? raw.sort : null;
+  const page = isPlainObject(raw.page) ? raw.page : null;
+  const meta = isPlainObject(raw.meta) ? raw.meta : null;
+  return { purpose, mode, scope, filter, sort, page, meta };
+}
+
+function serializeCriteria(criteria) {
+  const c = normalizeCriteriaInput(criteria);
+  const filterType = (typeof c.filter === 'function') ? 'fn' : (c.filter ? 'object' : 'none');
+  // Do NOT serialize predicate bodies.
+  const filter = (filterType === 'fn') ? null : c.filter;
+  return { ...c, filterType, filter };
+}
+
+function compileFilterPredicate(filter) {
+  if (!filter) return () => true;
+  if (typeof filter === 'function') return (rec, ctx) => !!filter(rec, ctx);
+
+  // Legacy: { field: value, ... } shallow equality.
+  if (isPlainObject(filter) && !('and' in filter) && !('or' in filter) && !('field' in filter) && !('op' in filter)) {
+    const entries = Object.entries(filter);
+    if (entries.length === 0) return () => true;
+    return (rec) => entries.every(([k, v]) => rec?.[k] === v);
+  }
+
+  // Minimal DSL:
+  // - { and: [Filter, ...] }
+  // - { or:  [Filter, ...] }
+  // - { field, op, value }
+  if (!isPlainObject(filter)) return () => true;
+
+  if (Array.isArray(filter.and)) {
+    const ps = filter.and.map(compileFilterPredicate);
+    return (rec, ctx) => ps.every(p => p(rec, ctx));
+  }
+  if (Array.isArray(filter.or)) {
+    const ps = filter.or.map(compileFilterPredicate);
+    return (rec, ctx) => ps.some(p => p(rec, ctx));
+  }
+
+  const field = filter.field;
+  const op = filter.op;
+  const value = filter.value;
+  if (typeof field !== 'string' || !field) return () => true;
+  const opKey = (typeof op === 'string' && op) ? op : 'eq';
+
+  return (rec) => {
+    const v = rec?.[field];
+    if (opKey === 'eq') return v === value;
+    if (opKey === 'ne') return v !== value;
+    if (opKey === 'in') return Array.isArray(value) ? value.includes(v) : false;
+    if (opKey === 'contains') {
+      if (v === undefined || v === null) return false;
+      const s = Array.isArray(v) ? v.join(', ') : String(v);
+      return String(s).toLowerCase().includes(String(value ?? '').toLowerCase());
+    }
+    const n = Number(v);
+    const x = Number(value);
+    if (opKey === 'gt') return Number.isFinite(n) && Number.isFinite(x) ? n > x : false;
+    if (opKey === 'gte') return Number.isFinite(n) && Number.isFinite(x) ? n >= x : false;
+    if (opKey === 'lt') return Number.isFinite(n) && Number.isFinite(x) ? n < x : false;
+    if (opKey === 'lte') return Number.isFinite(n) && Number.isFinite(x) ? n <= x : false;
+    if (opKey === 'between') {
+      if (!Array.isArray(value) || value.length < 2) return false;
+      const a = Number(value[0]);
+      const b = Number(value[1]);
+      if (!Number.isFinite(n) || !Number.isFinite(a) || !Number.isFinite(b)) return false;
+      return n >= Math.min(a, b) && n <= Math.max(a, b);
+    }
+    return true;
+  };
+}
+
+function applySortLocal(records, sort) {
+  if (!Array.isArray(sort) || sort.length === 0) return records;
+  const specs = sort
+    .filter(Boolean)
+    .map(s => ({ field: s.field, dir: (s.dir || 'asc').toLowerCase() === 'desc' ? 'desc' : 'asc' }))
+    .filter(s => typeof s.field === 'string' && s.field.length > 0);
+  if (specs.length === 0) return records;
+  const decorated = records.map((r, pos) => ({ r, pos }));
+  decorated.sort((a, b) => {
+    for (const s of specs) {
+      const av = a.r?.[s.field];
+      const bv = b.r?.[s.field];
+      if (av === bv) continue;
+      if (av === undefined || av === null) return s.dir === 'asc' ? 1 : -1;
+      if (bv === undefined || bv === null) return s.dir === 'asc' ? -1 : 1;
+      if (av < bv) return s.dir === 'asc' ? -1 : 1;
+      if (av > bv) return s.dir === 'asc' ? 1 : -1;
+    }
+    return a.pos - b.pos;
+  });
+  return decorated.map(x => x.r);
+}
+
+function sliceOffsetPage(records, { offset = 0, limit = 20 } = {}) {
+  const off = Number.isFinite(offset) ? Math.max(0, offset) : 0;
+  const lim = Number.isFinite(limit) ? Math.max(0, limit) : 20;
+  const items = records.slice(off, off + lim);
+  const totalCount = records.length;
+  return {
+    items,
+    pageInfo: {
+      mode: 'offset',
+      offset: off,
+      limit: lim,
+      totalCount,
+      hasPrev: off > 0,
+      hasNext: off + items.length < totalCount,
+    }
+  };
+}
+
 function createLegacyArrayStore(initialArray, dataModel) {
   // Validate computed metadata early (throws on cycles / invalid dependsOn).
   getComputedModelMeta(dataModel);
@@ -199,6 +374,117 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   let opSeq = 1;
   const pendingOps = []; // queued local ops (for offline / save batching)
 
+  // ---- Optional entity cache (multi-page / working-set / full) ----
+  const cacheConfig = normalizeCacheConfig(viewConfig.cache, { keyField, versionField });
+  const cacheState = cacheConfig
+    ? { entities: new Map(), access: new Map() } // Map preserves insertion order (stable for snapshots)
+    : null;
+
+  function cacheNow() { return Date.now(); }
+
+  function cacheEvictIfNeeded() {
+    if (!cacheConfig || !cacheState) return;
+    const policy = cacheConfig.eviction?.policy || 'lru';
+    const ttlMs = cacheConfig.eviction?.ttlMs;
+
+    if ((policy === 'ttl' || policy === 'lru+ttl') && Number.isFinite(ttlMs) && ttlMs > 0) {
+      const cutoff = cacheNow() - ttlMs;
+      for (const [id, ts] of cacheState.access.entries()) {
+        if (ts < cutoff) {
+          cacheState.access.delete(id);
+          cacheState.entities.delete(id);
+        }
+      }
+    }
+
+    if (Number.isFinite(cacheConfig.maxEntities) && cacheConfig.maxEntities >= 0) {
+      while (cacheState.entities.size > cacheConfig.maxEntities) {
+        // Evict least-recently-used (or oldest seen when access is missing).
+        let victimId = null;
+        let victimTs = Infinity;
+        for (const [id, rec] of cacheState.entities.entries()) {
+          const ts = cacheState.access.get(id) ?? 0;
+          if (ts < victimTs) { victimTs = ts; victimId = id; }
+          // Defensive: avoid unused var warning; rec not needed
+          void rec;
+        }
+        if (!victimId) break;
+        cacheState.entities.delete(victimId);
+        cacheState.access.delete(victimId);
+      }
+    }
+  }
+
+  function cacheTouch(id) {
+    if (!cacheConfig || !cacheState) return;
+    if (!id) return;
+    cacheState.access.set(String(id), cacheNow());
+  }
+
+  function cacheIngest(records) {
+    if (!cacheConfig || !cacheState) return;
+    if (!Array.isArray(records) || records.length === 0) return;
+    for (const r of records) {
+      if (!r || typeof r !== 'object') continue;
+      const id = r?.[keyField];
+      if (id === undefined || id === null || id === '') continue;
+      const sid = String(id);
+      const picked = pickRecordFields(r, cacheConfig.fields);
+      // Always ensure id+version exist in cache so updates can be reconciled.
+      const ensured = { ...picked, [keyField]: sid };
+      if (ensured[versionField] === undefined && r[versionField] !== undefined) ensured[versionField] = r[versionField];
+      cacheState.entities.set(sid, ensured);
+      cacheTouch(sid);
+    }
+    cacheEvictIfNeeded();
+  }
+
+  function cacheRemoveById(id) {
+    if (!cacheConfig || !cacheState) return;
+    const sid = String(id);
+    cacheState.entities.delete(sid);
+    cacheState.access.delete(sid);
+  }
+
+  function cacheSnapshot() {
+    if (!cacheConfig || !cacheState) return [];
+    cacheEvictIfNeeded();
+    return Array.from(cacheState.entities.values());
+  }
+
+  async function cacheWarmAll({ pageSize = 200, maxPages = 2000, criteriaOverride = null } = {}) {
+    if (!cacheConfig || !cacheState) return { warmed: 0, pages: 0 };
+    if (!dataSource || typeof dataSource.query !== 'function') return { warmed: 0, pages: 0 };
+
+    let cursor = null;
+    let pages = 0;
+    let warmed = 0;
+    for (; pages < maxPages; pages++) {
+      const res = await dataSource.query(
+        buildQuerySpec({
+          ...(criteriaOverride || {}),
+          page: { mode: 'cursor', after: cursor, limit: pageSize },
+        }),
+        { resource, entityType, keyField, versionField }
+      );
+      const fetched = (res?.entities?.[entityType] || []).map(r => stripComputedFields(model, clone(r)));
+      cacheIngest(fetched);
+      warmed += fetched.length;
+      const next = res?.pageInfo?.nextCursor;
+      if (next === null || next === undefined) break;
+      cursor = next;
+      // Respect maxEntities cap: don't keep warming forever if capped too low.
+      if (Number.isFinite(cacheConfig.maxEntities) && cacheConfig.maxEntities >= 0 && cacheState.entities.size >= cacheConfig.maxEntities) break;
+    }
+    return { warmed, pages };
+  }
+
+  // ---- Criteria (remote + local) ----
+  let activeCriteria = null;     // last setCriteria() input (normalized)
+  let criteriaSeq = 1;
+  let localMode = false;         // whether the view is currently materialized from cache
+  let localAll = [];             // filtered+sorted array used for local paging
+
   function notify(path, value) {
     subs.forEach(fn => fn({ path, value, data: current, store: storeApi }));
   }
@@ -212,6 +498,20 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   function subscribe(fn) { subs.add(fn); return () => subs.delete(fn); }
   function toJSON() { return current.map(r => cloneWithComputed(model, r, { clone })); }
   function getStatus() { return { status, error, pageInfo, pageState: { ...pageState }, criteria: clone(criteria) }; }
+
+  function getCriteria() {
+    return activeCriteria ? clone(serializeCriteria(activeCriteria)) : null;
+  }
+
+  function getCacheStatus() {
+    if (!cacheConfig || !cacheState) return { enabled: false };
+    return {
+      enabled: true,
+      config: clone(cacheConfig),
+      size: cacheState.entities.size,
+      completeness: cacheConfig.completeness,
+    };
+  }
 
   function diff() {
     // Keep legacy diff shape (index-based) for UI messaging/debugging.
@@ -304,6 +604,13 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     if (id !== undefined && id !== null) {
       enqueueUpdate(id, baseVersion, { [field]: value });
     }
+
+    // Keep cache in sync (best-effort). If localMode is active, this keeps projections stable.
+    cacheIngest([rec]);
+    if (localMode && activeCriteria) {
+      // Recompute local projection with updated record (simple but correct).
+      void applyLocalCriteria(activeCriteria);
+    }
   }
 
   function addRecord(record, atIndex = current.length) {
@@ -321,6 +628,11 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
       entity: { type: entityType },
       data: clone(rec),
     });
+
+    cacheIngest([rec]);
+    if (localMode && activeCriteria) {
+      void applyLocalCriteria(activeCriteria);
+    }
     return atIndex;
   }
 
@@ -348,6 +660,15 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
       const removedRecords = removed.map(item => item.record);
       notify([EventTypes.remove, removedIndexes], removedRecords);
     }
+
+    // Remove from cache by id (best-effort).
+    removed.forEach(({ record }) => {
+      const id = record?.[keyField];
+      if (id !== undefined && id !== null) cacheRemoveById(id);
+    });
+    if (localMode && activeCriteria) {
+      void applyLocalCriteria(activeCriteria);
+    }
     return removed.length;
   }
 
@@ -362,6 +683,11 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     if (index < 0 || index >= current.length) return null;
     current[index] = stripComputedFields(model, clone(record));
     notify([EventTypes.update, index], cloneWithComputed(model, current[index], { clone }));
+
+    cacheIngest([current[index]]);
+    if (localMode && activeCriteria) {
+      void applyLocalCriteria(activeCriteria);
+    }
     return decorateRecordWithComputed(model, current[index]);
   }
 
@@ -395,6 +721,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     const res = await dataSource.query(buildQuerySpec(), { resource, entityType, keyField, versionField });
     // Materialize as page-local array
     const records = (res?.entities?.[entityType] || []).map(r => stripComputedFields(model, clone(r)));
+    cacheIngest(records);
     current = records;
     original = clone(records);
     pageInfo = res?.pageInfo || null;
@@ -405,6 +732,17 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
 
   async function pageNext() {
     if (!dataSource || typeof dataSource.query !== 'function') throw new Error('Remote store requires a dataSource with query().');
+    if (localMode) {
+      // Local paging over the last materialized localAll set.
+      pageState = { ...pageState, mode: 'offset', offset: (pageState.offset || 0) + (pageState.limit || 20) };
+      const { items, pageInfo: pi } = sliceOffsetPage(localAll, { offset: pageState.offset, limit: pageState.limit });
+      current = items;
+      original = clone(items);
+      pageInfo = pi;
+      status = 'success';
+      notify([EventTypes.reset, 0], current[0] || null);
+      return { entities: { [entityType]: current }, result: [], pageInfo };
+    }
     const mode = pageState.mode || 'cursor';
     if (mode === 'page') pageState = { ...pageState, page: (pageState.page || 0) + 1 };
     else if (mode === 'offset') pageState = { ...pageState, offset: (pageState.offset || 0) + (pageState.limit || 20) };
@@ -416,6 +754,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     status = 'loading'; error = null;
     const res = await dataSource.query(buildQuerySpec(), { resource, entityType, keyField, versionField });
     const records = (res?.entities?.[entityType] || []).map(r => stripComputedFields(model, clone(r)));
+    cacheIngest(records);
     current = records;
     original = clone(records);
     pageInfo = res?.pageInfo || null;
@@ -426,6 +765,16 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
 
   async function pagePrev() {
     if (!dataSource || typeof dataSource.query !== 'function') throw new Error('Remote store requires a dataSource with query().');
+    if (localMode) {
+      pageState = { ...pageState, mode: 'offset', offset: Math.max(0, (pageState.offset || 0) - (pageState.limit || 20)) };
+      const { items, pageInfo: pi } = sliceOffsetPage(localAll, { offset: pageState.offset, limit: pageState.limit });
+      current = items;
+      original = clone(items);
+      pageInfo = pi;
+      status = 'success';
+      notify([EventTypes.reset, 0], current[0] || null);
+      return { entities: { [entityType]: current }, result: [], pageInfo };
+    }
     const mode = pageState.mode || 'cursor';
     if (mode === 'page') pageState = { ...pageState, page: Math.max(0, (pageState.page || 0) - 1) };
     else if (mode === 'offset') pageState = { ...pageState, offset: Math.max(0, (pageState.offset || 0) - (pageState.limit || 20)) };
@@ -437,6 +786,7 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     status = 'loading'; error = null;
     const res = await dataSource.query(buildQuerySpec(), { resource, entityType, keyField, versionField });
     const records = (res?.entities?.[entityType] || []).map(r => stripComputedFields(model, clone(r)));
+    cacheIngest(records);
     current = records;
     original = clone(records);
     pageInfo = res?.pageInfo || null;
@@ -446,7 +796,75 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   }
 
   async function search(nextCriteria) {
+    // Remote search always disables localMode materialization.
+    localMode = false;
+    localAll = [];
     return loadFirst(nextCriteria || {});
+  }
+
+  async function applyLocalCriteria(next) {
+    const nextC = normalizeCriteriaInput(next);
+    const ctx = { model, viewName, viewConfig, store: storeApi, criteria: nextC };
+
+    if (nextC.scope === 'all') {
+      // Best-effort warm-all (bounded by cacheConfig.maxEntities if set).
+      await cacheWarmAll({ criteriaOverride: null });
+    } else if (cacheConfig && cacheState && cacheState.entities.size === 0) {
+      // Seed cache with at least one page so local filters are useful in "auto" mode.
+      try { await loadFirst(null); } catch { /* ignore; local filter will apply to empty */ }
+    }
+
+    const records = cacheSnapshot().map(r => stripComputedFields(model, clone(r)));
+    const pred = compileFilterPredicate(nextC.filter);
+    let filtered = records.filter(r => pred(r, ctx));
+    filtered = applySortLocal(filtered, nextC.sort);
+
+    localAll = filtered;
+    localMode = true;
+    status = 'success';
+    error = null;
+    // Local paging uses offset mode (simplest, deterministic).
+    const limit = Number.isFinite(nextC.page?.limit) ? Math.max(1, nextC.page.limit) : (pageState.limit || 20);
+    pageState = { ...pageState, mode: 'offset', offset: 0, limit, page: 0, cursor: null, pageIndex: 0 };
+
+    const { items, pageInfo: pi } = sliceOffsetPage(localAll, { offset: 0, limit });
+    current = items;
+    original = clone(items);
+    pageInfo = pi;
+    notify([EventTypes.reset, 0], current[0] || null);
+    return { entities: { [entityType]: current }, result: [], pageInfo };
+  }
+
+  async function setCriteria(nextCriteria) {
+    const next = normalizeCriteriaInput(nextCriteria);
+    const mode = next.mode;
+
+    // Normalize mode when filter is a predicate (local-only).
+    const effectiveMode = (typeof next.filter === 'function' && mode !== 'local') ? 'local' : mode;
+
+    activeCriteria = { ...next, mode: effectiveMode, seq: criteriaSeq++ };
+    notify([EventTypes.criteriaChanged, next.purpose], serializeCriteria(activeCriteria));
+
+    // Avoid footguns: local materialization while edits are pending can hide records and confuse diff/save.
+    if (effectiveMode === 'local' && pendingOps.length > 0) {
+      throw new Error('Cannot apply local criteria while there are pending edits. Call save() or reset() first.');
+    }
+
+    if (effectiveMode === 'remote') {
+      // Map to existing remote criteria channel.
+      const remoteCriteria = { filter: next.filter ?? null, sort: next.sort ?? null, select: null };
+      return search(remoteCriteria);
+    }
+
+    if (effectiveMode === 'local') {
+      return applyLocalCriteria(activeCriteria);
+    }
+
+    // auto:
+    // - predicate => local (already handled)
+    // - otherwise prefer local if cache is enabled; fallback to remote.
+    if (cacheConfig) return applyLocalCriteria(activeCriteria);
+    return search({ filter: next.filter ?? null, sort: next.sort ?? null, select: null });
   }
 
   async function save() {
@@ -541,6 +959,12 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     save,
     getStatus,
     getPagingState: () => ({ pageInfo, pageState: { ...pageState } }),
+    // Criteria + cache API (new)
+    setCriteria,
+    getCriteria,
+    getCacheStatus,
+    cacheSnapshot: () => cacheSnapshot().map(r => cloneWithComputed(model, r, { clone })),
+    cacheWarmAll,
 
     // View compatibility (if store is used as a collection controller)
     collection: () => storeApi,
@@ -695,6 +1119,13 @@ export function blinxStore(arg1, arg2) {
     save: () => proxy('save'),
     getStatus: () => proxy('getStatus'),
     getPagingState: () => proxy('getPagingState'),
+
+    // Criteria + cache API (new; proxied to active view)
+    setCriteria: (criteria) => proxy('setCriteria', criteria),
+    getCriteria: () => proxy('getCriteria'),
+    getCacheStatus: () => proxy('getCacheStatus'),
+    cacheSnapshot: () => proxy('cacheSnapshot'),
+    cacheWarmAll: (opts) => proxy('cacheWarmAll', opts),
   };
 
   // Initialize subscription to the default view for manager-level events.

--- a/lib/blinx.store.js
+++ b/lib/blinx.store.js
@@ -479,11 +479,8 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     return { warmed, pages };
   }
 
-  // ---- Criteria (remote + local) ----
-  let activeCriteria = null;     // last setCriteria() input (normalized)
-  let criteriaSeq = 1;
-  let localMode = false;         // whether the view is currently materialized from cache
-  let localAll = [];             // filtered+sorted array used for local paging
+  // ---- Local views (per-consumer criteria projections) ----
+  const localViews = new Map(); // localViewKey -> derived local view store
 
   function notify(path, value) {
     subs.forEach(fn => fn({ path, value, data: current, store: storeApi }));
@@ -498,10 +495,6 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   function subscribe(fn) { subs.add(fn); return () => subs.delete(fn); }
   function toJSON() { return current.map(r => cloneWithComputed(model, r, { clone })); }
   function getStatus() { return { status, error, pageInfo, pageState: { ...pageState }, criteria: clone(criteria) }; }
-
-  function getCriteria() {
-    return activeCriteria ? clone(serializeCriteria(activeCriteria)) : null;
-  }
 
   function getCacheStatus() {
     if (!cacheConfig || !cacheState) return { enabled: false };
@@ -605,12 +598,8 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
       enqueueUpdate(id, baseVersion, { [field]: value });
     }
 
-    // Keep cache in sync (best-effort). If localMode is active, this keeps projections stable.
+    // Keep cache in sync (best-effort).
     cacheIngest([rec]);
-    if (localMode && activeCriteria) {
-      // Recompute local projection with updated record (simple but correct).
-      void applyLocalCriteria(activeCriteria);
-    }
   }
 
   function addRecord(record, atIndex = current.length) {
@@ -630,9 +619,6 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     });
 
     cacheIngest([rec]);
-    if (localMode && activeCriteria) {
-      void applyLocalCriteria(activeCriteria);
-    }
     return atIndex;
   }
 
@@ -666,9 +652,6 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
       const id = record?.[keyField];
       if (id !== undefined && id !== null) cacheRemoveById(id);
     });
-    if (localMode && activeCriteria) {
-      void applyLocalCriteria(activeCriteria);
-    }
     return removed.length;
   }
 
@@ -685,9 +668,6 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     notify([EventTypes.update, index], cloneWithComputed(model, current[index], { clone }));
 
     cacheIngest([current[index]]);
-    if (localMode && activeCriteria) {
-      void applyLocalCriteria(activeCriteria);
-    }
     return decorateRecordWithComputed(model, current[index]);
   }
 
@@ -732,17 +712,6 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
 
   async function pageNext() {
     if (!dataSource || typeof dataSource.query !== 'function') throw new Error('Remote store requires a dataSource with query().');
-    if (localMode) {
-      // Local paging over the last materialized localAll set.
-      pageState = { ...pageState, mode: 'offset', offset: (pageState.offset || 0) + (pageState.limit || 20) };
-      const { items, pageInfo: pi } = sliceOffsetPage(localAll, { offset: pageState.offset, limit: pageState.limit });
-      current = items;
-      original = clone(items);
-      pageInfo = pi;
-      status = 'success';
-      notify([EventTypes.reset, 0], current[0] || null);
-      return { entities: { [entityType]: current }, result: [], pageInfo };
-    }
     const mode = pageState.mode || 'cursor';
     if (mode === 'page') pageState = { ...pageState, page: (pageState.page || 0) + 1 };
     else if (mode === 'offset') pageState = { ...pageState, offset: (pageState.offset || 0) + (pageState.limit || 20) };
@@ -765,16 +734,6 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
 
   async function pagePrev() {
     if (!dataSource || typeof dataSource.query !== 'function') throw new Error('Remote store requires a dataSource with query().');
-    if (localMode) {
-      pageState = { ...pageState, mode: 'offset', offset: Math.max(0, (pageState.offset || 0) - (pageState.limit || 20)) };
-      const { items, pageInfo: pi } = sliceOffsetPage(localAll, { offset: pageState.offset, limit: pageState.limit });
-      current = items;
-      original = clone(items);
-      pageInfo = pi;
-      status = 'success';
-      notify([EventTypes.reset, 0], current[0] || null);
-      return { entities: { [entityType]: current }, result: [], pageInfo };
-    }
     const mode = pageState.mode || 'cursor';
     if (mode === 'page') pageState = { ...pageState, page: Math.max(0, (pageState.page || 0) - 1) };
     else if (mode === 'offset') pageState = { ...pageState, offset: Math.max(0, (pageState.offset || 0) - (pageState.limit || 20)) };
@@ -796,75 +755,167 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
   }
 
   async function search(nextCriteria) {
-    // Remote search always disables localMode materialization.
-    localMode = false;
-    localAll = [];
     return loadFirst(nextCriteria || {});
   }
 
-  async function applyLocalCriteria(next) {
-    const nextC = normalizeCriteriaInput(next);
-    const ctx = { model, viewName, viewConfig, store: storeApi, criteria: nextC };
+  function localView(localViewKey) {
+    const key = (localViewKey === undefined || localViewKey === null || localViewKey === '') ? 'default' : String(localViewKey);
+    if (localViews.has(key)) return localViews.get(key);
 
-    if (nextC.scope === 'all') {
-      // Best-effort warm-all (bounded by cacheConfig.maxEntities if set).
-      await cacheWarmAll({ criteriaOverride: null });
-    } else if (cacheConfig && cacheState && cacheState.entities.size === 0) {
-      // Seed cache with at least one page so local filters are useful in "auto" mode.
-      try { await loadFirst(null); } catch { /* ignore; local filter will apply to empty */ }
+    const lvSubs = new Set();
+    let lvApi;
+
+    let lvOriginal = [];
+    let lvCurrent = [];
+    let lvAll = [];
+    let lvPageInfo = null;
+    let lvPageState = { mode: 'offset', offset: 0, limit: 20 };
+    let lvStatus = 'idle';
+    let lvError = null;
+    let lvCriteria = { purpose: key, mode: 'local', scope: 'cached', filter: null, sort: null, page: null, meta: null };
+    let baseUnsub = null;
+
+    function lvNotify(path, value) {
+      lvSubs.forEach(fn => fn({ path, value, data: lvCurrent, store: lvApi, view: viewName, localView: key }));
     }
 
-    const records = cacheSnapshot().map(r => stripComputedFields(model, clone(r)));
-    const pred = compileFilterPredicate(nextC.filter);
-    let filtered = records.filter(r => pred(r, ctx));
-    filtered = applySortLocal(filtered, nextC.sort);
-
-    localAll = filtered;
-    localMode = true;
-    status = 'success';
-    error = null;
-    // Local paging uses offset mode (simplest, deterministic).
-    const limit = Number.isFinite(nextC.page?.limit) ? Math.max(1, nextC.page.limit) : (pageState.limit || 20);
-    pageState = { ...pageState, mode: 'offset', offset: 0, limit, page: 0, cursor: null, pageIndex: 0 };
-
-    const { items, pageInfo: pi } = sliceOffsetPage(localAll, { offset: 0, limit });
-    current = items;
-    original = clone(items);
-    pageInfo = pi;
-    notify([EventTypes.reset, 0], current[0] || null);
-    return { entities: { [entityType]: current }, result: [], pageInfo };
-  }
-
-  async function setCriteria(nextCriteria) {
-    const next = normalizeCriteriaInput(nextCriteria);
-    const mode = next.mode;
-
-    // Normalize mode when filter is a predicate (local-only).
-    const effectiveMode = (typeof next.filter === 'function' && mode !== 'local') ? 'local' : mode;
-
-    activeCriteria = { ...next, mode: effectiveMode, seq: criteriaSeq++ };
-    notify([EventTypes.criteriaChanged, next.purpose], serializeCriteria(activeCriteria));
-
-    // Avoid footguns: local materialization while edits are pending can hide records and confuse diff/save.
-    if (effectiveMode === 'local' && pendingOps.length > 0) {
-      throw new Error('Cannot apply local criteria while there are pending edits. Call save() or reset() first.');
+    function sourceSnapshot() {
+      // Prefer the shared per-view cache as the projection source.
+      if (cacheConfig && cacheState) return cacheSnapshot();
+      // Fallback: page-local snapshot (best-effort) if cache is disabled.
+      try {
+        return (storeApi?.toJSON ? storeApi.toJSON() : []).map(r => stripComputedFields(model, clone(r)));
+      } catch {
+        return [];
+      }
     }
 
-    if (effectiveMode === 'remote') {
-      // Map to existing remote criteria channel.
-      const remoteCriteria = { filter: next.filter ?? null, sort: next.sort ?? null, select: null };
-      return search(remoteCriteria);
+    async function materialize({ resetOffset = false } = {}) {
+      const nextC = normalizeCriteriaInput(lvCriteria);
+      lvCriteria = { ...lvCriteria, ...nextC, purpose: key, mode: 'local' };
+
+      if (nextC.scope === 'all') {
+        // Best-effort warm-all (bounded by cacheConfig.maxEntities if set).
+        await cacheWarmAll({ criteriaOverride: null });
+      }
+
+      const ctx = { model, viewName, viewConfig, store: storeApi, localView: key, criteria: lvCriteria };
+      const records = sourceSnapshot().map(r => stripComputedFields(model, clone(r)));
+      const pred = compileFilterPredicate(lvCriteria.filter);
+      let filtered = records.filter(r => pred(r, ctx));
+      filtered = applySortLocal(filtered, lvCriteria.sort);
+      lvAll = filtered;
+
+      const nextLimit = Number.isFinite(lvCriteria.page?.limit)
+        ? Math.max(1, lvCriteria.page.limit)
+        : (Number.isFinite(lvPageState.limit) ? lvPageState.limit : 20);
+      const nextOffset = resetOffset ? 0 : (Number.isFinite(lvPageState.offset) ? lvPageState.offset : 0);
+      lvPageState = { mode: 'offset', offset: Math.max(0, nextOffset), limit: nextLimit };
+
+      // Clamp offset to dataset length.
+      if (lvPageState.offset > 0 && lvPageState.offset >= lvAll.length) {
+        lvPageState = { ...lvPageState, offset: Math.max(0, lvAll.length - (lvPageState.limit || 20)) };
+      }
+
+      const { items, pageInfo: pi } = sliceOffsetPage(lvAll, { offset: lvPageState.offset, limit: lvPageState.limit });
+      lvCurrent = items;
+      lvOriginal = clone(items);
+      lvPageInfo = pi;
+      lvStatus = 'success';
+      lvError = null;
+
+      // Use reset to trigger UI refresh in collection/table without special-casing.
+      lvNotify([EventTypes.reset, 0], lvCurrent[0] || null);
+      return { entities: { [entityType]: lvCurrent }, result: [], pageInfo: lvPageInfo };
     }
 
-    if (effectiveMode === 'local') {
-      return applyLocalCriteria(activeCriteria);
+    function attachBaseSubscription() {
+      if (typeof baseUnsub === 'function') return;
+      // Subscribe to the remote view store's event bus; re-materialize on data changes.
+      baseUnsub = storeApi.subscribe(ev => {
+        if (!ev || !Array.isArray(ev.path)) return materialize({ resetOffset: false }).catch(() => {});
+        const action = ev.path[0];
+        // Any data mutation or page load can affect the cache/projection.
+        const relevant = new Set([EventTypes.add, EventTypes.remove, EventTypes.update, EventTypes.commit, EventTypes.reset]);
+        if (relevant.has(action)) {
+          materialize({ resetOffset: false }).catch(() => {});
+        }
+      });
     }
 
-    // auto:
-    // - predicate => local (already handled)
-    // - otherwise prefer local if cache is enabled; fallback to remote.
-    if (cacheConfig) return applyLocalCriteria(activeCriteria);
-    return search({ filter: next.filter ?? null, sort: next.sort ?? null, select: null });
+    function detachBaseSubscriptionIfIdle() {
+      if (lvSubs.size > 0) return;
+      if (typeof baseUnsub === 'function') {
+        try { baseUnsub(); } catch { /* ignore */ }
+      }
+      baseUnsub = null;
+    }
+
+    lvApi = {
+      // Store-like API (read-first)
+      getModel: () => model,
+      getRecord: (idx) => decorateRecordWithComputed(model, lvCurrent[idx]),
+      getLength: () => lvCurrent.length,
+      toJSON: () => lvCurrent.map(r => cloneWithComputed(model, r, { clone })),
+      subscribe(fn) {
+        lvSubs.add(fn);
+        if (lvSubs.size === 1) {
+          attachBaseSubscription();
+          // Eagerly materialize once so initial render is consistent.
+          materialize({ resetOffset: false }).catch(() => {});
+        }
+        return () => {
+          lvSubs.delete(fn);
+          detachBaseSubscriptionIfIdle();
+        };
+      },
+      diff: () => {
+        const changes = [];
+        const max = Math.max(lvCurrent.length, lvOriginal.length);
+        for (let i = 0; i < max; i++) {
+          const rec = lvCurrent[i];
+          const orig = lvOriginal[i];
+          if (rec && !orig) { changes.push({ index: i, added: true, to: rec }); continue; }
+          if (!rec && orig) { changes.push({ index: i, deleted: true, from: orig }); continue; }
+          if (rec && orig) {
+            for (const k2 of Object.keys(rec)) {
+              if (JSON.stringify(rec[k2]) !== JSON.stringify(orig[k2])) {
+                changes.push({ index: i, field: k2, from: orig[k2], to: rec[k2] });
+              }
+            }
+          }
+        }
+        return changes;
+      },
+      commit: () => { lvOriginal = clone(lvCurrent); lvNotify([EventTypes.commit], lvCurrent.map(r => cloneWithComputed(model, r, { clone }))); },
+      reset: () => { lvCurrent = clone(lvOriginal); lvNotify([EventTypes.reset, 0], lvCurrent[0] || null); },
+
+      // Local criteria API (per-consumer)
+      async setCriteria(nextCriteria) {
+        lvCriteria = { ...lvCriteria, ...normalizeCriteriaInput(nextCriteria), purpose: key, mode: 'local' };
+        lvNotify([EventTypes.criteriaChanged], serializeCriteria(lvCriteria));
+        return materialize({ resetOffset: true });
+      },
+      getCriteria: () => clone(serializeCriteria(lvCriteria)),
+      getStatus: () => ({ status: lvStatus, error: lvError, pageInfo: lvPageInfo, pageState: { ...lvPageState }, criteria: clone(serializeCriteria(lvCriteria)) }),
+      getPagingState: () => ({ pageInfo: lvPageInfo, pageState: { ...lvPageState } }),
+      async pageNext() {
+        lvPageState = { ...lvPageState, offset: (lvPageState.offset || 0) + (lvPageState.limit || 20) };
+        return materialize({ resetOffset: false });
+      },
+      async pagePrev() {
+        lvPageState = { ...lvPageState, offset: Math.max(0, (lvPageState.offset || 0) - (lvPageState.limit || 20)) };
+        return materialize({ resetOffset: false });
+      },
+
+      // Convenience: allow nested local views to be stable
+      localView: (k2) => localView(k2),
+      // For compatibility with "collection controller" usage
+      collection: () => lvApi,
+    };
+
+    localViews.set(key, lvApi);
+    return lvApi;
   }
 
   async function save() {
@@ -959,9 +1010,8 @@ function createRemoteViewStore({ model, dataSource, viewName, viewConfig }) {
     save,
     getStatus,
     getPagingState: () => ({ pageInfo, pageState: { ...pageState } }),
-    // Criteria + cache API (new)
-    setCriteria,
-    getCriteria,
+    // Local criteria projections (per-consumer)
+    localView,
     getCacheStatus,
     cacheSnapshot: () => cacheSnapshot().map(r => cloneWithComputed(model, r, { clone })),
     cacheWarmAll,
@@ -1120,9 +1170,8 @@ export function blinxStore(arg1, arg2) {
     getStatus: () => proxy('getStatus'),
     getPagingState: () => proxy('getPagingState'),
 
-    // Criteria + cache API (new; proxied to active view)
-    setCriteria: (criteria) => proxy('setCriteria', criteria),
-    getCriteria: () => proxy('getCriteria'),
+    // Local criteria projections (per-consumer; proxied to active view)
+    localView: (key) => proxy('localView', key),
     getCacheStatus: () => proxy('getCacheStatus'),
     cacheSnapshot: () => proxy('cacheSnapshot'),
     cacheWarmAll: (opts) => proxy('cacheWarmAll', opts),

--- a/lib/blinx.table.js
+++ b/lib/blinx.table.js
@@ -6,6 +6,7 @@ export function blinxTable({
   root, view, store,
   pageSize = 20,
   onRowClick,
+  localView,
   controls,
   context,
   actionRegistry,
@@ -38,6 +39,7 @@ export function blinxTable({
     actions: { create: true, deleteSelected: true },
     onItemClick: onRowClick ? ({ index }) => onRowClick(index) : null,
   };
+  if (Object.prototype.hasOwnProperty.call(args, 'localView')) opts.localView = localView;
   if (Object.prototype.hasOwnProperty.call(args, 'context')) opts.context = context;
   if (Object.prototype.hasOwnProperty.call(args, 'controls')) opts.controls = controls;
   if (Object.prototype.hasOwnProperty.call(args, 'actionRegistry')) opts.actionRegistry = actionRegistry;


### PR DESCRIPTION
Add local data filtering and multi-page entity caching to `blinx.store`.

This enables declarative, client-side filtering over cached data, centralizing filtering logic and improving UI responsiveness without requiring components to re-render or duplicate filtering mechanisms.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9d368dd-959d-4416-bf9a-968814157f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9d368dd-959d-4416-bf9a-968814157f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables client-side criteria on top of a per-view entity cache and integrates it with collection/table UIs.
> 
> - Store: add entity cache (`cache.{completeness,maxEntities,eviction,fields,persist}`), warm-all, and local views (`localView(key[, { mutable }])`) with `setCriteria({ scope, filter, sort, page, meta })`; emit `criteriaChanged`; expose `isMutable`, `deleteById`, `updateById`, cache APIs (`getCacheStatus/cacheSnapshot/cacheWarmAll`); manager proxies these
> - Criteria: supports DSL (`and/or`, `{field,op,value}`, `between`, etc.) and predicate escape hatch (serialized as `filterType: 'fn'`)
> - UI: `blinxCollection`/`blinxTable` accept `localView`; add `selection.isRowSelectable(ctx, record, index)` to gate row checkboxes; dynamic `controls.disabled/visible` functions are evaluated and synced; disable Create/Delete when store is read-only or empty; improved status messaging
> - Tests: cover local cache criteria across pages, warm-all behavior, predicate filter serialization, localView mutability, and read-only local views disabling mutations
> - Docs: add data-views and ui-views spec updates (cache strategy, local views/criteria, selection predicate, dynamic control state) and fix README links
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 128364c7a8fc0c12f6199b8f6214fc11e43e58e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->