### PR TITLE
New cart collection type

### DIFF
--- a/__tests__/blinx.cart.test.js
+++ b/__tests__/blinx.cart.test.js
@@ -1,0 +1,91 @@
+/** @jest-environment jsdom */
+
+import { blinxCart } from '../lib/blinx.cart.js';
+
+describe('blinxCart', () => {
+  test('defaults to all-selected and supports reset selection', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const root = document.createElement('div');
+
+    const { cartApi } = blinxCart({
+      root,
+      model,
+      labelField: 'name',
+      data: [{ name: 'A' }, { name: 'B' }],
+    });
+
+    // Initial selection is "all selected"
+    let cbs = root.querySelectorAll('input[type="checkbox"]');
+    expect(cbs.length).toBe(2);
+    expect(cbs[0].checked).toBe(true);
+    expect(cbs[1].checked).toBe(true);
+
+    // Deselect first -> row should be crossed-out
+    cbs[0].checked = false;
+    cbs[0].dispatchEvent(new Event('change', { bubbles: true }));
+
+    const rows = root.querySelectorAll('.blx-cart__row');
+    expect(rows[0].classList.contains('blx-cart__row--deselected')).toBe(true);
+
+    // Reset via default control
+    const resetBtn = Array.from(root.querySelectorAll('button')).find(b => b.textContent === 'Reset');
+    expect(resetBtn).toBeTruthy();
+    resetBtn.click();
+    await Promise.resolve();
+
+    cbs = root.querySelectorAll('input[type="checkbox"]');
+    expect(cbs[0].checked).toBe(true);
+    expect(cbs[1].checked).toBe(true);
+    expect(root.querySelectorAll('.blx-cart__row--deselected').length).toBe(0);
+
+    // getSelected returns selected records
+    const selected = cartApi.getSelected();
+    expect(selected).toEqual([{ name: 'A' }, { name: 'B' }]);
+  });
+
+  test('selectable=false renders prefix icon instead of checkbox', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const root = document.createElement('div');
+
+    blinxCart({
+      root,
+      model,
+      labelField: 'name',
+      data: [{ name: 'A' }],
+      selectable: false,
+    });
+
+    expect(root.querySelectorAll('input[type="checkbox"]').length).toBe(0);
+    expect(root.textContent).toContain('➖');
+  });
+
+  test('editable=true shows edit icon and executes record control action', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const root = document.createElement('div');
+    const editHandler = jest.fn();
+
+    blinxCart({
+      root,
+      model,
+      labelField: 'name',
+      data: [{ name: 'A' }],
+      editable: true,
+      actionRegistry: {
+        'blinx.global.journeys.edit-single-model': { handler: () => editHandler() },
+      },
+    });
+
+    const cb = root.querySelector('input[type="checkbox"]');
+    expect(cb.checked).toBe(true);
+
+    const editBtn = Array.from(root.querySelectorAll('button')).find(b => b.textContent === '⚙️');
+    expect(editBtn).toBeTruthy();
+    editBtn.click();
+    await Promise.resolve();
+
+    expect(editHandler).toHaveBeenCalledTimes(1);
+    // Clicking edit icon must NOT toggle selection
+    expect(root.querySelector('input[type="checkbox"]').checked).toBe(true);
+  });
+});
+

--- a/__tests__/blinx.cart.test.js
+++ b/__tests__/blinx.cart.test.js
@@ -57,6 +57,7 @@ describe('blinxCart', () => {
 
     expect(root.querySelectorAll('input[type="checkbox"]').length).toBe(0);
     expect(root.textContent).toContain('➖');
+    expect(Array.from(root.querySelectorAll('button')).some(b => b.textContent === 'Reset')).toBe(false);
   });
 
   test('editable=true shows edit icon and executes record control action', async () => {

--- a/__tests__/blinx.cart.test.js
+++ b/__tests__/blinx.cart.test.js
@@ -106,5 +106,69 @@ describe('blinxCart', () => {
     store.addRecord({ name: 'B' });
     expect(root.querySelectorAll('.blx-cart__row').length).toBe(2);
   });
+
+  test('supports multiple record controls (custom) and executes correct actions', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const root = document.createElement('div');
+    const editHandler = jest.fn();
+    const deleteHandler = jest.fn();
+
+    blinxCart({
+      root,
+      model,
+      labelField: 'name',
+      data: [{ name: 'A' }],
+      editable: false,
+      recordControls: {
+        edit: { label: 'Edit', action: 'cart.edit' },
+        delete: { label: 'Delete', action: 'cart.delete' },
+        hidden: { label: 'Hidden', visible: () => false, action: 'cart.hidden' },
+      },
+      actionRegistry: {
+        'cart.edit': { handler: () => editHandler() },
+        'cart.delete': { handler: () => deleteHandler() },
+        'cart.hidden': { handler: () => { throw new Error('should not run'); } },
+      },
+    });
+
+    const btn = (label) => Array.from(root.querySelectorAll('button')).find(b => b.textContent === label);
+    expect(btn('Edit')).toBeTruthy();
+    expect(btn('Delete')).toBeTruthy();
+    expect(btn('Hidden')).toBeFalsy();
+
+    btn('Edit').click();
+    btn('Delete').click();
+    await Promise.resolve();
+
+    expect(editHandler).toHaveBeenCalledTimes(1);
+    expect(deleteHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test('getSelected() returns only selected items (some selected, none selected)', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const root = document.createElement('div');
+
+    const { cartApi } = blinxCart({
+      root,
+      model,
+      labelField: 'name',
+      data: [{ name: 'A' }, { name: 'B' }, { name: 'C' }],
+      selectable: true,
+    });
+
+    // Deselect B only.
+    const cbs = Array.from(root.querySelectorAll('input[type="checkbox"]'));
+    expect(cbs.length).toBe(3);
+    cbs[1].checked = false;
+    cbs[1].dispatchEvent(new Event('change', { bubbles: true }));
+    expect(cartApi.getSelected()).toEqual([{ name: 'A' }, { name: 'C' }]);
+
+    // Deselect all.
+    for (const cb of Array.from(root.querySelectorAll('input[type="checkbox"]'))) {
+      cb.checked = false;
+      cb.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+    expect(cartApi.getSelected()).toEqual([]);
+  });
 });
 

--- a/__tests__/blinx.cart.test.js
+++ b/__tests__/blinx.cart.test.js
@@ -1,6 +1,7 @@
 /** @jest-environment jsdom */
 
 import { blinxCart } from '../lib/blinx.cart.js';
+import { blinxStore } from '../lib/blinx.store.js';
 
 describe('blinxCart', () => {
   test('defaults to all-selected and supports reset selection', async () => {
@@ -87,6 +88,23 @@ describe('blinxCart', () => {
     expect(editHandler).toHaveBeenCalledTimes(1);
     // Clicking edit icon must NOT toggle selection
     expect(root.querySelector('input[type="checkbox"]').checked).toBe(true);
+  });
+
+  test('accepts external store so external actions can add items', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+
+    blinxCart({
+      root,
+      store,
+      labelField: 'name',
+      // model optional when store is provided
+    });
+
+    expect(root.querySelectorAll('.blx-cart__row').length).toBe(1);
+    store.addRecord({ name: 'B' });
+    expect(root.querySelectorAll('.blx-cart__row').length).toBe(2);
   });
 });
 

--- a/__tests__/blinx.collection.test.js
+++ b/__tests__/blinx.collection.test.js
@@ -261,5 +261,76 @@ describe('blinxCollection', () => {
     expect(btn('Create').disabled).toBe(true);
     expect(btn('Delete Selected').disabled).toBe(true);
   });
+
+  test('api.setSelection(asBaseline) + api.resetSelection restores selection baseline', () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }, { name: 'B' }], model);
+    const root = document.createElement('div');
+
+    const { api } = blinxCollection({
+      root,
+      store,
+      view: { layout: 'table', columns: [{ field: 'name', label: 'Name' }] },
+      paging: { pageSize: 20 },
+      selection: { mode: 'multi' },
+      controls: {}, // suppress toolbar noise
+    });
+
+    // Baseline = all selected.
+    api.setSelection([0, 1], { asBaseline: true });
+
+    let cbs = root.querySelectorAll('tbody tr input[type="checkbox"]');
+    expect(cbs[0].checked).toBe(true);
+    expect(cbs[1].checked).toBe(true);
+
+    // Deselect one.
+    cbs[0].checked = false;
+    cbs[0].dispatchEvent(new Event('change', { bubbles: true }));
+
+    cbs = root.querySelectorAll('tbody tr input[type="checkbox"]');
+    expect(cbs[0].checked).toBe(false);
+    expect(cbs[1].checked).toBe(true);
+
+    // Reset back to baseline.
+    api.resetSelection();
+    cbs = root.querySelectorAll('tbody tr input[type="checkbox"]');
+    expect(cbs[0].checked).toBe(true);
+    expect(cbs[1].checked).toBe(true);
+  });
+
+  test('view.recordControls renders per-row buttons and does not toggle row selection', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+    const onItemClick = jest.fn();
+    const onEdit = jest.fn();
+
+    blinxCollection({
+      root,
+      store,
+      view: {
+        layout: 'table',
+        columns: [{ field: 'name', label: 'Name' }],
+        recordControls: {
+          edit: { label: 'Edit', action: () => onEdit() },
+        },
+      },
+      paging: { pageSize: 20 },
+      onItemClick,
+      controls: {}, // keep DOM small
+    });
+
+    const cb = root.querySelector('tbody tr input[type="checkbox"]');
+    expect(cb.checked).toBe(false);
+
+    const editBtn = Array.from(root.querySelectorAll('tbody tr button')).find(b => b.textContent === 'Edit');
+    expect(editBtn).toBeTruthy();
+    editBtn.click();
+    await Promise.resolve();
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onItemClick).toHaveBeenCalledTimes(0);
+    expect(root.querySelector('tbody tr input[type="checkbox"]').checked).toBe(false);
+  });
 });
 

--- a/__tests__/blinx.collection.test.js
+++ b/__tests__/blinx.collection.test.js
@@ -332,5 +332,66 @@ describe('blinxCollection', () => {
     expect(onItemClick).toHaveBeenCalledTimes(0);
     expect(root.querySelector('tbody tr input[type="checkbox"]').checked).toBe(false);
   });
+
+  test('view.recordControls supports multiple actions with visible/disabled guards', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+    const onItemClick = jest.fn();
+    const onEdit = jest.fn();
+    const onDelete = jest.fn();
+
+    blinxCollection({
+      root,
+      store,
+      view: {
+        layout: 'table',
+        columns: [{ field: 'name', label: 'Name' }],
+        recordControls: {
+          edit: { label: 'Edit', action: () => onEdit() },
+          delete: {
+            label: 'Delete',
+            disabled: (_ctx) => true,
+            action: () => onDelete(),
+          },
+          hidden: {
+            label: 'Hidden',
+            visible: () => false,
+            action: () => { throw new Error('should not run'); },
+          },
+        },
+      },
+      paging: { pageSize: 20 },
+      onItemClick,
+      controls: {},
+    });
+
+    // Should render Edit + Delete only (Hidden suppressed)
+    const row = root.querySelector('tbody tr');
+    const buttons = Array.from(row.querySelectorAll('button'));
+    const labels = buttons.map(b => b.textContent);
+    expect(labels).toContain('Edit');
+    expect(labels).toContain('Delete');
+    expect(labels).not.toContain('Hidden');
+
+    const editBtn = buttons.find(b => b.textContent === 'Edit');
+    const deleteBtn = buttons.find(b => b.textContent === 'Delete');
+    expect(editBtn.disabled).toBe(false);
+    expect(deleteBtn.disabled).toBe(true);
+
+    // Clicking disabled button does nothing
+    deleteBtn.click();
+    await Promise.resolve();
+    expect(onDelete).toHaveBeenCalledTimes(0);
+
+    // Clicking edit triggers handler but not row click nor selection toggle
+    const cb = row.querySelector('input[type="checkbox"]');
+    expect(cb.checked).toBe(false);
+    editBtn.click();
+    await Promise.resolve();
+    expect(onEdit).toHaveBeenCalledTimes(1);
+    expect(onItemClick).toHaveBeenCalledTimes(0);
+    expect(row.querySelector('input[type="checkbox"]').checked).toBe(false);
+  });
 });
 

--- a/docs/spec/ui-views.md
+++ b/docs/spec/ui-views.md
@@ -337,6 +337,31 @@ selection: {
 }
 ```
 
+### Record controls (optional)
+
+Collection views may optionally declare **per-record controls** via `view.recordControls`.
+
+Notes:
+- Controls are **rendered by layouts that support them** (currently built-in `table`, and any custom layout that chooses to use them).
+- `action` supports the same action shapes as `view.controls` (function / string id / `{id,payload}`).
+- `visible` / `disabled` may be booleans or functions `(ctx) => boolean`.
+
+Example:
+
+```js
+{
+  layout: 'table',
+  columns: [{ field: 'name', label: 'Name' }],
+  recordControls: {
+    edit: {
+      label: '⚙️',
+      action: 'blinx.global.journeys.edit-single-model',
+      disabled: (ctx) => !ctx.record?.id,
+    },
+  },
+}
+```
+
 ### Column
 
 ```js

--- a/lib/blinx.cart.js
+++ b/lib/blinx.cart.js
@@ -161,12 +161,14 @@ export function blinxCart({
 
   const store = blinxStore(Array.isArray(data) ? data : [], model);
 
-  const defaultControls = {
+  const defaultControls = selectable ? {
     resetButton: {
       label: 'Reset',
+      // Hide in case callers override selection mode to 'none' via a custom view.
+      visible: (ctx2) => (ctx2?.getState?.()?.selectionMode || 'multi') !== 'none',
       action: (ctx2) => ctx2?.api?.resetSelection?.(),
     }
-  };
+  } : {};
   const givenControls = isPlainObject(controls) ? controls : {};
 
   const defaultRecordControls = editable

--- a/lib/blinx.cart.js
+++ b/lib/blinx.cart.js
@@ -1,0 +1,237 @@
+import { blinxStore } from './blinx.store.js';
+import { blinxCollection } from './blinx.collection.js';
+
+function isPlainObject(v) {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function cartLabelFieldFromView(view, fallback) {
+  if (view?.item?.labelField) return String(view.item.labelField);
+  if (view?.labelField) return String(view.labelField);
+  const firstCol = Array.isArray(view?.columns) ? view.columns[0] : null;
+  if (firstCol?.field) return String(firstCol.field);
+  return fallback ? String(fallback) : null;
+}
+
+function createCartLayout() {
+  return {
+    mount({ root: mountRoot, view, controller, onItemClick, ctx, runRecordAction }) {
+      const list = document.createElement('div');
+      list.className = 'blx-cart';
+      mountRoot.appendChild(list);
+
+      function update() {
+        list.innerHTML = '';
+        const state = controller.getState();
+        const items = state?.items || [];
+        const selectionMode = state?.selectionMode || 'multi';
+        const selectable = selectionMode !== 'none';
+
+        const labelField = cartLabelFieldFromView(view, null);
+
+        const recordControls = isPlainObject(view?.recordControls) ? view.recordControls : null;
+        const recordControlEntries = recordControls ? Object.entries(recordControls) : [];
+
+        const prefix = isPlainObject(view?.prefix) ? view.prefix : null;
+
+        const frag = document.createDocumentFragment();
+        for (const { index, record } of items) {
+          const row = document.createElement('div');
+          row.className = 'blx-cart__row';
+
+          const selected = selectable ? controller.isSelected(index) : true;
+          if (selectable && !selected) row.classList.add('blx-cart__row--deselected');
+
+          // Prefix (either selection checkbox or an icon)
+          const prefixEl = document.createElement('span');
+          prefixEl.className = 'blx-cart__prefix';
+
+          if (selectable) {
+            const cb = document.createElement('input');
+            cb.type = 'checkbox';
+            cb.className = 'blx-checkbox';
+            cb.checked = selected;
+            if (typeof controller.isRowSelectable === 'function') {
+              const rowSelectable = !!controller.isRowSelectable(index, record);
+              cb.disabled = !rowSelectable;
+              cb.setAttribute('aria-disabled', rowSelectable ? 'false' : 'true');
+            }
+            cb.addEventListener('change', () => {
+              controller.toggleSelected(index, cb.checked);
+              // Multi-select mode does not always force a refresh; keep crossed-out styling in sync.
+              if (cb.checked) row.classList.remove('blx-cart__row--deselected');
+              else row.classList.add('blx-cart__row--deselected');
+            });
+            prefixEl.appendChild(cb);
+          } else {
+            const icon = document.createElement('span');
+            icon.className = 'blx-cart__prefix-icon';
+            icon.textContent = (typeof prefix?.label === 'string' && prefix.label) ? prefix.label : '➖';
+            prefixEl.appendChild(icon);
+          }
+
+          const label = document.createElement('span');
+          label.className = 'blx-cart__label';
+          if (labelField) label.textContent = record?.[labelField] ?? '';
+          else label.textContent = record ? String(record) : '';
+
+          const controls = document.createElement('span');
+          controls.className = 'blx-cart__controls';
+
+          for (const [name, spec] of recordControlEntries) {
+            const raw = isPlainObject(spec) ? spec : {};
+            const controlCtx = {
+              store: ctx?.store,
+              model: ctx?.model,
+              view: ctx?.view,
+              kind: ctx?.kind,
+              record,
+              index,
+              getState: () => controller.getState(),
+              context: ctx,
+            };
+            const visible = (typeof raw.visible === 'function')
+              ? (() => { try { return !!raw.visible(controlCtx); } catch { return false; } })()
+              : (typeof raw.visible === 'boolean' ? raw.visible : true);
+            if (!visible) continue;
+            const disabled = (typeof raw.disabled === 'function')
+              ? (() => { try { return !!raw.disabled(controlCtx); } catch { return true; } })()
+              : (typeof raw.disabled === 'boolean' ? raw.disabled : false);
+
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'blx-cart__control';
+            btn.textContent = (typeof raw.label === 'string' && raw.label) ? raw.label : String(name);
+            btn.disabled = !!disabled;
+            btn.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+            btn.addEventListener('click', async (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (btn.disabled) return;
+              if (typeof runRecordAction === 'function') {
+                await runRecordAction({ name, action: raw.action, record, index, meta: { kind: 'cart', controlName: name, viewId: view?.id } });
+              }
+            });
+            controls.appendChild(btn);
+          }
+
+          row.append(prefixEl, label, controls);
+
+          if (onItemClick) {
+            row.addEventListener('click', (e) => {
+              // Prevent row click when interacting with checkbox/buttons.
+              const t = e.target;
+              if (t && (t.tagName === 'INPUT' || t.tagName === 'BUTTON')) return;
+              onItemClick({ index, record });
+            });
+          }
+
+          frag.appendChild(row);
+        }
+        list.appendChild(frag);
+      }
+
+      return { update, destroy: () => { try { list.remove(); } catch { /* ignore */ } } };
+    }
+  };
+}
+
+export function blinxCart({
+  root,
+  view,
+  labelField,
+  data = [],
+  model,
+  selectable = true,
+  editable = false,
+  onRowClick,
+  controls,
+  recordControls,
+  context,
+  actionRegistry,
+  actionRunner,
+} = {}) {
+  if (!root) throw new Error('blinxCart requires a root element.');
+  if (!model || !isPlainObject(model) || !isPlainObject(model.fields)) {
+    throw new Error('blinxCart requires a model with fields.');
+  }
+  if (!labelField && !(view && typeof view === 'object')) {
+    throw new Error('blinxCart requires labelField when view is not provided.');
+  }
+
+  const store = blinxStore(Array.isArray(data) ? data : [], model);
+
+  const defaultControls = {
+    resetButton: {
+      label: 'Reset',
+      action: (ctx2) => ctx2?.api?.resetSelection?.(),
+    }
+  };
+  const givenControls = isPlainObject(controls) ? controls : {};
+
+  const defaultRecordControls = editable
+    ? {
+      editIcon: {
+        label: '⚙️',
+        action: 'blinx.global.journeys.edit-single-model',
+      }
+    }
+    : {};
+  const givenRecordControls = isPlainObject(recordControls) ? recordControls : {};
+
+  const cartView = (view && typeof view === 'object') ? view : {
+    layout: 'cart',
+    columns: [{ field: String(labelField), label: String(labelField) }],
+    item: { labelField: String(labelField) },
+    controls: { ...defaultControls, ...givenControls },
+    recordControls: { ...defaultRecordControls, ...givenRecordControls },
+    prefix: { label: '➖' },
+  };
+
+  const pageSize = Math.max(1, store.getLength());
+
+  const { api } = blinxCollection({
+    root,
+    store,
+    view: cartView,
+    layouts: { cart: createCartLayout() },
+    paging: { pageSize, page: 0 },
+    selection: { mode: selectable ? 'multi' : 'none' },
+    actions: { create: false, deleteSelected: false },
+    controls: cartView.controls,
+    onItemClick: onRowClick ? ({ index }) => onRowClick(index) : null,
+    context,
+    actionRegistry,
+    actionRunner,
+  });
+
+  // Cart default: initial selection includes all items when selectable.
+  if (selectable) {
+    const all = Array.from({ length: store.getLength() }, (_, i) => i);
+    api.setSelection(all, { asBaseline: true });
+  }
+
+  function getSelected() {
+    // Commit the store snapshot, then return selected records.
+    try { store.commit(); } catch { /* ignore */ }
+    const state = api.getState();
+    const sel = state?.selected instanceof Set ? state.selected : new Set();
+    const dataSnap = store.toJSON();
+    const out = [];
+    sel.forEach((idx) => {
+      if (idx >= 0 && idx < dataSnap.length) out.push(dataSnap[idx]);
+    });
+    return out;
+  }
+
+  return {
+    cartApi: {
+      ...api,
+      getSelected,
+    }
+  };
+}
+
+// Backwards-compatible alias (deprecated)
+export { blinxCart as renderBlinxCart };
+

--- a/lib/blinx.cart.js
+++ b/lib/blinx.cart.js
@@ -140,6 +140,7 @@ export function blinxCart({
   root,
   view,
   labelField,
+  store,
   data = [],
   model,
   selectable = true,
@@ -152,14 +153,19 @@ export function blinxCart({
   actionRunner,
 } = {}) {
   if (!root) throw new Error('blinxCart requires a root element.');
-  if (!model || !isPlainObject(model) || !isPlainObject(model.fields)) {
-    throw new Error('blinxCart requires a model with fields.');
-  }
   if (!labelField && !(view && typeof view === 'object')) {
     throw new Error('blinxCart requires labelField when view is not provided.');
   }
 
-  const store = blinxStore(Array.isArray(data) ? data : [], model);
+  if (store && typeof store.getModel !== 'function') {
+    throw new Error('blinxCart requires store to implement getModel().');
+  }
+  const modelFromStore = store ? store.getModel() : null;
+  const resolvedModel = modelFromStore || model;
+  if (!resolvedModel || !isPlainObject(resolvedModel) || !isPlainObject(resolvedModel.fields)) {
+    throw new Error('blinxCart requires a model with fields (either via store.getModel() or model param).');
+  }
+  store = store || blinxStore(Array.isArray(data) ? data : [], resolvedModel);
 
   const defaultControls = selectable ? {
     resetButton: {
@@ -190,7 +196,9 @@ export function blinxCart({
     prefix: { label: '➖' },
   };
 
-  const pageSize = Math.max(1, store.getLength());
+  // Cart UX: show the full cart without paging.
+  // Use a large finite number (Infinity is not finite and would be ignored by blinxCollection).
+  const pageSize = 100000;
 
   const { api } = blinxCollection({
     root,

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -112,7 +112,18 @@ function resolveLayout(layout, builtins, customLayouts) {
 
 function createTableLayout() {
   return {
-    mount({ root, model, view, getUI, supportsRendererForCell, controller, onItemClick, ctx }) {
+    mount({
+      root,
+      model,
+      view,
+      getUI,
+      supportsRendererForCell,
+      controller,
+      onItemClick,
+      ctx,
+      runAction,
+      runRecordAction,
+    }) {
       const table = document.createElement('table');
       table.className = 'blx-table';
       const thead = document.createElement('thead');
@@ -140,6 +151,17 @@ function createTableLayout() {
           }
           thr.appendChild(th);
         });
+
+        const recordControls = (view && typeof view === 'object' && view.recordControls && typeof view.recordControls === 'object')
+          ? view.recordControls
+          : null;
+        const recordControlEntries = recordControls ? Object.entries(recordControls) : [];
+        const hasRecordControls = recordControlEntries.length > 0;
+        if (hasRecordControls) {
+          const th = document.createElement('th');
+          th.textContent = '';
+          thr.appendChild(th);
+        }
 
         tbody.innerHTML = '';
         const { items } = controller.getState();
@@ -224,6 +246,66 @@ function createTableLayout() {
 
             tr.appendChild(td);
           });
+
+          if (hasRecordControls) {
+            const td = document.createElement('td');
+            td.className = 'blx-record-controls';
+            const wrapper = document.createElement('div');
+            wrapper.className = 'blx-toolbar';
+
+            for (const [name, spec] of recordControlEntries) {
+              const raw = (spec && typeof spec === 'object') ? spec : {};
+              const label = (typeof raw.label === 'string' && raw.label) ? raw.label : String(name);
+
+              const controlCtx = {
+                store: ctx?.store,
+                model: ctx?.model,
+                view: ctx?.view,
+                kind: ctx?.kind,
+                record,
+                index,
+                getState: () => controller.getState(),
+                context: ctx,
+              };
+              const visible = (typeof raw.visible === 'function')
+                ? (() => { try { return !!raw.visible(controlCtx); } catch { return false; } })()
+                : (typeof raw.visible === 'boolean' ? raw.visible : true);
+              if (!visible) continue;
+
+              const disabled = (typeof raw.disabled === 'function')
+                ? (() => { try { return !!raw.disabled(controlCtx); } catch { return true; } })()
+                : (typeof raw.disabled === 'boolean' ? raw.disabled : false);
+
+              const btn = document.createElement('button');
+              btn.type = 'button';
+              btn.textContent = label;
+              if (typeof raw.css === 'string' && raw.css.trim()) btn.className = raw.css.trim();
+              if (typeof raw.variant === 'string' && raw.variant.trim()) btn.setAttribute('data-variant', raw.variant.trim());
+              btn.disabled = !!disabled;
+              btn.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+
+              btn.addEventListener('click', async (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (btn.disabled) return;
+                const action = raw.action;
+                if (!action) return;
+                if (typeof runRecordAction === 'function') {
+                  await runRecordAction({ name, action, record, index, meta: { kind: 'collection', controlName: name, viewId: view?.id } });
+                  return;
+                }
+                if (typeof runAction === 'function') {
+                  await runAction({ name, action, meta: { kind: 'collection', controlName: name, viewId: view?.id } });
+                }
+              });
+
+              wrapper.appendChild(btn);
+            }
+
+            td.appendChild(wrapper);
+            tr.appendChild(td);
+          }
+
           frag.appendChild(tr);
         }
         tbody.appendChild(frag);
@@ -467,6 +549,7 @@ export function blinxCollection({
   let pageSize = Number.isFinite(paging.pageSize) ? paging.pageSize : 20;
   let page = Number.isFinite(paging.page) ? paging.page : 0;
   let selected = new Set();
+  let selectionBaseline = new Set();
   let internalChangeDepth = 0;
   let pendingResetSync = null;
   const cleanupFns = [];
@@ -821,6 +904,38 @@ export function blinxCollection({
     if (needsRefresh) refresh();
   }
 
+  function setSelection(nextSelected, { asBaseline = false } = {}) {
+    if (selectionMode === 'none') return;
+    const data = getDataSnapshot();
+    const len = Array.isArray(data) ? data.length : 0;
+    const next = new Set();
+
+    const addIndex = (idx) => {
+      const i = Number(idx);
+      if (!Number.isFinite(i)) return;
+      if (i < 0 || i >= len) return;
+      next.add(i);
+    };
+
+    if (nextSelected instanceof Set) {
+      nextSelected.forEach(addIndex);
+    } else if (Array.isArray(nextSelected)) {
+      nextSelected.forEach(addIndex);
+    } else if (typeof nextSelected === 'number') {
+      addIndex(nextSelected);
+    }
+
+    selected = next;
+    if (asBaseline) selectionBaseline = new Set(selected);
+    refresh();
+  }
+
+  function resetSelection() {
+    if (selectionMode === 'none') return;
+    selected = new Set(selectionBaseline);
+    refresh();
+  }
+
   const listeners = { create: [], deleteSelected: [] };
 
   async function runInterceptors(type, executor) {
@@ -941,6 +1056,8 @@ export function blinxCollection({
     }
   }
 
+  let api = null;
+
   const controller = {
     getState: () => {
       const data = getDataSnapshot();
@@ -971,6 +1088,90 @@ export function blinxCollection({
     runInternalChange,
   };
 
+  async function runAction({ name, action, meta } = {}) {
+    if (!action) return;
+    // For collection actions, expose a facade bound to the first visible item by default.
+    // (Advanced actions can still read selection state via ctx.getState().)
+    const facade = createActionFacade({
+      store,
+      getRecord: () => {
+        const s = controller.getState();
+        const first = s?.items?.[0];
+        return first?.record ?? null;
+      },
+      getRecordIndex: () => {
+        const s = controller.getState();
+        const first = s?.items?.[0];
+        return Number.isFinite(first?.index) ? first.index : 0;
+      },
+      setStatus: (msg, color) => setStatus(dom, msg, color),
+      strict: false,
+    });
+    const actionCtx = {
+      api,
+      store,
+      getState: () => controller.getState(),
+      setStatus: (msg, color) => setStatus(dom, msg, color),
+      // Spec v0 (nested): intuitive action facade
+      getRecord: () => facade.getRecord(),
+      model: (record) => facade.model(record),
+      flush: () => facade.flush(),
+      getIssues: () => facade.getIssues(),
+    };
+    try {
+      const res = await executeActionSpec({
+        action,
+        ctx: actionCtx,
+        registry: actionRegistry,
+        runner: actionRunner,
+        meta,
+      });
+      if (res?.status === 'invalid') {
+        actionCtx.setStatus(`Action "${name}" blocked.`, '#e53e3e');
+      }
+    } catch {
+      actionCtx.setStatus(`Action "${name}" failed.`, '#e53e3e');
+    }
+  }
+
+  async function runRecordAction({ name, action, record, index, meta } = {}) {
+    if (!action) return;
+    const facade = createActionFacade({
+      store,
+      getRecord: () => record ?? null,
+      getRecordIndex: () => (Number.isFinite(index) ? index : 0),
+      setStatus: (msg, color) => setStatus(dom, msg, color),
+      strict: false,
+    });
+    const actionCtx = {
+      api,
+      store,
+      getState: () => controller.getState(),
+      setStatus: (msg, color) => setStatus(dom, msg, color),
+      record,
+      recordIndex: index,
+      // Spec v0 (nested): intuitive action facade
+      getRecord: () => facade.getRecord(),
+      model: (r) => facade.model(r ?? record),
+      flush: () => facade.flush(),
+      getIssues: () => facade.getIssues(),
+    };
+    try {
+      const res = await executeActionSpec({
+        action,
+        ctx: actionCtx,
+        registry: actionRegistry,
+        runner: actionRunner,
+        meta,
+      });
+      if (res?.status === 'invalid') {
+        actionCtx.setStatus(`Action "${name}" blocked.`, '#e53e3e');
+      }
+    } catch {
+      actionCtx.setStatus(`Action "${name}" failed.`, '#e53e3e');
+    }
+  }
+
   const layoutApi = layout.mount({
     root: contentRoot,
     model,
@@ -981,6 +1182,11 @@ export function blinxCollection({
     ctx,
     controller,
     onItemClick,
+    api,
+    actionRegistry,
+    actionRunner,
+    runAction,
+    runRecordAction,
   });
 
   if (!layoutApi || typeof layoutApi.update !== 'function') {
@@ -988,11 +1194,13 @@ export function blinxCollection({
   }
   cleanupFns.push(() => { try { layoutApi.destroy && layoutApi.destroy(); } catch { /* ignore */ } });
 
-  const api = {
+  api = {
     onCreate: fn => listeners.create.push(fn),
     onDeleteSelected: fn => listeners.deleteSelected.push(fn),
     setPage: controller.setPage,
     getState: controller.getState,
+    setSelection,
+    resetSelection,
     destroy: () => destroy(),
   };
 
@@ -1005,49 +1213,7 @@ export function blinxCollection({
     const action = spec?.action;
     if (!el || !action) continue;
     const onClick = async () => {
-      // For collection actions, expose a facade bound to the first visible item by default.
-      // (Advanced actions can still read selection state via ctx.getState().)
-      const facade = createActionFacade({
-        store,
-        getRecord: () => {
-          const s = controller.getState();
-          const first = s?.items?.[0];
-          return first?.record ?? null;
-        },
-        getRecordIndex: () => {
-          const s = controller.getState();
-          const first = s?.items?.[0];
-          return Number.isFinite(first?.index) ? first.index : 0;
-        },
-        setStatus: (msg, color) => setStatus(dom, msg, color),
-        strict: false,
-      });
-      const ctx = {
-        api,
-        store,
-        getState: () => controller.getState(),
-        setStatus: (msg, color) => setStatus(dom, msg, color),
-        // Spec v0 (nested): intuitive action facade
-        getRecord: () => facade.getRecord(),
-        model: (record) => facade.model(record),
-        flush: () => facade.flush(),
-        getIssues: () => facade.getIssues(),
-      };
-      try {
-        const res = await executeActionSpec({
-          action,
-          ctx,
-          registry: actionRegistry,
-          runner: actionRunner,
-          meta: { kind: 'collection', controlName: name, viewId: view?.id },
-        });
-        if (res?.status === 'invalid') {
-          ctx.setStatus(`Action "${name}" blocked.`, '#e53e3e');
-        }
-      } catch (e) {
-        // Best-effort feedback; avoid unhandled rejections from async click handlers.
-        ctx.setStatus(`Action "${name}" failed.`, '#e53e3e');
-      }
+      await runAction({ name, action, meta: { kind: 'collection', controlName: name, viewId: view?.id } });
     };
     el.addEventListener('click', onClick);
     cleanupFns.push(() => el.removeEventListener('click', onClick));

--- a/lib/blinx.css
+++ b/lib/blinx.css
@@ -325,6 +325,58 @@
 .blx-table tbody tr:hover { background: color-mix(in srgb, var(--blx-surface), white 12%); }
 
 /* =========================================================
+  CART (custom collection layout)
+========================================================= */
+.blx-cart {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.blx-cart__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--blx-border), transparent 30%);
+  border-radius: var(--blx-radius);
+  background: var(--blx-surface);
+}
+
+.blx-cart__row:hover {
+  background: color-mix(in srgb, var(--blx-surface), white 8%);
+}
+
+.blx-cart__prefix {
+  width: 1.5rem;
+  display: inline-flex;
+  justify-content: center;
+}
+
+.blx-cart__label {
+  flex: 1;
+}
+
+.blx-cart__controls {
+  display: inline-flex;
+  gap: 0.25rem;
+}
+
+.blx-cart__control {
+  border: 1px solid var(--blx-border);
+  background: color-mix(in srgb, var(--blx-surface), white 4%);
+  color: var(--blx-text);
+  border-radius: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.blx-cart__row--deselected .blx-cart__label {
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+
+/* =========================================================
   UTILITIES
 ========================================================= */
 .blx-text-muted { color: var(--blx-muted); }


### PR DESCRIPTION
Adds a `blinxCart()` convenience wrapper and extends `blinxCollection` with `recordControls` and selection baseline API to support cart-like components.

The `blinxCart` component is implemented as a custom layout for `blinxCollection` to adhere to Blinx DNA principles of extensibility. This PR also introduces generic `recordControls` and selection baseline management to `blinxCollection`, which were identified as necessary enhancements during the design phase for `blinxCart` and are beneficial for other collection types.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf981a63-eaa3-4d2f-bc2d-ff9644627356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cf981a63-eaa3-4d2f-bc2d-ff9644627356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a cart-style collection wrapper and expands collection capabilities for per-record actions and selection management.
> 
> - New `blinxCart()` built on `blinxCollection` with custom `cart` layout (`lib/blinx.cart.js`) and styles (`.blx-cart*` in `lib/blinx.css`); defaults to all-selected, includes a `Reset` control, supports non-selectable prefix icon, and optional edit icon via `editable`.
> - `blinxCollection` table layout now renders `view.recordControls` per row and routes clicks via `runRecordAction` without toggling selection; shared `runAction`/`runRecordAction` used for custom controls.
> - Selection API: `api.setSelection(indices, { asBaseline: true })` to capture a baseline and `api.resetSelection()` to restore it; controller exposes `selectionMode` and respects `isRowSelectable`.
> - Docs: add "Record controls" section to `docs/spec/ui-views.md` explaining `view.recordControls` API.
> - Tests: new `__tests__/blinx.cart.test.js` and additions in `__tests__/blinx.collection.test.js` covering baseline reset and record controls behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa1edbeb97826100dda2d30e0b599939ce946d15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->