### PR TITLE
Blinx picker component design

### DIFF
--- a/__tests__/blinx.picker.test.js
+++ b/__tests__/blinx.picker.test.js
@@ -128,5 +128,37 @@ describe('blinxPicker', () => {
     // API getSelected matches the same.
     expect(pickerApi.getSelected()).toEqual([{ id: 'b', name: 'B' }]);
   });
+
+  test('picker-level status: reset sets status and confirm failure shows error', async () => {
+    const model = { fields: { id: { type: 'string' }, name: { type: 'string' } } };
+    const childStore = blinxStore([{ id: 'a', name: 'A' }], model);
+    const root = document.createElement('div');
+
+    const onConfirm = jest.fn(() => { throw new Error('boom'); });
+
+    blinxPicker({
+      root,
+      childStore,
+      selectionMode: 'multiple',
+      keyField: 'id',
+      labelField: 'name',
+      views: {
+        table: { columns: [{ field: 'name', label: 'Name' }] },
+      },
+      onConfirm,
+    });
+
+    const status = () => root.querySelector('.blinx-picker__status')?.textContent || '';
+
+    // Reset should set a friendly status message.
+    byText(root, 'Reset')[0].click();
+    await Promise.resolve();
+    expect(status()).toBe('Reset done.');
+
+    // A failing confirm should show an error status.
+    byText(root, 'Confirm')[0].click();
+    await Promise.resolve();
+    expect(status()).toBe('Confirm failed.');
+  });
 });
 

--- a/__tests__/blinx.picker.test.js
+++ b/__tests__/blinx.picker.test.js
@@ -1,0 +1,132 @@
+/** @jest-environment jsdom */
+
+import { blinxStore } from '../lib/blinx.store.js';
+import { blinxPicker } from '../lib/blinx.picker.js';
+
+function byText(root, text) {
+  return Array.from(root.querySelectorAll('button')).filter(b => b.textContent === text);
+}
+
+describe('blinxPicker', () => {
+  test('multiple: add ➕ adds to cart, dedupes, and enables 🗑️ remove', async () => {
+    const model = { fields: { id: { type: 'string' }, name: { type: 'string' } } };
+    const childStore = blinxStore([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }], model);
+    const root = document.createElement('div');
+
+    blinxPicker({
+      root,
+      childStore,
+      selectionMode: 'multiple',
+      keyField: 'id',
+      labelField: 'name',
+      views: {
+        table: { columns: [{ field: 'name', label: 'Name' }] },
+      },
+    });
+
+    // Two add buttons initially.
+    let addBtns = byText(root, '➕');
+    expect(addBtns.length).toBe(2);
+    expect(addBtns[0].disabled).toBe(false);
+
+    // Add first record => cart shows 1 row and add disabled for that row.
+    addBtns[0].click();
+    await Promise.resolve();
+
+    expect(root.querySelectorAll('.blx-cart__row').length).toBe(1);
+    addBtns = byText(root, '➕');
+    expect(addBtns[0].disabled).toBe(true);
+
+    // Dedupe: clicking again should not add another.
+    addBtns[0].click();
+    await Promise.resolve();
+    expect(root.querySelectorAll('.blx-cart__row').length).toBe(1);
+
+    // Remove from cart => cart becomes empty and add re-enabled.
+    const removeBtns = byText(root, '🗑️');
+    expect(removeBtns.length).toBe(1);
+    removeBtns[0].click();
+    await Promise.resolve();
+
+    expect(root.querySelectorAll('.blx-cart__row').length).toBe(0);
+    addBtns = byText(root, '➕');
+    expect(addBtns[0].disabled).toBe(false);
+  });
+
+  test('single: once cart has one item, all ➕ are disabled', async () => {
+    const model = { fields: { id: { type: 'string' }, name: { type: 'string' } } };
+    const childStore = blinxStore([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }], model);
+    const root = document.createElement('div');
+
+    blinxPicker({
+      root,
+      childStore,
+      selectionMode: 'single',
+      keyField: 'id',
+      labelField: 'name',
+      views: {
+        table: { columns: [{ field: 'name', label: 'Name' }] },
+      },
+    });
+
+    let addBtns = byText(root, '➕');
+    expect(addBtns.length).toBe(2);
+    expect(addBtns[0].disabled).toBe(false);
+    expect(addBtns[1].disabled).toBe(false);
+
+    addBtns[0].click();
+    await Promise.resolve();
+
+    addBtns = byText(root, '➕');
+    expect(addBtns[0].disabled).toBe(true); // dedupe for the chosen record
+    expect(addBtns[1].disabled).toBe(true); // cart not empty locks further adds
+  });
+
+  test('reset restores initial baseline and confirm returns selected records', async () => {
+    const model = { fields: { id: { type: 'string' }, name: { type: 'string' } } };
+    const childStore = blinxStore([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }], model);
+    const root = document.createElement('div');
+    const onConfirm = jest.fn();
+
+    const { pickerApi } = blinxPicker({
+      root,
+      childStore,
+      selectionMode: 'multiple',
+      keyField: 'id',
+      labelField: 'name',
+      initial: [{ id: 'b', name: 'B' }],
+      views: {
+        table: { columns: [{ field: 'name', label: 'Name' }] },
+      },
+      onConfirm,
+    });
+
+    // Baseline has 1 cart row (B)
+    expect(root.querySelectorAll('.blx-cart__row').length).toBe(1);
+    expect(root.textContent).toContain('B');
+
+    // Add A => cart has 2 rows.
+    const addBtns = byText(root, '➕');
+    addBtns[0].click();
+    await Promise.resolve();
+    expect(root.querySelectorAll('.blx-cart__row').length).toBe(2);
+
+    // Reset => back to baseline (1 row).
+    const resetBtn = byText(root, 'Reset')[0];
+    resetBtn.click();
+    await Promise.resolve();
+    expect(root.querySelectorAll('.blx-cart__row').length).toBe(1);
+    expect(root.textContent).toContain('B');
+
+    // Confirm => calls onConfirm with baseline selection
+    const confirmBtn = byText(root, 'Confirm')[0];
+    confirmBtn.click();
+    await Promise.resolve();
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith([{ id: 'b', name: 'B' }]);
+
+    // API getSelected matches the same.
+    expect(pickerApi.getSelected()).toEqual([{ id: 'b', name: 'B' }]);
+  });
+});
+

--- a/__tests__/blinx.picker.test.js
+++ b/__tests__/blinx.picker.test.js
@@ -10,12 +10,12 @@ function byText(root, text) {
 describe('blinxPicker', () => {
   test('multiple: add ➕ adds to cart, dedupes, and enables 🗑️ remove', async () => {
     const model = { fields: { id: { type: 'string' }, name: { type: 'string' } } };
-    const childStore = blinxStore([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }], model);
+    const store = blinxStore([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }], model);
     const root = document.createElement('div');
 
     blinxPicker({
       root,
-      childStore,
+      store,
       selectionMode: 'multiple',
       keyField: 'id',
       labelField: 'name',
@@ -55,12 +55,12 @@ describe('blinxPicker', () => {
 
   test('single: once cart has one item, all ➕ are disabled', async () => {
     const model = { fields: { id: { type: 'string' }, name: { type: 'string' } } };
-    const childStore = blinxStore([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }], model);
+    const store = blinxStore([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }], model);
     const root = document.createElement('div');
 
     blinxPicker({
       root,
-      childStore,
+      store,
       selectionMode: 'single',
       keyField: 'id',
       labelField: 'name',
@@ -84,13 +84,13 @@ describe('blinxPicker', () => {
 
   test('reset restores initial baseline and confirm returns selected records', async () => {
     const model = { fields: { id: { type: 'string' }, name: { type: 'string' } } };
-    const childStore = blinxStore([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }], model);
+    const store = blinxStore([{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }], model);
     const root = document.createElement('div');
     const onConfirm = jest.fn();
 
     const { pickerApi } = blinxPicker({
       root,
-      childStore,
+      store,
       selectionMode: 'multiple',
       keyField: 'id',
       labelField: 'name',
@@ -131,14 +131,14 @@ describe('blinxPicker', () => {
 
   test('picker-level status: reset sets status and confirm failure shows error', async () => {
     const model = { fields: { id: { type: 'string' }, name: { type: 'string' } } };
-    const childStore = blinxStore([{ id: 'a', name: 'A' }], model);
+    const store = blinxStore([{ id: 'a', name: 'A' }], model);
     const root = document.createElement('div');
 
     const onConfirm = jest.fn(() => { throw new Error('boom'); });
 
     blinxPicker({
       root,
-      childStore,
+      store,
       selectionMode: 'multiple',
       keyField: 'id',
       labelField: 'name',

--- a/lib/blinx.picker.js
+++ b/lib/blinx.picker.js
@@ -39,6 +39,8 @@ function buildUniqueInitial({ initial, keyField, selectionMode }) {
 
 export function blinxPicker({
   root,
+  store,
+  // Back-compat alias (deprecated): prefer `store`.
   childStore,
   selectionMode,
   keyField = 'id',
@@ -52,17 +54,18 @@ export function blinxPicker({
   onConfirm,
   onCancel,
 } = {}) {
+  const resolvedStore = store || childStore;
   if (!root) throw new Error('blinxPicker requires a root element.');
-  if (!childStore || typeof childStore.getModel !== 'function') {
-    throw new Error('blinxPicker requires childStore to implement getModel().');
+  if (!resolvedStore || typeof resolvedStore.getModel !== 'function') {
+    throw new Error('blinxPicker requires store to implement getModel().');
   }
   if (selectionMode !== 'none' && selectionMode !== 'single' && selectionMode !== 'multiple') {
     throw new Error('blinxPicker requires selectionMode to be one of "none" | "single" | "multiple".');
   }
 
-  const childModel = childStore.getModel();
+  const childModel = resolvedStore.getModel();
   if (!childModel || !childModel.fields) {
-    throw new Error('blinxPicker requires childStore model to define fields.');
+    throw new Error('blinxPicker requires store model to define fields.');
   }
 
   const modeForCollection =
@@ -235,7 +238,7 @@ export function blinxPicker({
   const tableViewRaw = (views && typeof views === 'object' && Object.prototype.hasOwnProperty.call(views, 'table'))
     ? views.table
     : undefined;
-  const resolveArgs = { store: childStore, model: childModel, kind: 'collection' };
+  const resolveArgs = { store: resolvedStore, model: childModel, kind: 'collection' };
   if (tableViewRaw !== undefined) resolveArgs.view = tableViewRaw;
   const resolved = resolveComponentUIView(resolveArgs);
   const baseTableView = resolved ? { ...resolved, layout: 'table' } : resolved;
@@ -252,7 +255,7 @@ export function blinxPicker({
   }
 
   const resolvedCreateEnabled = (createEnabled === undefined)
-    ? ((typeof childStore.isMutable === 'function') ? !!childStore.isMutable() : true)
+    ? ((typeof resolvedStore.isMutable === 'function') ? !!resolvedStore.isMutable() : true)
     : !!createEnabled;
 
   if (resolvedCreateEnabled) {
@@ -272,7 +275,7 @@ export function blinxPicker({
           action: 'blinx.global.journeys.create-single-model',
           ctx: {
             pickerApi: null, // reserved for future expansion
-            store: childStore,
+            store: resolvedStore,
             model: childModel,
             context,
             setStatus,
@@ -293,7 +296,7 @@ export function blinxPicker({
   // Allow search/pager toolbar auto-rendering, but disable built-in create/deleteSelected mutations.
   const { api } = blinxCollection({
     root: tableContentRoot,
-    store: childStore,
+    store: resolvedStore,
     view: baseTableView,
     selection: { mode: 'none' },
     actions: { create: false, deleteSelected: false },

--- a/lib/blinx.picker.js
+++ b/lib/blinx.picker.js
@@ -190,22 +190,41 @@ export function blinxPicker({
   cancelBtn.setAttribute('data-variant', 'surface');
   cancelBtn.textContent = 'Cancel';
 
-  controlsRoot.append(confirmBtn, resetBtn, cancelBtn);
+  const statusEl = document.createElement('span');
+  statusEl.className = 'blinx-picker__status';
+
+  function setStatus(msg, color = '#4a5568') {
+    statusEl.textContent = String(msg ?? '');
+    statusEl.style.color = color;
+  }
+
+  controlsRoot.append(confirmBtn, resetBtn, cancelBtn, statusEl);
 
   const onConfirmClick = async () => {
     const selected = getCartSnapshot();
-    if (typeof onConfirm === 'function') await onConfirm(selected);
+    try {
+      if (typeof onConfirm === 'function') await onConfirm(selected);
+      setStatus('', '#4a5568');
+    } catch (e) {
+      setStatus('Confirm failed.', '#e53e3e');
+    }
   };
   const onResetClick = () => {
     try { cartStore.reset(); } catch { /* ignore */ }
     refreshCart();
     refreshTable();
+    setStatus('Reset done.', '#4a5568');
   };
   const onCancelClick = async () => {
     try { cartStore.reset(); } catch { /* ignore */ }
     refreshCart();
     refreshTable();
-    if (typeof onCancel === 'function') await onCancel();
+    try {
+      if (typeof onCancel === 'function') await onCancel();
+      setStatus('', '#4a5568');
+    } catch {
+      setStatus('Cancel failed.', '#e53e3e');
+    }
   };
 
   confirmBtn.addEventListener('click', onConfirmClick);
@@ -248,18 +267,24 @@ export function blinxPicker({
       if (!resolvedCreateEnabled) return;
       // Journey hook (implementation lives outside this iteration).
       // We execute it through the shared action runner/registry mechanism.
-      await executeActionSpec({
-        action: 'blinx.global.journey.create-single-model',
-        ctx: {
-          pickerApi: null, // reserved for future expansion
-          store: childStore,
-          model: childModel,
-          context,
-        },
-        registry: actionRegistry,
-        runner: actionRunner,
-        meta: { kind: 'picker', controlName: 'create' },
-      });
+      try {
+        await executeActionSpec({
+          action: 'blinx.global.journeys.create-single-model',
+          ctx: {
+            pickerApi: null, // reserved for future expansion
+            store: childStore,
+            model: childModel,
+            context,
+            setStatus,
+          },
+          registry: actionRegistry,
+          runner: actionRunner,
+          meta: { kind: 'picker', controlName: 'create' },
+        });
+        setStatus('', '#4a5568');
+      } catch {
+        setStatus('Create failed.', '#e53e3e');
+      }
     };
 
     createBtn.addEventListener('click', onCreate);

--- a/lib/blinx.picker.js
+++ b/lib/blinx.picker.js
@@ -1,0 +1,301 @@
+import { blinxStore } from './blinx.store.js';
+import { blinxCart } from './blinx.cart.js';
+import { blinxCollection } from './blinx.collection.js';
+import { resolveComponentUIView } from './blinx.ui-views.js';
+import { executeActionSpec } from './blinx.actions.js';
+
+function isPlainObject(v) {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function toIdRecord(value, keyField) {
+  if (value === null || value === undefined) return null;
+  if (isPlainObject(value)) return value;
+  return { [keyField]: value };
+}
+
+function buildUniqueInitial({ initial, keyField, selectionMode }) {
+  const raw = Array.isArray(initial) ? initial : [];
+  const seen = new Set();
+  const out = [];
+
+  for (const item of raw) {
+    const rec = toIdRecord(item, keyField);
+    if (!rec) continue;
+    const id = rec?.[keyField];
+    if (id === undefined || id === null || id === '') {
+      // If the key is missing, treat it as unique (best-effort).
+      out.push(rec);
+    } else if (!seen.has(id)) {
+      seen.add(id);
+      out.push(rec);
+    }
+    if (selectionMode === 'single' && out.length >= 1) break;
+  }
+
+  if (selectionMode === 'none') return [];
+  return out;
+}
+
+export function blinxPicker({
+  root,
+  childStore,
+  selectionMode,
+  keyField = 'id',
+  labelField,
+  initial,
+  views,
+  createEnabled,
+  context,
+  actionRegistry,
+  actionRunner,
+  onConfirm,
+  onCancel,
+} = {}) {
+  if (!root) throw new Error('blinxPicker requires a root element.');
+  if (!childStore || typeof childStore.getModel !== 'function') {
+    throw new Error('blinxPicker requires childStore to implement getModel().');
+  }
+  if (selectionMode !== 'none' && selectionMode !== 'single' && selectionMode !== 'multiple') {
+    throw new Error('blinxPicker requires selectionMode to be one of "none" | "single" | "multiple".');
+  }
+
+  const childModel = childStore.getModel();
+  if (!childModel || !childModel.fields) {
+    throw new Error('blinxPicker requires childStore model to define fields.');
+  }
+
+  const modeForCollection =
+    selectionMode === 'multiple' ? 'multi' :
+    selectionMode === 'single' ? 'single' :
+    'none';
+
+  // Cart store: ephemeral array store with baseline reset.
+  const initialRecords = buildUniqueInitial({ initial, keyField, selectionMode });
+  const cartStore = blinxStore(initialRecords, childModel);
+  try { cartStore.commit(); } catch { /* ignore */ }
+
+  function getCartSnapshot() {
+    const snap = cartStore.toJSON();
+    return Array.isArray(snap) ? snap : [];
+  }
+
+  function getCartIds() {
+    const ids = new Set();
+    for (const rec of getCartSnapshot()) {
+      const id = rec?.[keyField];
+      if (id !== undefined && id !== null && id !== '') ids.add(id);
+    }
+    return ids;
+  }
+
+  // Ensure we can force-refresh table recordControls disabled state when the cart changes.
+  let tableApi = null;
+  function refreshTable() {
+    try {
+      const p = tableApi?.getState?.()?.page ?? 0;
+      tableApi?.setPage?.(p);
+    } catch { /* ignore */ }
+  }
+
+  function canAdd(record) {
+    if (selectionMode === 'none') return false;
+    const id = record?.[keyField];
+    const ids = getCartIds();
+    if (id !== undefined && id !== null && id !== '' && ids.has(id)) return false;
+    if (selectionMode === 'single' && getCartSnapshot().length > 0) return false;
+    return true;
+  }
+
+  function addToCart(record) {
+    if (!canAdd(record)) return;
+    cartStore.addRecord(record);
+    refreshTable();
+  }
+
+  function removeFromCart(index) {
+    try { cartStore.removeRecords([index]); } catch { /* ignore */ }
+    refreshTable();
+  }
+
+  // Root layout
+  root.innerHTML = '';
+  const wrapper = document.createElement('div');
+  wrapper.className = 'blinx-picker';
+  wrapper.setAttribute('data-blinx-theme', '');
+
+  const cartRoot = document.createElement('div');
+  cartRoot.className = 'blinx-picker__cart';
+  const controlsRoot = document.createElement('div');
+  controlsRoot.className = 'blinx-picker__controls blx-toolbar';
+  const tableRoot = document.createElement('div');
+  tableRoot.className = 'blinx-picker__table';
+
+  const tableToolbarRoot = document.createElement('div');
+  tableToolbarRoot.className = 'blinx-picker__table-toolbar blx-toolbar';
+  const tableContentRoot = document.createElement('div');
+  tableContentRoot.className = 'blinx-picker__table-content';
+  tableRoot.append(tableToolbarRoot, tableContentRoot);
+
+  wrapper.append(cartRoot, controlsRoot, tableRoot);
+  root.appendChild(wrapper);
+
+  // Cart: not selectable; use record control 🗑️ to remove.
+  const { cartApi } = blinxCart({
+    root: cartRoot,
+    store: cartStore,
+    model: childModel,
+    labelField,
+    selectable: false,
+    editable: false,
+    recordControls: {
+      __picker_remove: {
+        label: '🗑️',
+        action: (ctx) => {
+          // ctx.recordIndex is the cart item index (from blinxCollection record action ctx)
+          const idx = Number.isFinite(ctx?.recordIndex) ? ctx.recordIndex : null;
+          if (idx === null) return;
+          removeFromCart(idx);
+        },
+      },
+    },
+    context,
+    actionRegistry,
+    actionRunner,
+  });
+
+  function refreshCart() {
+    try {
+      const p = cartApi?.getState?.()?.page ?? 0;
+      cartApi?.setPage?.(p);
+    } catch { /* ignore */ }
+  }
+
+  // Controls under cart
+  const confirmBtn = document.createElement('button');
+  confirmBtn.type = 'button';
+  confirmBtn.className = 'blx-btn';
+  confirmBtn.setAttribute('data-variant', 'primary');
+  confirmBtn.textContent = 'Confirm';
+
+  const resetBtn = document.createElement('button');
+  resetBtn.type = 'button';
+  resetBtn.className = 'blx-btn';
+  resetBtn.setAttribute('data-variant', 'surface');
+  resetBtn.textContent = 'Reset';
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.className = 'blx-btn';
+  cancelBtn.setAttribute('data-variant', 'surface');
+  cancelBtn.textContent = 'Cancel';
+
+  controlsRoot.append(confirmBtn, resetBtn, cancelBtn);
+
+  const onConfirmClick = async () => {
+    const selected = getCartSnapshot();
+    if (typeof onConfirm === 'function') await onConfirm(selected);
+  };
+  const onResetClick = () => {
+    try { cartStore.reset(); } catch { /* ignore */ }
+    refreshCart();
+    refreshTable();
+  };
+  const onCancelClick = async () => {
+    try { cartStore.reset(); } catch { /* ignore */ }
+    refreshCart();
+    refreshTable();
+    if (typeof onCancel === 'function') await onCancel();
+  };
+
+  confirmBtn.addEventListener('click', onConfirmClick);
+  resetBtn.addEventListener('click', onResetClick);
+  cancelBtn.addEventListener('click', onCancelClick);
+
+  // Table: force table layout, disable selection, add record control ➕.
+  const tableViewRaw = (views && typeof views === 'object' && Object.prototype.hasOwnProperty.call(views, 'table'))
+    ? views.table
+    : undefined;
+  const resolveArgs = { store: childStore, model: childModel, kind: 'collection' };
+  if (tableViewRaw !== undefined) resolveArgs.view = tableViewRaw;
+  const resolved = resolveComponentUIView(resolveArgs);
+  const baseTableView = resolved ? { ...resolved, layout: 'table' } : resolved;
+  if (baseTableView && typeof baseTableView === 'object') {
+    const existingRC = isPlainObject(baseTableView.recordControls) ? baseTableView.recordControls : {};
+    baseTableView.recordControls = {
+      ...existingRC,
+      __picker_add: {
+        label: '➕',
+        disabled: ({ record }) => !canAdd(record),
+        action: ({ record }) => addToCart(record),
+      },
+    };
+  }
+
+  const resolvedCreateEnabled = (createEnabled === undefined)
+    ? ((typeof childStore.isMutable === 'function') ? !!childStore.isMutable() : true)
+    : !!createEnabled;
+
+  if (resolvedCreateEnabled) {
+    const createBtn = document.createElement('button');
+    createBtn.type = 'button';
+    createBtn.className = 'blx-btn';
+    createBtn.setAttribute('data-variant', 'surface');
+    createBtn.textContent = 'Create';
+    tableToolbarRoot.appendChild(createBtn);
+
+    const onCreate = async () => {
+      if (!resolvedCreateEnabled) return;
+      // Journey hook (implementation lives outside this iteration).
+      // We execute it through the shared action runner/registry mechanism.
+      await executeActionSpec({
+        action: 'blinx.global.journey.create-single-model',
+        ctx: {
+          pickerApi: null, // reserved for future expansion
+          store: childStore,
+          model: childModel,
+          context,
+        },
+        registry: actionRegistry,
+        runner: actionRunner,
+        meta: { kind: 'picker', controlName: 'create' },
+      });
+    };
+
+    createBtn.addEventListener('click', onCreate);
+  }
+
+  // Allow search/pager toolbar auto-rendering, but disable built-in create/deleteSelected mutations.
+  const { api } = blinxCollection({
+    root: tableContentRoot,
+    store: childStore,
+    view: baseTableView,
+    selection: { mode: 'none' },
+    actions: { create: false, deleteSelected: false },
+    context,
+    actionRegistry,
+    actionRunner,
+  });
+  tableApi = api;
+
+  function destroy() {
+    try { cartApi?.destroy?.(); } catch { /* ignore */ }
+    try { tableApi?.destroy?.(); } catch { /* ignore */ }
+    try { confirmBtn.removeEventListener('click', onConfirmClick); } catch { /* ignore */ }
+    try { resetBtn.removeEventListener('click', onResetClick); } catch { /* ignore */ }
+    try { cancelBtn.removeEventListener('click', onCancelClick); } catch { /* ignore */ }
+    try { root.innerHTML = ''; } catch { /* ignore */ }
+  }
+
+  const pickerApi = {
+    getSelected: () => getCartSnapshot(),
+    reset: () => onResetClick(),
+    destroy,
+  };
+
+  return { pickerApi };
+}
+
+// Backwards-compatible alias (deprecated)
+export { blinxPicker as renderBlinxPicker };
+


### PR DESCRIPTION
Implements the `blinxPicker()` component to provide a simplified "pick journey" UI for nested fields, using Add/Remove icons instead of dual selection.

---
<a href="https://cursor.com/background-agent?bcId=bc-39a77f28-458a-42a0-be7d-98d26174ae9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39a77f28-458a-42a0-be7d-98d26174ae9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a new cart-driven picker UI for nested selections.
> 
> - Adds `lib/blinx.picker.js` exporting `blinxPicker` (and deprecated alias `renderBlinxPicker`) that composes `blinxCart` and `blinxCollection`
> - Supports selection modes (`none`|`single`|`multiple`), unique `initial` baseline, and picker API (`getSelected`, `reset`, `destroy`)
> - Injects table `recordControls` with `➕` add (disabled when deduped or in `single` after one add) and cart rows with `🗑️` remove
> - Renders controls: `Confirm`, `Reset`, `Cancel` with picker-level status messaging and error handling
> - Optional `Create` button in table toolbar triggers `executeActionSpec('blinx.global.journeys.create-single-model')`
> - Adds `__tests__/blinx.picker.test.js` covering multi/single add behavior, dedupe/remove, reset/confirm flow, and status messages
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f65387bfbd39944959a276d568acee5c3d75dc15. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->