### PR TITLE
Relation controls implementation check

### DIFF
--- a/__tests__/blinx.form.test.js
+++ b/__tests__/blinx.form.test.js
@@ -334,4 +334,56 @@ describe('blinxForm', () => {
     expect(root.querySelector('input, textarea, select')).not.toBeNull();
     expect(root.querySelectorAll('button').length).toBe(0);
   });
+
+  test('relation unlink refreshes journey widget even when flush/save fails', async () => {
+    // SNM-style nested field => defaults to relation.mode = journey.
+    const ChildModel = {
+      id: 'Child',
+      fields: { name: { type: 'string' } },
+    };
+    const ParentModel = {
+      id: 'Parent',
+      fields: {
+        child: { type: 'model', model: ChildModel, embedded: false },
+      },
+    };
+
+    const store = blinxStore([{ child: 'c-1' }], ParentModel);
+    // Simulate an async-backed store where persistence fails.
+    store.save = async () => { throw new Error('save failed'); };
+
+    const view = { sections: [{ title: 'Main', columns: 1, fields: ['child'] }] };
+    const root = document.createElement('div');
+    blinxForm({ root, view, store, recordIndex: 0 }); // controls omitted => internal toolbar
+
+    const rel = root.querySelector('[data-blinx-field="child"]');
+    expect(rel).toBeTruthy();
+    expect(rel.getAttribute('data-blinx-relation-mode')).toBe('journey');
+
+    const preview = rel.querySelector('[data-blinx-part="input"]');
+    expect(preview).toBeTruthy();
+    expect(preview.textContent).toBe('c-1');
+
+    const unlinkBtn = rel.querySelector('button[data-blinx-action="unlink"]');
+    expect(unlinkBtn).toBeTruthy();
+    unlinkBtn.click();
+
+    // Let async click handler run (unlink mutates synchronously, flush fails asynchronously).
+    for (let i = 0; i < 20; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.resolve();
+      if (root.textContent.includes('Unlink:')) break;
+    }
+
+    // Data is mutated even though persistence failed.
+    expect(store.getRecord(0).child).toBe(null);
+
+    // UI should reflect the unlink (preview cleared) even if flush/save failed.
+    const rel2 = root.querySelector('[data-blinx-field="child"]');
+    const preview2 = rel2.querySelector('[data-blinx-part="input"]');
+    expect(preview2.textContent).toBe('');
+
+    // Status should indicate failure (persistence failure path).
+    expect(root.textContent).toContain('Unlink: failed.');
+  });
 });

--- a/__tests__/blinx.nested-uiviews.integration.test.js
+++ b/__tests__/blinx.nested-uiviews.integration.test.js
@@ -126,6 +126,49 @@ describe('Nested UI views (Option A registry) (integration)', () => {
     expect(shippingRoot.textContent).not.toContain('country');
   });
 
+  test('SNM nested fields (embedded: false) default to relation.mode=journey (no inline nested form)', () => {
+    const AddressModel = {
+      id: 'AddressSNM',
+      fields: {
+        line1: { type: 'string' },
+        city: { type: 'string' },
+      },
+    };
+
+    const OrderModel = {
+      id: 'OrderSNM',
+      fields: {
+        shippingAddress: { type: 'model', model: AddressModel, embedded: false },
+      },
+    };
+
+    registerModelViews(AddressModel, {
+      form: {
+        default: { sections: [{ title: 'Address', columns: 2, fields: ['line1', 'city'] }] },
+      },
+    });
+
+    registerModelViews(OrderModel, {
+      form: {
+        default: { sections: [{ title: 'Order', columns: 1, fields: ['shippingAddress'] }] },
+      },
+    });
+
+    // SNM normalized: the parent record holds an id, not an embedded object.
+    const store = blinxStore([{ shippingAddress: 'addr-1' }], OrderModel);
+
+    const root = document.createElement('div');
+    blinxForm({ root, store });
+
+    const rel = root.querySelector('[data-blinx-field="shippingAddress"]');
+    expect(rel).toBeTruthy();
+    expect(rel.getAttribute('data-blinx-relation-mode')).toBe('journey');
+
+    // No nested Address form should be rendered inline.
+    expect(rel.textContent).not.toContain('line1');
+    expect(rel.textContent).not.toContain('city');
+  });
+
   test('nested collection item edits do not overwrite each other (no stale closure)', () => {
     const ItemModel = {
       id: 'Item',

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -103,6 +103,11 @@ function bindClick(controlEl, role, handler) {
   };
 }
 
+function normalizeRelationMode(mode, fallback) {
+  if (mode === 'inline' || mode === 'journey') return mode;
+  return fallback;
+}
+
 export function blinxForm({
   root, view, store,
   // Optional: declarative data-view selection when a multi-view store manager is provided.
@@ -416,6 +421,44 @@ export function blinxForm({
     if (dom.status) dom.status.textContent = '';
   }
 
+  // Internal facade used for non-action inline edits (e.g. nested sub-forms).
+  // Important: this should not surface issues or flush automatically; it just mutates the parent store
+  // through the facade API so nested semantics can evolve without UI code touching store internals.
+  const internalFacade = createActionFacade({
+    store,
+    getRecord: () => store.getRecord(currentIndex),
+    getRecordIndex: () => currentIndex,
+    strict: false,
+  });
+
+  function resolveRelationSpec(fieldDef, fieldSpec) {
+    const rel = (fieldSpec && typeof fieldSpec === 'object') ? fieldSpec.relation : null;
+    const embedded = fieldDef?.embedded !== false; // default true
+    const defaultMode = embedded ? 'inline' : 'journey';
+    const mode = normalizeRelationMode(rel?.mode, defaultMode);
+
+    const pick = rel?.pick;
+    const edit = rel?.edit;
+    const unlink = rel?.unlink;
+    const del = rel?.delete;
+
+    // Defaults:
+    // - For journey mode, pick/edit/unlink are enabled by default.
+    // - Delete is conservative by default (must be explicitly enabled).
+    const pickEnabled = (typeof pick?.enabled === 'boolean') ? pick.enabled : (mode === 'journey');
+    const editEnabled = (typeof edit?.enabled === 'boolean') ? edit.enabled : (mode === 'journey');
+    const unlinkEnabled = (typeof unlink?.enabled === 'boolean') ? unlink.enabled : true;
+    const deleteEnabled = (typeof del?.enabled === 'boolean') ? del.enabled : false;
+
+    return {
+      mode,
+      pick: { enabled: !!pickEnabled, action: pick?.action },
+      edit: { enabled: !!editEnabled, action: edit?.action },
+      unlink: { enabled: !!unlinkEnabled },
+      delete: { enabled: !!deleteEnabled },
+    };
+  }
+
   function runInternalChange(fn) {
     internalChangeDepth += 1;
     let res;
@@ -478,6 +521,7 @@ export function blinxForm({
         // - def.type === 'model': render nested blinxForm using the nested model's default view (or override via { view })
         // - def.type === 'collection': render repeated nested blinxForm for items using item model default view (or override via { itemView })
         if (def?.type === 'model' && def?.model && typeof def.model === 'object') {
+          const relation = resolveRelationSpec(def, (f && typeof f === 'object') ? f : null);
           const nestedModel = def.model;
           const overrideViewName = (f && typeof f === 'object') ? (f.view || null) : null;
           const nestedView = resolveModelUIView({ model: nestedModel, kind: 'form', viewName: overrideViewName });
@@ -489,11 +533,156 @@ export function blinxForm({
             );
           }
 
-          if (!nestedView && BlinxConfig.isGeneratedViewAllowed() === false) {
+          if (!nestedView && BlinxConfig.isGeneratedViewAllowed() === false && relation.mode !== 'journey') {
             // Strict mode: nested model rendering requires an explicit view.
             throw new Error(
               `blinxForm: strict mode: missing nested ui view for model "${String(nestedModel?.id || nestedModel?.name || nestedModel?.entity || 'unknown')}" (field "${String(key)}").`
             );
+          }
+
+          // Relation journey mode: do not render inline nested forms. Render a minimal relation widget instead.
+          if (relation.mode === 'journey') {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'blx-field blx-field--relation';
+            wrapper.setAttribute('data-blinx-field', key);
+            wrapper.setAttribute('data-blinx-relation-mode', 'journey');
+
+            const label = document.createElement('label');
+            label.className = 'blx-label';
+            label.setAttribute('data-blinx-part', 'label');
+            label.textContent = key;
+
+            const input = document.createElement('span');
+            input.className = 'blx-input blx-input--readonly';
+            input.setAttribute('data-blinx-part', 'input');
+            input.setAttribute('data-blinx-readonly', 'true');
+            input.textContent = String(getUI('default').formatCell(value, def) ?? '');
+
+            const actionsEl = document.createElement('div');
+            actionsEl.className = 'blx-toolbar';
+            actionsEl.setAttribute('data-blinx-part', 'actions');
+
+            const addActionButton = (actionKey, labelText, handler) => {
+              const btn = document.createElement('button');
+              btn.type = 'button';
+              btn.className = 'blx-btn';
+              btn.setAttribute('data-variant', 'surface');
+              btn.setAttribute('data-blinx-action', actionKey);
+              btn.textContent = labelText;
+              btn.addEventListener('click', handler);
+              fieldCleanupFns.push(() => { try { btn.removeEventListener('click', handler); } catch { /* ignore */ } });
+              actionsEl.appendChild(btn);
+            };
+
+            const runRelationBuiltin = async (executor, metaLabel) => {
+              const facade = createActionFacade({
+                store,
+                getRecord: () => store.getRecord(currentIndex),
+                getRecordIndex: () => currentIndex,
+                setStatus,
+                strict: false,
+              });
+              try {
+                await runInternalChange(async () => {
+                  await executor(facade);
+                  await facade.flush();
+                });
+                const issues = facade.getIssues();
+                if (issues.length) setStatus(`${metaLabel}: ${issues.map(i => i.code).join(', ')}`, '#e53e3e');
+                else setStatus(`${metaLabel}: done.`, '#2f855a');
+              } catch (e) {
+                setStatus(`${metaLabel}: failed.`, '#e53e3e');
+              }
+            };
+
+            if (relation.pick.enabled) {
+              addActionButton('pick', 'Pick', async (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (relation.pick.action) {
+                  // If an action is provided, execute it (expected to mutate via ctx.model().get(fieldKey)).
+                  const facade = createActionFacade({
+                    store,
+                    getRecord: () => store.getRecord(currentIndex),
+                    getRecordIndex: () => currentIndex,
+                    setStatus,
+                    strict: false,
+                  });
+                  const actionCtx = {
+                    formApi: api,
+                    store,
+                    get recordIndex() { return currentIndex; },
+                    get record() { return store.getRecord(currentIndex); },
+                    setStatus,
+                    clearStatus,
+                    getRecord: () => facade.getRecord(),
+                    model: (record) => facade.model(record),
+                    flush: () => facade.flush(),
+                    getIssues: () => facade.getIssues(),
+                  };
+                  try {
+                    await executeActionSpec({
+                      action: relation.pick.action,
+                      ctx: actionCtx,
+                      registry: actionRegistry,
+                      runner: actionRunner,
+                      meta: { kind: 'form', controlName: `relation:${key}:pick`, viewId: view?.id },
+                    });
+                    await runInternalChange(() => facade.flush());
+                  } catch {
+                    setStatus(`Pick failed.`, '#e53e3e');
+                    return;
+                  }
+                  const issues = facade.getIssues();
+                  if (issues.length) setStatus(`Pick: ${issues.map(i => i.code).join(', ')}`, '#e53e3e');
+                  else setStatus('Pick: done.', '#2f855a');
+                  return;
+                }
+                setStatus('Pick journey is not implemented yet.', '#4a5568');
+              });
+            }
+            if (relation.edit.enabled) {
+              addActionButton('edit', 'Edit', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setStatus('Edit journey is not implemented yet.', '#4a5568');
+              });
+            }
+            if (relation.unlink.enabled) {
+              addActionButton('unlink', 'Unlink', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                void runRelationBuiltin((facade) => {
+                  facade.model().get(key).unlink();
+                }, 'Unlink');
+              });
+            }
+            if (relation.delete.enabled) {
+              addActionButton('delete', 'Delete', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                void runRelationBuiltin((facade) => {
+                  facade.model().get(key).delete();
+                }, 'Delete');
+              });
+            }
+
+            wrapper.appendChild(label);
+            wrapper.appendChild(input);
+            wrapper.appendChild(actionsEl);
+
+            const cell = document.createElement('div');
+            if (typeof f === 'object' && f.span === 2) cell.style.gridColumn = 'span 2';
+            if (fieldPresent?.attrs) {
+              applyAttrs(cell, fieldPresent.attrs.cell);
+              applyAttrs(wrapper, fieldPresent.attrs.wrapper);
+              applyAttrs(wrapper, fieldPresent.attrs.root);
+              applyAttrs(label, fieldPresent.attrs.label);
+              applyAttrs(input, fieldPresent.attrs.input);
+            }
+            cell.appendChild(wrapper);
+            grid.appendChild(cell);
+            return;
           }
 
           // Non-strict: if we still can't resolve a nested view (e.g., malformed nested model),
@@ -515,7 +704,7 @@ export function blinxForm({
               setField: (_idx, field, nextVal) => {
                 nestedRecord = { ...nestedRecord, [field]: nextVal };
                 if (!store.getRecord(currentIndex)) return;
-                runInternalChange(() => store.setField(currentIndex, key, nestedRecord));
+                runInternalChange(() => internalFacade.model().get(key).set(nestedRecord));
                 subs.forEach(fn => fn({ path: [0, field], value: nextVal, data: [nestedRecord], store: nestedStore }));
               },
               subscribe: fn => { subs.add(fn); return () => subs.delete(fn); },
@@ -549,9 +738,112 @@ export function blinxForm({
         }
 
         if (def?.type === 'collection' && def?.model && typeof def.model === 'object') {
+          const relation = resolveRelationSpec(def, (f && typeof f === 'object') ? f : null);
           const itemModel = def.model;
           const overrideItemViewName = (f && typeof f === 'object') ? (f.itemView || null) : null;
           const items = Array.isArray(value) ? value : [];
+
+          // Relation journey mode: do not render inline nested collection forms.
+          if (relation.mode === 'journey') {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'blx-field blx-field--relation';
+            wrapper.setAttribute('data-blinx-field', key);
+            wrapper.setAttribute('data-blinx-relation-mode', 'journey');
+
+            const label = document.createElement('label');
+            label.className = 'blx-label';
+            label.setAttribute('data-blinx-part', 'label');
+            label.textContent = key;
+
+            const input = document.createElement('span');
+            input.className = 'blx-input blx-input--readonly';
+            input.setAttribute('data-blinx-part', 'input');
+            input.setAttribute('data-blinx-readonly', 'true');
+            // Default renderer formatting for collections is typically JSON-ish; provide a friendlier summary.
+            const summary = Array.isArray(value) ? `${value.length} item(s)` : String(getUI('default').formatCell(value, def) ?? '');
+            input.textContent = summary;
+
+            const actionsEl = document.createElement('div');
+            actionsEl.className = 'blx-toolbar';
+            actionsEl.setAttribute('data-blinx-part', 'actions');
+
+            const addActionButton = (actionKey, labelText, handler) => {
+              const btn = document.createElement('button');
+              btn.type = 'button';
+              btn.className = 'blx-btn';
+              btn.setAttribute('data-variant', 'surface');
+              btn.setAttribute('data-blinx-action', actionKey);
+              btn.textContent = labelText;
+              btn.addEventListener('click', handler);
+              fieldCleanupFns.push(() => { try { btn.removeEventListener('click', handler); } catch { /* ignore */ } });
+              actionsEl.appendChild(btn);
+            };
+
+            const runRelationBuiltin = async (executor, metaLabel) => {
+              const facade = createActionFacade({
+                store,
+                getRecord: () => store.getRecord(currentIndex),
+                getRecordIndex: () => currentIndex,
+                setStatus,
+                strict: false,
+              });
+              try {
+                await runInternalChange(async () => {
+                  await executor(facade);
+                  await facade.flush();
+                });
+                const issues = facade.getIssues();
+                if (issues.length) setStatus(`${metaLabel}: ${issues.map(i => i.code).join(', ')}`, '#e53e3e');
+                else setStatus(`${metaLabel}: done.`, '#2f855a');
+              } catch {
+                setStatus(`${metaLabel}: failed.`, '#e53e3e');
+              }
+            };
+
+            if (relation.pick.enabled) {
+              addActionButton('pick', 'Pick', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setStatus('Pick journey is not implemented yet.', '#4a5568');
+              });
+            }
+            if (relation.unlink.enabled) {
+              addActionButton('unlink', 'Unlink', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                void runRelationBuiltin((facade) => {
+                  facade.model().get(key).unlink();
+                }, 'Unlink');
+              });
+            }
+            if (relation.delete.enabled) {
+              addActionButton('delete', 'Delete', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                void runRelationBuiltin((facade) => {
+                  // Collection delete requires scoping; without a journey implementation we cannot safely delete.
+                  facade.model().get(key).delete();
+                }, 'Delete');
+              });
+            }
+
+            wrapper.appendChild(label);
+            wrapper.appendChild(input);
+            wrapper.appendChild(actionsEl);
+
+            const cell = document.createElement('div');
+            if (typeof f === 'object' && f.span === 2) cell.style.gridColumn = 'span 2';
+            if (fieldPresent?.attrs) {
+              applyAttrs(cell, fieldPresent.attrs.cell);
+              applyAttrs(wrapper, fieldPresent.attrs.wrapper);
+              applyAttrs(wrapper, fieldPresent.attrs.root);
+              applyAttrs(label, fieldPresent.attrs.label);
+              applyAttrs(input, fieldPresent.attrs.input);
+            }
+            cell.appendChild(wrapper);
+            grid.appendChild(cell);
+            return;
+          }
 
           const list = document.createElement('div');
           list.className = 'blinx-nested blinx-nested--collection';
@@ -591,7 +883,7 @@ export function blinxForm({
                 const base = Array.isArray(latest) ? latest : [];
                 const nextItems = base.slice();
                 nextItems[itemIndex] = nestedRecord;
-                runInternalChange(() => store.setField(currentIndex, key, nextItems));
+                runInternalChange(() => internalFacade.model().get(key).set(nextItems));
                 subs.forEach(fn => fn({ path: [0, field], value: nextVal, data: [nestedRecord], store: itemStore }));
               },
               subscribe: fn => { subs.add(fn); return () => subs.delete(fn); },

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -590,6 +590,9 @@ export function blinxForm({
                 const issues = facade.getIssues();
                 if (issues.length) setStatus(`${metaLabel}: ${issues.map(i => i.code).join(', ')}`, '#e53e3e');
                 else setStatus(`${metaLabel}: done.`, '#2f855a');
+                // Journey widgets display a derived preview string; refresh so the UI reflects unlink/delete.
+                buildSections();
+                updateIndicator();
               } catch (e) {
                 setStatus(`${metaLabel}: failed.`, '#e53e3e');
               }
@@ -636,6 +639,9 @@ export function blinxForm({
                   const issues = facade.getIssues();
                   if (issues.length) setStatus(`Pick: ${issues.map(i => i.code).join(', ')}`, '#e53e3e');
                   else setStatus('Pick: done.', '#2f855a');
+                  // Ensure the preview reflects the picked value.
+                  buildSections();
+                  updateIndicator();
                   return;
                 }
                 setStatus('Pick journey is not implemented yet.', '#4a5568');
@@ -795,6 +801,9 @@ export function blinxForm({
                 const issues = facade.getIssues();
                 if (issues.length) setStatus(`${metaLabel}: ${issues.map(i => i.code).join(', ')}`, '#e53e3e');
                 else setStatus(`${metaLabel}: done.`, '#2f855a');
+                // Journey widgets display summaries; refresh so the UI reflects unlink/delete.
+                buildSections();
+                updateIndicator();
               } catch {
                 setStatus(`${metaLabel}: failed.`, '#e53e3e');
               }

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -595,6 +595,10 @@ export function blinxForm({
                 updateIndicator();
               } catch (e) {
                 setStatus(`${metaLabel}: failed.`, '#e53e3e');
+                // `executor()` can mutate the store synchronously before `flush()` fails.
+                // Refresh anyway so UI reflects the current (already-mutated) state.
+                buildSections();
+                updateIndicator();
               }
             };
 
@@ -634,6 +638,9 @@ export function blinxForm({
                     await runInternalChange(() => facade.flush());
                   } catch {
                     setStatus(`Pick failed.`, '#e53e3e');
+                    // The action may have mutated the store before flush failed; refresh to keep UI consistent.
+                    buildSections();
+                    updateIndicator();
                     return;
                   }
                   const issues = facade.getIssues();
@@ -806,6 +813,10 @@ export function blinxForm({
                 updateIndicator();
               } catch {
                 setStatus(`${metaLabel}: failed.`, '#e53e3e');
+                // `executor()` can mutate the store synchronously before `flush()` fails.
+                // Refresh anyway so UI reflects the current (already-mutated) state.
+                buildSections();
+                updateIndicator();
               }
             };
 


### PR DESCRIPTION
Implement `relation.mode` parsing and wire built-in nested controls to the action façade to enable correct SNM semantics.

This change prevents building more UI that bypasses the action façade, ensuring all built-in nested interactions mutate via `ctx.model().get(field)` rather than touching stores directly, as outlined in `docs/wip.md` (Aspect 2 -> Iteration 1).

---
<a href="https://cursor.com/background-agent?bcId=bc-62814d1b-585a-42d7-ba3a-26a419ba0f78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62814d1b-585a-42d7-ba3a-26a419ba0f78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces relation semantics and non-inline rendering for normalized relations while aligning nested mutations with the action façade.
> 
> - Parse `relation.mode` with `inline`/`journey` (default `journey` when `embedded: false`); new `normalizeRelationMode` and `resolveRelationSpec`
> - For `journey` on `model`/`collection` fields, render a minimal relation widget (`data-blinx-relation-mode="journey"`) showing a readonly preview and toolbar actions (`pick`, `edit`, `unlink`, `delete`) wired through `createActionFacade` and `executeActionSpec` where applicable
> - Relax strict nested-view requirement when in `journey` mode; no inline nested forms are rendered
> - Route inline nested changes through the façade (`internalFacade.model().get(key).set(...)`) instead of touching `store.setField` directly, including collection item edits (avoids stale closures)
> - Update status messaging and rebuild sections after relation actions; add concise collection summaries (e.g., "N item(s)")
> - Add integration test asserting SNM defaults to `journey` and suppresses inline nested forms
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13d8aa84110d9d1d76940601345f93259fcec105. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->