### PR TITLE
Pluggable issue notifier system

### DIFF
--- a/__tests__/blinx.notifier.integration.test.js
+++ b/__tests__/blinx.notifier.integration.test.js
@@ -22,6 +22,39 @@ describe('Notifier post-action hook (forms/collections)', () => {
     Notifier.set(null);
   });
 
+  test('blinxForm: custom action can call ctx.notify() (no Notifier import)', async () => {
+    const model = { fields: { name: { type: 'string' } } };
+    const store = blinxStore([{ name: 'A' }], model);
+    const root = document.createElement('div');
+
+    const notify = jest.fn();
+    Notifier.set({ notify });
+
+    blinxForm({
+      root,
+      store,
+      recordIndex: 0,
+      view: {
+        sections: [{ title: 'Main', columns: 1, fields: ['name'] }],
+        controls: {
+          saveStatus: true,
+          custom: {
+            label: 'Do',
+            action: (ctx) => {
+              ctx.notify('Hello from action');
+            },
+          },
+        },
+      },
+    });
+
+    getToolbarButton(root, 'Do')?.click();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0][0]?.message).toBe('Hello from action');
+  });
+
   test('blinxForm: after custom action, issues are routed to active notifier impl', async () => {
     const model = {
       fields: {

--- a/__tests__/blinx.notifier.integration.test.js
+++ b/__tests__/blinx.notifier.integration.test.js
@@ -1,0 +1,135 @@
+/** @jest-environment jsdom */
+
+import { blinxStore } from '../lib/blinx.store.js';
+import { blinxForm } from '../lib/blinx.form.js';
+import { blinxCollection } from '../lib/blinx.collection.js';
+import { Notifier } from '../lib/blinx.notifier.js';
+
+function getToolbarButton(root, label) {
+  const toolbar = root.querySelector('.blinx-controls');
+  if (!toolbar) return null;
+  return Array.from(toolbar.querySelectorAll('button')).find(b => b.textContent === label) || null;
+}
+
+function getToolbarText(root) {
+  const toolbar = root.querySelector('.blinx-controls');
+  return toolbar ? toolbar.textContent : '';
+}
+
+describe('Notifier post-action hook (forms/collections)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    Notifier.set(null);
+  });
+
+  test('blinxForm: after custom action, issues are routed to active notifier impl', async () => {
+    const model = {
+      fields: {
+        name: { type: 'string' },
+        child: { type: 'model', embedded: true, model: { id: 'Child', fields: { id: { type: 'string' } } } },
+      },
+    };
+    const store = blinxStore([{ name: 'A', child: { id: 'c1' } }], model);
+    const root = document.createElement('div');
+
+    const notify = jest.fn();
+    Notifier.set({ notify });
+
+    blinxForm({
+      root,
+      store,
+      recordIndex: 0,
+      view: {
+        sections: [{ title: 'Main', columns: 1, fields: ['name'] }],
+        controls: {
+          // Provide a status area so fallback would have somewhere to write (if used).
+          saveStatus: true,
+          custom: {
+            label: 'Do',
+            action: (ctx) => {
+              // ENM delete is denied by default => facade reports an issue.
+              ctx.model().get('child').delete();
+            },
+          },
+        },
+      },
+    });
+
+    getToolbarButton(root, 'Do')?.click();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    const payload = notify.mock.calls[0][0];
+    expect(payload?.issues?.[0]?.code).toBe('ENM_DELETE_DENIED');
+  });
+
+  test('blinxForm: without notifier impl, issues fall back to setStatus()', async () => {
+    const model = {
+      fields: {
+        name: { type: 'string' },
+        child: { type: 'model', embedded: true, model: { id: 'Child', fields: { id: { type: 'string' } } } },
+      },
+    };
+    const store = blinxStore([{ name: 'A', child: { id: 'c1' } }], model);
+    const root = document.createElement('div');
+
+    blinxForm({
+      root,
+      store,
+      recordIndex: 0,
+      view: {
+        sections: [{ title: 'Main', columns: 1, fields: ['name'] }],
+        controls: {
+          saveStatus: true,
+          custom: {
+            label: 'Do',
+            action: (ctx) => {
+              ctx.model().get('child').delete();
+            },
+          },
+        },
+      },
+    });
+
+    getToolbarButton(root, 'Do')?.click();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(getToolbarText(root)).toContain('Issues: ENM_DELETE_DENIED');
+  });
+
+  test('blinxCollection: after custom action, issues fall back to status by default', async () => {
+    const model = {
+      fields: {
+        name: { type: 'string' },
+        child: { type: 'model', embedded: true, model: { id: 'Child', fields: { id: { type: 'string' } } } },
+      },
+    };
+    const store = blinxStore([{ name: 'A', child: { id: 'c1' } }], model);
+    const root = document.createElement('div');
+
+    blinxCollection({
+      root,
+      store,
+      paging: { pageSize: 20 },
+      view: {
+        layout: 'table',
+        columns: [{ field: 'name', label: 'Name' }],
+        controls: {
+          status: true,
+          custom: {
+            label: 'Do',
+            action: (ctx) => {
+              ctx.model().get('child').delete();
+            },
+          },
+        },
+      },
+    });
+
+    getToolbarButton(root, 'Do')?.click();
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(getToolbarText(root)).toContain('Issues: ENM_DELETE_DENIED');
+  });
+});
+

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -12,6 +12,7 @@ Docs:
 - [`data-views.md`](data-views.md)
 - [`ui-views.md`](ui-views.md)
 - [`action-facade.md`](action-facade.md)
+- [`notifier.md`](notifier.md)
 - [`nested.md`](nested.md)
 - [`blinx-app.md`](blinx-app.md)
 

--- a/docs/spec/action-facade.md
+++ b/docs/spec/action-facade.md
@@ -151,6 +151,7 @@ Both `blinxForm` and `blinxCollection` expose the action facade to custom contro
     flush,           // facade.flush
     getIssues,       // facade.getIssues
     setStatus,       // optional status reporter
+    notify,          // ctx.notify(messageOrIssues[, fallback])
   }
   ```
 
@@ -161,7 +162,31 @@ Both `blinxForm` and `blinxCollection` expose the action facade to custom contro
     model(record?),  // defaults to the row
     flush,
     getIssues,
+    notify,          // ctx.notify(messageOrIssues[, fallback])
   }
   ```
+
+### 8.1 Issue reporting (`ctx.getIssues()` → notifier)
+
+Facade operations may report non-fatal issues (especially in `strict: false` mode). In forms/collections:
+
+- Custom actions can still inspect issues manually via `ctx.getIssues()`.
+- Additionally, Blinx runs a **post-action hook**: after a custom action completes successfully, if `ctx.getIssues()` contains entries, Blinx will surface them through the centralized notifier mechanism (see [`notifier.md`](notifier.md)). If no notifier implementation is registered, Blinx falls back to the component’s built-in status channel (`setStatus(...)`).
+
+### 8.2 User-intent notifications (`ctx.notify(...)`)
+
+Custom actions often need to emit intentional UX messages that are not “facade issues” (e.g., “Copied”, “Export started”).
+
+Use `ctx.notify(...)` rather than importing the global notifier directly:
+
+```js
+action: async (ctx) => {
+  ctx.notify('Export started');
+  // ... do work ...
+  ctx.notify('Export finished');
+}
+```
+
+`ctx.notify(messageOrIssues[, fallback])` is a thin wrapper over the centralized notifier. When no notifier implementation is registered, it defaults to a best-effort fallback using the component’s `setStatus(...)` channel.
 
 Custom action definitions (e.g., `controls: [{ type: 'action', action: async (ctx) => { ... } }]`) can call `ctx.model().get('field')` to mutate fields, `ctx.flush()` to persist, and inspect `ctx.getIssues()` for non-fatal warnings. Because these contexts delegate to `createActionFacade` internally, SNM-specific behavior (child store patch/delete, lazy store resolution, issue tracking) works identically in forms, collections, and standalone action runners.

--- a/docs/spec/notifier.md
+++ b/docs/spec/notifier.md
@@ -1,0 +1,84 @@
+<!--
+  Notifier spec: centralized notification routing.
+  This is intentionally small: it defines the stable API surface and how UI actions should use it.
+-->
+
+# Notifier (`lib/blinx.notifier.js`)
+
+Blinx does not ship a built-in toast/banner UI. Instead it provides a **central, pluggable notifier** that any app can register once and all Blinx components can use without prop-drilling.
+
+This solves the “custom actions collect issues but don’t automatically render them” gap described in `docs/wip.md` (Aspect 2 / Iteration 1).
+
+## 1) Direct API (app integration)
+
+Use this in your app bootstrap code to register a single notifier implementation.
+
+```js
+import { Notifier } from '../lib/blinx.notifier.js';
+
+Notifier.set({
+  notify(payload) {
+    // payload = { message, issues?, raw }
+    // Render a toast/banner however your app prefers.
+    console.log(payload.message);
+  },
+});
+```
+
+### 1.1 `Notifier.set(impl)`
+
+- Registers the active notifier implementation (only one is active per runtime).
+- Pass `null`/`undefined` to clear.
+- `impl` must be an object with `notify(payload)`.
+
+### 1.2 `Notifier.get()`
+
+Returns the currently active implementation or `null`.
+
+### 1.3 `Notifier.notify(messageOrIssues, fallback?)`
+
+Best-effort notification:
+
+- If an implementation is registered, calls `impl.notify(payload)`.
+- Otherwise, calls the provided `fallback(message, payload)` if present.
+
+Accepted inputs:
+
+- `string | number | ...` → normalized to `{ message: String(input) }`
+- `Issue[]` → normalized to `{ issues, message }`
+- `{ issues: Issue[] }` → normalized to `{ issues, message }`
+
+Where an `Issue` is the facade issue shape:
+
+```ts
+type Issue = { code: string; message?: string; field?: string; [k: string]: any };
+```
+
+## 2) Recommended API for custom actions: `ctx.notify(...)`
+
+Custom actions should **not** import `Notifier` directly. Instead, forms/collections provide:
+
+```js
+ctx.notify(messageOrIssues, fallback?)
+```
+
+This is a thin wrapper over `Notifier.notify(...)` that defaults its fallback to the component’s existing status channel (`setStatus(...)`).
+
+Example:
+
+```js
+action: async (ctx) => {
+  ctx.notify('Copied to clipboard');
+}
+```
+
+## 3) Automatic issue surfacing: `ctx.getIssues()` post-action hook
+
+For custom actions executed by `blinxForm` and `blinxCollection`:
+
+- Actions can collect non-fatal warnings/errors via the action facade.
+- After the action completes successfully, Blinx checks `ctx.getIssues()`.
+- If issues exist, they are routed to the notifier (`Notifier`), falling back to `setStatus(...)` when no notifier implementation is registered.
+
+This keeps “issues” as structured data while still making them visible by default.
+

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -1113,6 +1113,11 @@ export function blinxCollection({
       store,
       getState: () => controller.getState(),
       setStatus: (msg, color) => setStatus(dom, msg, color),
+      // Centralized notifications: actions should call ctx.notify(...) instead of importing Notifier directly.
+      notify: (messageOrIssues, fallback = null) => {
+        const fb = (typeof fallback === 'function') ? fallback : (msg) => setStatus(dom, msg, '#e53e3e');
+        Notifier.notify(messageOrIssues, fb);
+      },
       // Spec v0 (nested): intuitive action facade
       getRecord: () => facade.getRecord(),
       model: (record) => facade.model(record),
@@ -1155,6 +1160,11 @@ export function blinxCollection({
       store,
       getState: () => controller.getState(),
       setStatus: (msg, color) => setStatus(dom, msg, color),
+      // Centralized notifications: actions should call ctx.notify(...) instead of importing Notifier directly.
+      notify: (messageOrIssues, fallback = null) => {
+        const fb = (typeof fallback === 'function') ? fallback : (msg) => setStatus(dom, msg, '#e53e3e');
+        Notifier.notify(messageOrIssues, fb);
+      },
       record,
       recordIndex: index,
       // Spec v0 (nested): intuitive action facade

--- a/lib/blinx.collection.js
+++ b/lib/blinx.collection.js
@@ -10,6 +10,7 @@ import {
 } from './blinx.controls.js';
 import { executeActionSpec } from './blinx.actions.js';
 import { createActionFacade } from './blinx.action-facade.js';
+import { Notifier } from './blinx.notifier.js';
 
 const ROOT_CLEANUP = Symbol('blinxCollectionCleanup');
 
@@ -1128,6 +1129,12 @@ export function blinxCollection({
       });
       if (res?.status === 'invalid') {
         actionCtx.setStatus(`Action "${name}" blocked.`, '#e53e3e');
+        return;
+      }
+      // Post-action hook: surface any facade issues via centralized notifier.
+      const issues = actionCtx?.getIssues?.() || [];
+      if (Array.isArray(issues) && issues.length) {
+        Notifier.notify(issues, (msg) => actionCtx.setStatus(msg, '#e53e3e'));
       }
     } catch {
       actionCtx.setStatus(`Action "${name}" failed.`, '#e53e3e');
@@ -1166,6 +1173,12 @@ export function blinxCollection({
       });
       if (res?.status === 'invalid') {
         actionCtx.setStatus(`Action "${name}" blocked.`, '#e53e3e');
+        return;
+      }
+      // Post-action hook: surface any facade issues via centralized notifier.
+      const issues = actionCtx?.getIssues?.() || [];
+      if (Array.isArray(issues) && issues.length) {
+        Notifier.notify(issues, (msg) => actionCtx.setStatus(msg, '#e53e3e'));
       }
     } catch {
       actionCtx.setStatus(`Action "${name}" failed.`, '#e53e3e');

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -1150,6 +1150,11 @@ export function blinxForm({
         get record() { return store.getRecord(currentIndex); },
         setStatus,
         clearStatus,
+        // Centralized notifications: actions should call ctx.notify(...) instead of importing Notifier directly.
+        notify: (messageOrIssues, fallback = null) => {
+          const fb = (typeof fallback === 'function') ? fallback : (msg) => setStatus(msg, '#e53e3e');
+          Notifier.notify(messageOrIssues, fb);
+        },
         // Spec v0 (nested): intuitive action facade
         getRecord: () => facade.getRecord(),
         model: (record) => facade.model(record),

--- a/lib/blinx.form.js
+++ b/lib/blinx.form.js
@@ -12,6 +12,7 @@ import {
 } from './blinx.controls.js';
 import { executeActionSpec } from './blinx.actions.js';
 import { createActionFacade } from './blinx.action-facade.js';
+import { Notifier } from './blinx.notifier.js';
 
 // Prevent handler accumulation when blinxForm is called multiple times
 // with the same DOM controls (common in tests and re-renders).
@@ -1142,7 +1143,7 @@ export function blinxForm({
         setStatus,
         strict: false,
       });
-      const ctx = {
+      const actionCtx = {
         formApi: api,
         store,
         get recordIndex() { return currentIndex; },
@@ -1158,7 +1159,7 @@ export function blinxForm({
       try {
         const res = await executeActionSpec({
           action,
-          ctx,
+          ctx: actionCtx,
           registry: actionRegistry,
           runner: actionRunner,
           meta: { kind: 'form', controlName: name, viewId: view?.id },
@@ -1167,6 +1168,11 @@ export function blinxForm({
           // Best-effort feedback; do not throw.
           setStatus(`Action "${name}" blocked.`, '#e53e3e');
           return;
+        }
+        // Post-action hook: surface any facade issues via centralized notifier.
+        const issues = actionCtx?.getIssues?.() || [];
+        if (Array.isArray(issues) && issues.length) {
+          Notifier.notify(issues, (msg) => setStatus(msg, '#e53e3e'));
         }
       } catch (e) {
         setStatus(`Action "${name}" failed.`, '#e53e3e');

--- a/lib/blinx.notifier.js
+++ b/lib/blinx.notifier.js
@@ -1,0 +1,92 @@
+function isPlainObject(v) {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function formatIssues(issues) {
+  if (!Array.isArray(issues) || issues.length === 0) return '';
+  const codes = issues.map(i => i?.code).filter(Boolean);
+  const messages = issues.map(i => i?.message).filter(Boolean);
+  if (codes.length && messages.length) return `Issues: ${codes.join(', ')} — ${messages[0]}`;
+  if (codes.length) return `Issues: ${codes.join(', ')}`;
+  if (messages.length) return `Issues: ${messages[0]}`;
+  return 'Issues occurred.';
+}
+
+function normalizePayload(input) {
+  // Accept:
+  // - string/number/etc => { message }
+  // - Issue[] => { issues, message }
+  // - { issues: Issue[] } => { issues, message }
+  if (Array.isArray(input)) {
+    const issues = input.slice();
+    return { issues, message: formatIssues(issues), raw: input };
+  }
+  if (isPlainObject(input) && Array.isArray(input.issues)) {
+    const issues = input.issues.slice();
+    return { issues, message: formatIssues(issues), raw: input };
+  }
+  const message = (input === undefined || input === null) ? '' : String(input);
+  return { issues: null, message, raw: input };
+}
+
+let ACTIVE_NOTIFIER = null;
+
+/**
+ * Centralized, singleton notifier registry.
+ *
+ * Only one implementation is active per app/runtime.
+ * Consumers can call Notifier.notify(...) without having to pass it through props/params.
+ *
+ * Contract for implementations:
+ * - { notify(payload) } where payload is { message, issues?, raw }
+ */
+export const Notifier = {
+  /**
+   * Register the active notifier implementation.
+   * Passing null/undefined clears the notifier.
+   */
+  set(impl) {
+    if (!impl) {
+      ACTIVE_NOTIFIER = null;
+      return;
+    }
+    if (!isPlainObject(impl) || typeof impl.notify !== 'function') {
+      throw new Error('Notifier.set(impl): impl must be an object with notify(payload).');
+    }
+    ACTIVE_NOTIFIER = impl;
+  },
+
+  /**
+   * Returns the currently active notifier implementation (or null).
+   */
+  get() {
+    return ACTIVE_NOTIFIER;
+  },
+
+  /**
+   * Notify via the active impl, falling back to the provided fallback function.
+   *
+   * @param {any} messageOrIssues
+   * @param {Function|null} fallback - fallback(message, payload) called when no notifier is registered.
+   */
+  notify(messageOrIssues, fallback = null) {
+    const payload = normalizePayload(messageOrIssues);
+    const impl = ACTIVE_NOTIFIER;
+    if (impl && typeof impl.notify === 'function') {
+      try {
+        impl.notify(payload);
+        return;
+      } catch {
+        // If a notifier impl throws, do not crash the app; fall back.
+      }
+    }
+    if (typeof fallback === 'function') {
+      try {
+        fallback(payload.message, payload);
+      } catch {
+        // ignore fallback failures (best-effort)
+      }
+    }
+  },
+};
+


### PR DESCRIPTION
Add a centralized, pluggable notifier and post-action hooks in forms/collections to automatically surface `ctx.getIssues()` from custom UI actions.

This addresses the remaining part of "Aspect 2 / Iteration 1" from `docs/wip.md`, ensuring that issues from custom UI actions are no longer silent and providing a framework-level mechanism for handling notifications, which can be customized (e.g., for toast messages) or fall back to the existing `setStatus()` channel.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1668d03-750c-49f9-b598-a19b9e9e2559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f1668d03-750c-49f9-b598-a19b9e9e2559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a central mechanism to surface issues from custom UI actions and a safe fallback path.
> 
> - **New** `lib/blinx.notifier.js`: singleton `Notifier` with `set/get/notify`, payload normalization (`issues`/`message`), and message formatting; falls back to a provided handler when no impl is registered
> - **Forms** (`lib/blinx.form.js`): after executing custom control actions, collect `ctx.getIssues()` and call `Notifier.notify(issues, fallback => setStatus(...))`; early-return on invalid actions
> - **Collections** (`lib/blinx.collection.js`): same post-action hook for both collection-level and record-level custom actions; uses `Notifier.notify(issues, fallback => actionCtx.setStatus(...))`; early-return on invalid
> - **Tests** (`__tests__/blinx.notifier.integration.test.js`): integration coverage verifying notifier routing and fallback to toolbar status for both `blinxForm` and `blinxCollection`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91a9325da89f69ffdbbad98ba864984d3fc56e02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->