### PR TITLE
Toast notifier implementation design

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,19 @@ This layering keeps validation, diffing, and messaging logic reusable while adap
 - Save/Reset/Delete actions surface user-friendly messages through the injected `status` DOM node using semantic colors (`#2f855a` success, `#e53e3e` errors, slate for neutral states).
 - Form and table share this pattern so embedding apps can style a single CSS class to affect both widgets.
 
+## Notifications (Toast / Banner)
+
+Blinx routes custom-action notifications through a centralized, pluggable notifier (`lib/blinx.notifier.js`). This keeps the core headless while allowing apps to register their preferred toast/banner UI once.
+
+To opt into the built-in DOM toast implementation:
+
+```js
+import { Notifier } from './lib/blinx.notifier.js';
+import { createToastNotifier } from './lib/blinx.toast-notifier.js';
+
+Notifier.set(createToastNotifier());
+```
+
 ## Interceptors & Events
 
 - Store events are granular: `add`, `update`, and `reset` fire once per record, while `remove` batches all removed records into a single payload and `commit` ships the entire dataset snapshot plus the store reference for query access.

--- a/__tests__/blinx.toast-notifier.test.js
+++ b/__tests__/blinx.toast-notifier.test.js
@@ -1,0 +1,68 @@
+/** @jest-environment jsdom */
+
+import { createToastNotifier } from '../lib/blinx.toast-notifier.js';
+
+function q(selector) {
+  return document.querySelector(selector);
+}
+
+describe('createToastNotifier', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('creates a region on first notify and appends a toast', () => {
+    const n = createToastNotifier({ durationMs: 10_000 });
+    n.notify({ message: 'Hello', issues: null, raw: 'Hello' });
+
+    expect(q('.blx-toast-region')).toBeTruthy();
+    expect(q('.blx-toast')?.textContent).toContain('Hello');
+  });
+
+  test('dedupes repeated messages within window (increments count)', () => {
+    const n = createToastNotifier({ dedupeWindowMs: 5_000, durationMs: 10_000 });
+
+    n.notify({ message: 'Saved', issues: null, raw: 'Saved' });
+    n.notify({ message: 'Saved', issues: null, raw: 'Saved' });
+
+    const toasts = document.querySelectorAll('.blx-toast');
+    expect(toasts.length).toBe(1);
+
+    const badge = q('.blx-toast [data-blx-part="count"]');
+    expect(badge).toBeTruthy();
+    expect(badge.hidden).toBe(false);
+    expect(badge.textContent).toBe('×2');
+  });
+
+  test('auto-dismisses toast after duration (and removes from DOM)', () => {
+    const n = createToastNotifier({ durationMs: 50, dedupeWindowMs: 0 });
+    n.notify({ message: 'Will disappear', issues: null, raw: 'Will disappear' });
+
+    expect(q('.blx-toast')).toBeTruthy();
+
+    jest.advanceTimersByTime(50);
+    // leaving transition timer (180ms in implementation)
+    jest.advanceTimersByTime(200);
+
+    expect(q('.blx-toast')).toBeFalsy();
+  });
+
+  test('danger variant uses longer timeout by default', () => {
+    const n = createToastNotifier({ durationMs: 10, dangerDurationMs: 100 });
+    n.notify({ message: 'Issues: X', issues: [{ code: 'X' }], raw: null });
+
+    // Before 100ms it should still exist.
+    jest.advanceTimersByTime(50);
+    expect(q('.blx-toast')).toBeTruthy();
+
+    jest.advanceTimersByTime(60);
+    jest.advanceTimersByTime(200);
+    expect(q('.blx-toast')).toBeFalsy();
+  });
+});
+

--- a/__tests__/blinx.toast-notifier.test.js
+++ b/__tests__/blinx.toast-notifier.test.js
@@ -52,6 +52,25 @@ describe('createToastNotifier', () => {
     expect(q('.blx-toast')).toBeFalsy();
   });
 
+  test('close button cancels auto-dismiss timer', () => {
+    const n = createToastNotifier({ durationMs: 10_000, dedupeWindowMs: 10_000 });
+    n.notify({ message: 'Closable', issues: null, raw: 'Closable' });
+
+    // Flush the "enter -> shown" 0ms timer so only the auto-dismiss remains.
+    jest.advanceTimersByTime(0);
+    expect(jest.getTimerCount()).toBe(1);
+
+    q('.blx-toast [data-blx-part="close"]')?.click();
+
+    // Close schedules immediate removal (0ms) + transition cleanup (180ms),
+    // and should have cancelled the original long auto-dismiss timer.
+    jest.advanceTimersByTime(0);
+    expect(jest.getTimerCount()).toBe(1);
+
+    jest.advanceTimersByTime(200);
+    expect(q('.blx-toast')).toBeFalsy();
+  });
+
   test('danger variant uses longer timeout by default', () => {
     const n = createToastNotifier({ durationMs: 10, dangerDurationMs: 100 });
     n.notify({ message: 'Issues: X', issues: [{ code: 'X' }], raw: null });
@@ -63,6 +82,16 @@ describe('createToastNotifier', () => {
     jest.advanceTimersByTime(60);
     jest.advanceTimersByTime(200);
     expect(q('.blx-toast')).toBeFalsy();
+  });
+
+  test('dedupe updates variant styling when severity changes', () => {
+    const n = createToastNotifier({ dedupeWindowMs: 10_000, durationMs: 10_000, dangerDurationMs: 10_000 });
+
+    n.notify({ message: 'Same', issues: null, raw: null });
+    expect(q('.blx-toast')?.getAttribute('data-variant')).toBe('info');
+
+    n.notify({ message: 'Same', issues: [{ code: 'E' }], raw: null });
+    expect(q('.blx-toast')?.getAttribute('data-variant')).toBe('danger');
   });
 });
 

--- a/demo/basic-model/basic-model.html
+++ b/demo/basic-model/basic-model.html
@@ -38,6 +38,11 @@
     import { blinxStore } from '../../lib/blinx.store.js';
     import { blinxForm } from '../../lib/blinx.form.js';
     import { blinxTable } from '../../lib/blinx.table.js';
+    import { Notifier } from '../../lib/blinx.notifier.js';
+    import { createToastNotifier } from '../../lib/blinx.toast-notifier.js';
+
+    // Opt-in toast notifier (no prop drilling; used by ctx.notify(...) and post-action issue surfacing).
+    Notifier.set(createToastNotifier());
 
     const store = blinxStore(initialDataset, productModel);
 

--- a/docs/spec/notifier.md
+++ b/docs/spec/notifier.md
@@ -5,7 +5,9 @@
 
 # Notifier (`lib/blinx.notifier.js`)
 
-Blinx does not ship a built-in toast/banner UI. Instead it provides a **central, pluggable notifier** that any app can register once and all Blinx components can use without prop-drilling.
+Blinx keeps the core runtime headless: it does **not** auto-render toast/banner UI by default. Instead it provides a **central, pluggable notifier** that any app can register once and all Blinx components can use without prop-drilling.
+
+This repo also includes an **optional DOM toast implementation** (`lib/blinx.toast-notifier.js`) that you can opt into as a convenient default for the built-in HTML adapter.
 
 This solves the “custom actions collect issues but don’t automatically render them” gap described in `docs/wip.md` (Aspect 2 / Iteration 1).
 
@@ -23,6 +25,17 @@ Notifier.set({
     console.log(payload.message);
   },
 });
+```
+
+### 1.0 Optional built-in toast notifier (opt-in)
+
+If you want a ready-to-use toast UI (with Blinx token-based styling), register the toast notifier:
+
+```js
+import { Notifier } from '../lib/blinx.notifier.js';
+import { createToastNotifier } from '../lib/blinx.toast-notifier.js';
+
+Notifier.set(createToastNotifier());
 ```
 
 ### 1.1 `Notifier.set(impl)`

--- a/lib/blinx.css
+++ b/lib/blinx.css
@@ -377,6 +377,103 @@
 }
 
 /* =========================================================
+  TOAST NOTIFIER (optional)
+  - Used by `createToastNotifier()` (see `lib/blinx.toast-notifier.js`)
+  - Fully scoped to `.blx-*` classes to avoid affecting host apps.
+========================================================= */
+.blx-toast-region {
+  position: fixed;
+  z-index: 2147483000; /* high, but below browser UI */
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: min(28rem, calc(100vw - 2rem));
+  padding: 1rem;
+  pointer-events: none; /* allow clicks through except on toast itself */
+}
+
+.blx-toast-region[data-position="top-right"] { top: 0; right: 0; align-items: flex-end; }
+.blx-toast-region[data-position="top-left"] { top: 0; left: 0; align-items: flex-start; }
+.blx-toast-region[data-position="bottom-right"] { bottom: 0; right: 0; align-items: flex-end; }
+.blx-toast-region[data-position="bottom-left"] { bottom: 0; left: 0; align-items: flex-start; }
+
+.blx-toast {
+  pointer-events: auto;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.75rem 0.9rem;
+  border-radius: calc(var(--blx-radius) * 0.9);
+  border: 1px solid var(--blx-border);
+  background: color-mix(in srgb, var(--blx-surface), white 10%);
+  color: var(--blx-text);
+  box-shadow: var(--blx-shadow-lg);
+  max-width: 100%;
+}
+
+.blx-toast[data-variant="danger"] { border-color: color-mix(in srgb, var(--blx-danger), white 35%); }
+.blx-toast[data-variant="warning"] { border-color: color-mix(in srgb, var(--blx-warning), white 35%); }
+.blx-toast[data-variant="success"] { border-color: color-mix(in srgb, var(--blx-success), white 35%); }
+
+.blx-toast__message {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.blx-toast__right {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.blx-toast__count {
+  display: inline-block;
+  font-size: 0.75rem;
+  color: var(--blx-muted);
+  border: 1px solid color-mix(in srgb, var(--blx-border), transparent 20%);
+  border-radius: 9999px;
+  padding: 0.1rem 0.45rem;
+  background: color-mix(in srgb, var(--blx-surface), white 18%);
+}
+
+.blx-toast__close {
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--blx-border), transparent 20%);
+  background: color-mix(in srgb, var(--blx-surface), white 12%);
+  color: var(--blx-text);
+  border-radius: 0.65rem;
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  line-height: 1;
+}
+.blx-toast__close:hover { background: color-mix(in srgb, var(--blx-surface), white 18%); }
+.blx-toast__close:focus-visible {
+  outline: 3px solid var(--blx-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Motion (respects prefers-reduced-motion via earlier global theme rule) */
+.blx-toast[data-state="enter"] {
+  opacity: 0;
+  transform: translateY(-6px);
+}
+.blx-toast[data-state="shown"] {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+.blx-toast[data-state="leaving"] {
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: opacity 160ms ease, transform 160ms ease;
+}
+
+/* =========================================================
   UTILITIES
 ========================================================= */
 .blx-text-muted { color: var(--blx-muted); }

--- a/lib/blinx.toast-notifier.js
+++ b/lib/blinx.toast-notifier.js
@@ -1,0 +1,215 @@
+function isElement(v) {
+  return !!v && typeof v === 'object' && v.nodeType === 1 && typeof v.appendChild === 'function';
+}
+
+function nowMs() {
+  return Date.now();
+}
+
+function safeRemove(el) {
+  try { el?.remove?.(); } catch { /* ignore */ }
+}
+
+function resolveMountRoot(root) {
+  if (isElement(root)) return root;
+  if (typeof document === 'undefined') return null;
+  // Prefer an existing Blinx theme boundary when present.
+  const themed = document.querySelector?.('[data-blinx-theme]');
+  if (themed) return themed;
+  return document.body || document.documentElement || null;
+}
+
+function pickVariant(payload, explicitVariant) {
+  if (explicitVariant) return String(explicitVariant);
+  const hasIssues = Array.isArray(payload?.issues) && payload.issues.length > 0;
+  if (hasIssues) return 'danger';
+  return 'info';
+}
+
+function isEmptyMessage(msg) {
+  return !msg || !String(msg).trim();
+}
+
+/**
+ * Create a DOM toast notifier implementation compatible with `Notifier.set(...)`.
+ *
+ * Notes:
+ * - Opt-in only: does not register itself.
+ * - Best-effort: never throws on notify().
+ * - Scoped styling: uses `.blx-*` classes and Blinx CSS tokens (see `lib/blinx.css`).
+ */
+export function createToastNotifier(options = {}) {
+  const {
+    root = null,
+    position = 'top-right', // 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'
+    maxToasts = 4,
+    dedupeWindowMs = 1200,
+    durationMs = 4000,
+    dangerDurationMs = 8000,
+    ariaLive = 'polite', // 'polite' | 'assertive' | 'off'
+    label = 'Notifications',
+    onNotify = null,
+  } = options || {};
+
+  let region = null;
+  const dedupe = new Map(); // key -> { el, count, lastAt, timerId }
+
+  function ensureRegion() {
+    if (region && region.isConnected) return region;
+    const mountRoot = resolveMountRoot(root);
+    if (!mountRoot || typeof document === 'undefined') return null;
+    const el = document.createElement('div');
+    el.className = 'blx-toast-region';
+    el.setAttribute('data-position', String(position || 'top-right'));
+    if (label) el.setAttribute('aria-label', String(label));
+    el.setAttribute('aria-live', String(ariaLive || 'polite'));
+    el.setAttribute('aria-relevant', 'additions text');
+    el.setAttribute('aria-atomic', 'false');
+    mountRoot.appendChild(el);
+    region = el;
+    return region;
+  }
+
+  function updateCount(toastEl, count) {
+    if (!toastEl) return;
+    const badge = toastEl.querySelector?.('[data-blx-part="count"]');
+    if (!badge) return;
+    const n = Number(count) || 1;
+    badge.textContent = n > 1 ? `×${n}` : '';
+    badge.toggleAttribute?.('hidden', !(n > 1));
+  }
+
+  function scheduleRemoval(toastEl, ms, key) {
+    if (!toastEl) return;
+    const delay = Math.max(0, Number(ms) || 0);
+    const existing = key ? dedupe.get(key) : null;
+    if (existing?.timerId) {
+      try { clearTimeout(existing.timerId); } catch { /* ignore */ }
+      existing.timerId = null;
+    }
+    const timerId = setTimeout(() => {
+      // Mark leaving for CSS transition, then remove.
+      try { toastEl.setAttribute('data-state', 'leaving'); } catch { /* ignore */ }
+      setTimeout(() => {
+        safeRemove(toastEl);
+        if (key && dedupe.get(key)?.el === toastEl) dedupe.delete(key);
+      }, 180);
+    }, delay);
+    if (existing) existing.timerId = timerId;
+    return timerId;
+  }
+
+  function enforceMax(regionEl) {
+    if (!regionEl) return;
+    const max = Math.max(1, Number(maxToasts) || 1);
+    while (regionEl.children.length > max) {
+      safeRemove(regionEl.firstElementChild);
+    }
+  }
+
+  function buildToast({ message, variant }) {
+    const toastEl = document.createElement('div');
+    toastEl.className = 'blx-toast';
+    toastEl.setAttribute('data-variant', variant);
+    toastEl.setAttribute('data-state', 'enter');
+
+    const msgEl = document.createElement('div');
+    msgEl.className = 'blx-toast__message';
+    msgEl.setAttribute('data-blx-part', 'message');
+    msgEl.textContent = message;
+
+    const countEl = document.createElement('span');
+    countEl.className = 'blx-toast__count';
+    countEl.setAttribute('data-blx-part', 'count');
+    countEl.hidden = true;
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'blx-toast__close';
+    closeBtn.type = 'button';
+    closeBtn.setAttribute('data-blx-part', 'close');
+    closeBtn.setAttribute('aria-label', 'Dismiss notification');
+    closeBtn.textContent = '×';
+    closeBtn.addEventListener('click', () => {
+      scheduleRemoval(toastEl, 0);
+    });
+
+    const right = document.createElement('div');
+    right.className = 'blx-toast__right';
+    right.appendChild(countEl);
+    right.appendChild(closeBtn);
+
+    toastEl.appendChild(msgEl);
+    toastEl.appendChild(right);
+
+    // Let the browser apply initial state before transitioning in.
+    setTimeout(() => {
+      try { toastEl.setAttribute('data-state', 'shown'); } catch { /* ignore */ }
+    }, 0);
+
+    return toastEl;
+  }
+
+  function notify(payload) {
+    try {
+      if (!payload || typeof payload !== 'object') return;
+      const message = String(payload.message ?? '');
+      const hasIssues = Array.isArray(payload.issues) && payload.issues.length > 0;
+      if (isEmptyMessage(message) && !hasIssues) return;
+
+      const variant = pickVariant(payload, options?.variant);
+      const regionEl = ensureRegion();
+      if (!regionEl) return;
+
+      // Dedupe by message for a short window to avoid spam (e.g., repeated save failures).
+      const key = message;
+      const t = nowMs();
+      const prev = dedupe.get(key);
+      const withinWindow = prev && (t - prev.lastAt) <= Math.max(0, Number(dedupeWindowMs) || 0) && prev.el?.isConnected;
+      if (withinWindow) {
+        prev.count += 1;
+        prev.lastAt = t;
+        updateCount(prev.el, prev.count);
+        // Refresh dismissal timer.
+        const autoMs = (variant === 'danger') ? dangerDurationMs : durationMs;
+        scheduleRemoval(prev.el, autoMs, key);
+        if (typeof onNotify === 'function') {
+          try { onNotify({ payload, toastEl: prev.el, deduped: true }); } catch { /* ignore */ }
+        }
+        return;
+      }
+
+      const toastEl = buildToast({ message: message || (hasIssues ? 'Issues occurred.' : ''), variant });
+      regionEl.appendChild(toastEl);
+      enforceMax(regionEl);
+
+      dedupe.set(key, { el: toastEl, count: 1, lastAt: t, timerId: null });
+
+      const autoMs = (variant === 'danger') ? dangerDurationMs : durationMs;
+      scheduleRemoval(toastEl, autoMs, key);
+
+      if (typeof onNotify === 'function') {
+        try { onNotify({ payload, toastEl, deduped: false }); } catch { /* ignore */ }
+      }
+    } catch {
+      // Never throw from a notifier; best-effort only.
+    }
+  }
+
+  function destroy() {
+    try {
+      for (const [, entry] of dedupe) {
+        if (entry?.timerId) {
+          try { clearTimeout(entry.timerId); } catch { /* ignore */ }
+        }
+      }
+      dedupe.clear();
+      safeRemove(region);
+      region = null;
+    } catch {
+      // ignore
+    }
+  }
+
+  return { notify, destroy };
+}
+

--- a/lib/blinx.toast-notifier.js
+++ b/lib/blinx.toast-notifier.js
@@ -54,6 +54,21 @@ export function createToastNotifier(options = {}) {
   let region = null;
   const dedupe = new Map(); // key -> { el, count, lastAt, timerId }
 
+  function dismiss(toastEl, key) {
+    try {
+      const entry = key ? dedupe.get(key) : null;
+      if (entry?.timerId) {
+        try { clearTimeout(entry.timerId); } catch { /* ignore */ }
+        entry.timerId = null;
+      }
+      if (key) dedupe.delete(key);
+    } catch {
+      // ignore
+    }
+    // Keep the leave animation even for manual dismiss.
+    scheduleRemoval(toastEl, 0);
+  }
+
   function ensureRegion() {
     if (region && region.isConnected) return region;
     const mountRoot = resolveMountRoot(root);
@@ -107,7 +122,7 @@ export function createToastNotifier(options = {}) {
     }
   }
 
-  function buildToast({ message, variant }) {
+  function buildToast({ message, variant, key }) {
     const toastEl = document.createElement('div');
     toastEl.className = 'blx-toast';
     toastEl.setAttribute('data-variant', variant);
@@ -130,7 +145,7 @@ export function createToastNotifier(options = {}) {
     closeBtn.setAttribute('aria-label', 'Dismiss notification');
     closeBtn.textContent = '×';
     closeBtn.addEventListener('click', () => {
-      scheduleRemoval(toastEl, 0);
+      dismiss(toastEl, key);
     });
 
     const right = document.createElement('div');
@@ -169,6 +184,8 @@ export function createToastNotifier(options = {}) {
         prev.count += 1;
         prev.lastAt = t;
         updateCount(prev.el, prev.count);
+        // Keep styling aligned with the most recent payload severity.
+        try { prev.el?.setAttribute?.('data-variant', variant); } catch { /* ignore */ }
         // Refresh dismissal timer.
         const autoMs = (variant === 'danger') ? dangerDurationMs : durationMs;
         scheduleRemoval(prev.el, autoMs, key);
@@ -178,7 +195,7 @@ export function createToastNotifier(options = {}) {
         return;
       }
 
-      const toastEl = buildToast({ message: message || (hasIssues ? 'Issues occurred.' : ''), variant });
+      const toastEl = buildToast({ message: message || (hasIssues ? 'Issues occurred.' : ''), variant, key });
       regionEl.appendChild(toastEl);
       enforceMax(regionEl);
 


### PR DESCRIPTION
Add an opt-in toast notifier implementation to provide a default notification UI for Blinx applications.

---
<a href="https://cursor.com/background-agent?bcId=bc-6352674e-a3d4-439c-8abc-1b9ef6fa7480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6352674e-a3d4-439c-8abc-1b9ef6fa7480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an opt-in notification UI while keeping the core headless.
> 
> - New `lib/blinx.toast-notifier.js` implements a DOM toast notifier: ARIA live region, positionable regions, close button, auto-dismiss with variant-based timeouts, deduping with count badge, max-toasts capping, and `destroy()` cleanup
> - Extends `lib/blinx.css` with scoped `.blx-toast*` styles and transitions
> - Tests (`__tests__/blinx.toast-notifier.test.js`) cover region creation, dedupe/counting, auto-dismiss, and longer danger timeout
> - Docs updated: `README.md` and `docs/spec/notifier.md` add Notifications section and opt-in usage snippet (`Notifier.set(createToastNotifier())`)
> - Demo updated (`demo/basic-model/basic-model.html`) to register the toast notifier at startup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a8cc1baf692a70a9f61701329d9d2406f39a6b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->