### PR TITLE
docs: add additional feature demos

### DIFF
--- a/demo/computed-fields-demo.html
+++ b/demo/computed-fields-demo.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Blinx Demo - Computed Fields</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../lib/blinx.css">
+  <style>
+    .demo-shell { max-width: 1040px; margin: 0 auto; }
+    .demo-lede { color: var(--blx-muted); }
+    .demo-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(18rem, 0.65fr); gap: var(--blx-space); }
+    .demo-output { white-space: pre-wrap; padding: 0.75rem; border: 1px solid var(--blx-border); border-radius: var(--blx-radius); background: color-mix(in srgb, var(--blx-surface), white 8%); }
+    @media (max-width: 850px) { .demo-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <main class="blx-page demo-shell" data-blinx-theme>
+    <h1>Computed fields demo: PR #31</h1>
+    <p class="demo-lede">
+      Edit price, quantity, discount, or tax. Blinx recomputes read-only virtual fields from their dependencies.
+    </p>
+
+    <div class="demo-grid">
+      <section class="blx-card">
+        <div id="invoice-form"></div>
+      </section>
+      <section class="blx-card">
+        <h2>Computed snapshot</h2>
+        <p class="demo-lede">Computed fields appear in <code>toJSON()</code> but are not directly settable.</p>
+        <pre id="computed-output" class="demo-output"></pre>
+        <div class="blx-toolbar">
+          <button id="boost-qty" class="blx-btn" data-variant="surface">Set quantity to 5</button>
+          <button id="try-set-computed" class="blx-btn" data-variant="danger">Try setting computed total</button>
+        </div>
+        <p id="computed-status"></p>
+      </section>
+    </div>
+  </main>
+
+  <script type="module">
+    import { blinxStore } from '../lib/blinx.store.js';
+    import { blinxForm } from '../lib/blinx.form.js';
+
+    const money = (value) => Math.round((Number(value) || 0) * 100) / 100;
+
+    const InvoiceLineModel = {
+      id: 'ComputedDemoInvoiceLine',
+      fields: {
+        sku: { type: 'string', required: true },
+        price: { type: 'number', min: 0 },
+        quantity: { type: 'number', min: 1, integerOnly: true },
+        discountRate: { type: 'number', min: 0, max: 1, step: 0.05 },
+        taxRate: { type: 'number', min: 0, max: 1, step: 0.01 },
+        subtotal: {
+          type: 'number',
+          computed: true,
+          dependsOn: ['price', 'quantity'],
+          compute: (record) => money(record.price * record.quantity),
+        },
+        discountAmount: {
+          type: 'number',
+          computed: true,
+          dependsOn: ['subtotal', 'discountRate'],
+          compute: (record) => money(record.subtotal * record.discountRate),
+        },
+        total: {
+          type: 'number',
+          computed: true,
+          dependsOn: ['subtotal', 'discountAmount', 'taxRate'],
+          compute: (record) => money((record.subtotal - record.discountAmount) * (1 + record.taxRate)),
+        },
+      },
+    };
+
+    const store = blinxStore([{
+      sku: 'desk-lamp',
+      price: 45,
+      quantity: 2,
+      discountRate: 0.1,
+      taxRate: 0.07,
+    }], InvoiceLineModel);
+
+    const output = document.getElementById('computed-output');
+    const status = document.getElementById('computed-status');
+
+    function refreshOutput(message = '') {
+      output.textContent = JSON.stringify(store.toJSON()[0], null, 2);
+      status.textContent = message;
+    }
+
+    blinxForm({
+      root: document.getElementById('invoice-form'),
+      store,
+      recordIndex: 0,
+      view: {
+        sections: [{
+          title: 'Invoice line',
+          columns: 2,
+          fields: ['sku', 'price', 'quantity', 'discountRate', 'taxRate', 'subtotal', 'discountAmount', 'total'],
+        }],
+        controls: {
+          saveButton: true,
+          resetButton: true,
+          saveStatus: true,
+        },
+      },
+    });
+
+    store.subscribe(() => refreshOutput('Dependencies changed; computed fields were invalidated and recomputed.'));
+    document.getElementById('boost-qty').addEventListener('click', () => {
+      store.setField(0, 'quantity', 5);
+    });
+    document.getElementById('try-set-computed').addEventListener('click', () => {
+      try {
+        store.setField(0, 'total', 999);
+      } catch (error) {
+        status.textContent = error.message;
+      }
+      refreshOutput(status.textContent);
+    });
+
+    refreshOutput('Initial computed values.');
+  </script>
+</body>
+</html>

--- a/demo/conditional-display-demo.html
+++ b/demo/conditional-display-demo.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Blinx Demo - Conditional Display</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../lib/blinx.css">
+  <style>
+    .demo-shell { max-width: 1180px; margin: 0 auto; }
+    .demo-lede { color: var(--blx-muted); }
+    .demo-grid { display: grid; grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr); gap: var(--blx-space); }
+    tr[data-risk="high"] { outline: 2px solid var(--blx-danger); background: color-mix(in srgb, var(--blx-danger), transparent 88%); }
+    tr[data-status="approved"] { background: color-mix(in srgb, var(--blx-success), transparent 88%); }
+    td[data-money="true"] { font-weight: 700; color: var(--blx-accent); }
+    [data-confidential-hidden="true"] { display: none; }
+    @media (max-width: 900px) { .demo-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <main class="blx-page demo-shell" data-blinx-theme>
+    <h1>Conditional display demo: PR #32</h1>
+    <p class="demo-lede">
+      Demonstrates <code>present()</code> on form fields and columns plus <code>rowPresent()</code> on collection rows.
+    </p>
+
+    <div class="demo-grid">
+      <section class="blx-card">
+        <h2>Form present()</h2>
+        <p class="demo-lede">Switch records to see fields become hidden or read-only based on record data.</p>
+        <div id="request-form"></div>
+      </section>
+
+      <section class="blx-card">
+        <h2>Collection rowPresent()</h2>
+        <div class="blx-toolbar">
+          <button id="role-reviewer" class="blx-btn" data-variant="surface">Reviewer view</button>
+          <button id="role-admin" class="blx-btn" data-variant="primary">Admin view</button>
+          <span id="role-label"></span>
+        </div>
+        <p class="demo-lede">
+          High-risk rows are outlined. Admin view reveals the confidential note column.
+        </p>
+        <div id="request-table"></div>
+      </section>
+    </div>
+  </main>
+
+  <script type="module">
+    import { blinxStore } from '../lib/blinx.store.js';
+    import { blinxForm } from '../lib/blinx.form.js';
+    import { blinxCollection } from '../lib/blinx.collection.js';
+
+    const RequestModel = {
+      id: 'ConditionalDisplayRequest',
+      fields: {
+        id: { type: 'string' },
+        title: { type: 'string', required: true },
+        status: { type: 'enum', values: ['draft', 'review', 'approved'] },
+        priority: { type: 'enum', values: ['low', 'medium', 'high'] },
+        budget: { type: 'number', min: 0 },
+        approvalNote: { type: 'string' },
+        confidentialNote: { type: 'string' },
+      },
+    };
+
+    const store = blinxStore([
+      { id: 'r-1', title: 'Laptop refresh', status: 'draft', priority: 'medium', budget: 3200, approvalNote: '', confidentialNote: 'Vendor discount expires Friday.' },
+      { id: 'r-2', title: 'Data migration', status: 'review', priority: 'high', budget: 12000, approvalNote: 'Requires security sign-off.', confidentialNote: 'Includes regulated data.' },
+      { id: 'r-3', title: 'Team workshop', status: 'approved', priority: 'low', budget: 1800, approvalNote: 'Approved by finance.', confidentialNote: 'Negotiate catering fee.' },
+    ], RequestModel);
+
+    blinxForm({
+      root: document.getElementById('request-form'),
+      store,
+      recordIndex: 0,
+      view: {
+        sections: [{
+          title: 'Request',
+          columns: 2,
+          fields: [
+            'title',
+            'status',
+            'priority',
+            {
+              field: 'budget',
+              present: (_ctx, record) => ({
+                attrs: {
+                  input: { readonly: record?.status === 'approved' },
+                  wrapper: { 'data-approved-lock': record?.status === 'approved' },
+                },
+              }),
+            },
+            {
+              field: 'approvalNote',
+              present: (_ctx, record) => ({
+                attrs: {
+                  wrapper: { hidden: record?.priority !== 'high' && record?.status !== 'approved' },
+                },
+              }),
+            },
+            {
+              field: 'confidentialNote',
+              present: (ctx) => ({
+                attrs: {
+                  wrapper: { hidden: ctx.role !== 'admin' },
+                },
+              }),
+            },
+          ],
+        }],
+        controls: {
+          prevButton: true,
+          nextButton: true,
+          recordIndicator: true,
+          saveStatus: true,
+        },
+      },
+      context: { role: 'admin' },
+    });
+
+    let role = 'admin';
+    const tableRoot = document.getElementById('request-table');
+    const roleLabel = document.getElementById('role-label');
+
+    function renderTable() {
+      tableRoot.innerHTML = '';
+      roleLabel.textContent = `Current role: ${role}`;
+      blinxCollection({
+        root: tableRoot,
+        store,
+        paging: { pageSize: 10 },
+        actions: { create: false, deleteSelected: false },
+        context: { role },
+        view: {
+          layout: 'table',
+          columns: [
+            { field: 'title', label: 'Title' },
+            { field: 'status', label: 'Status' },
+            { field: 'priority', label: 'Priority' },
+            {
+              field: 'budget',
+              label: 'Budget',
+              present: () => ({ attrs: { cell: { 'data-money': 'true' } } }),
+            },
+            {
+              field: 'confidentialNote',
+              label: 'Confidential',
+              present: (ctx) => ({
+                attrs: {
+                  header: { 'data-confidential-hidden': ctx.role !== 'admin' },
+                  cell: { 'data-confidential-hidden': ctx.role !== 'admin' },
+                },
+              }),
+            },
+          ],
+          rowPresent: (_ctx, record) => ({
+            attrs: {
+              row: {
+                'data-risk': record?.priority === 'high' ? 'high' : 'normal',
+                'data-status': record?.status || '',
+              },
+            },
+          }),
+        },
+      });
+    }
+
+    document.getElementById('role-reviewer').addEventListener('click', () => {
+      role = 'reviewer';
+      renderTable();
+    });
+    document.getElementById('role-admin').addEventListener('click', () => {
+      role = 'admin';
+      renderTable();
+    });
+
+    renderTable();
+  </script>
+</body>
+</html>

--- a/demo/datasource-rest-demo.html
+++ b/demo/datasource-rest-demo.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Blinx Demo - Data Sources and REST</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../lib/blinx.css">
+  <style>
+    .demo-shell { max-width: 1180px; margin: 0 auto; }
+    .demo-lede { color: var(--blx-muted); }
+    .demo-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(20rem, 0.9fr); gap: var(--blx-space); }
+    .demo-output { max-height: 30rem; overflow: auto; white-space: pre-wrap; padding: 0.75rem; border: 1px solid var(--blx-border); border-radius: var(--blx-radius); background: color-mix(in srgb, var(--blx-surface), white 8%); }
+    @media (max-width: 900px) { .demo-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <main class="blx-page demo-shell" data-blinx-theme>
+    <h1>Data source + REST demo: PR #24 / #25</h1>
+    <p class="demo-lede">
+      Demonstrates a remote-capable Blinx store with a REST datasource, mock HTTP query/mutate calls, optimistic save, create reconciliation, and ETag conflicts.
+    </p>
+
+    <div class="demo-grid">
+      <section class="blx-card blx-stack">
+        <div class="blx-toolbar">
+          <button id="reload" class="blx-btn" data-variant="surface">Reload from mock REST</button>
+          <button id="edit-first" class="blx-btn" data-variant="surface">Edit first row locally</button>
+          <button id="save" class="blx-btn" data-variant="primary">Save changes</button>
+          <button id="create-save" class="blx-btn" data-variant="surface">Create + save</button>
+          <button id="conflict-save" class="blx-btn" data-variant="danger">Simulate conflict + save</button>
+        </div>
+        <p><strong>Status:</strong> <span id="status">Loading...</span></p>
+        <div id="remote-table"></div>
+      </section>
+
+      <section class="blx-card">
+        <h2>Mock REST traffic and store state</h2>
+        <pre id="rest-log" class="demo-output"></pre>
+      </section>
+    </div>
+  </main>
+
+  <script type="module">
+    import { blinxStore } from '../lib/blinx.store.js';
+    import { blinxCollection } from '../lib/blinx.collection.js';
+    import { BlinxRestDataSource } from '../lib/blinx.datasource.js';
+
+    const ProductModel = {
+      id: 'RestDemoProduct',
+      fields: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        category: { type: 'string' },
+        price: { type: 'number' },
+        version: { type: 'string' },
+      },
+    };
+
+    let nextId = 4;
+    const serverRecords = [
+      { id: 'p-1', name: 'Desk Lamp', category: 'Office', price: 45, version: '"v1"' },
+      { id: 'p-2', name: 'Travel Mug', category: 'Kitchen', price: 18, version: '"v1"' },
+      { id: 'p-3', name: 'USB Hub', category: 'Tech', price: 42, version: '"v1"' },
+    ];
+    const traffic = [];
+
+    function headers(map = {}) {
+      const lower = new Map(Object.entries(map).map(([key, value]) => [String(key).toLowerCase(), String(value)]));
+      return { get: (name) => lower.get(String(name).toLowerCase()) || null };
+    }
+
+    function response({ status = 200, json = null, headerMap = {} } = {}) {
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        headers: headers(headerMap),
+        async json() { return json; },
+      };
+    }
+
+    function bumpVersion(record) {
+      const current = Number(String(record.version || '"v0"').replace(/\D/g, '')) || 0;
+      record.version = `"v${current + 1}"`;
+      return record.version;
+    }
+
+    async function mockFetch(url, init = {}) {
+      const method = init.method || 'GET';
+      const parsed = new URL(url, window.location.origin);
+      traffic.push({
+        method,
+        url: parsed.pathname + parsed.search,
+        ifMatch: init.headers?.['If-Match'] || init.headers?.['if-match'] || null,
+        body: init.body ? JSON.parse(init.body) : null,
+      });
+
+      const idMatch = parsed.pathname.match(/\/products\/([^/]+)$/);
+      if (method === 'GET' && !idMatch) {
+        return response({
+          status: 200,
+          json: serverRecords.map((record) => ({ ...record })),
+          headerMap: { 'x-total-count': String(serverRecords.length) },
+        });
+      }
+
+      if (method === 'GET' && idMatch) {
+        const record = serverRecords.find((item) => item.id === idMatch[1]);
+        return record
+          ? response({ status: 200, json: { ...record }, headerMap: { etag: record.version } })
+          : response({ status: 404, json: { message: 'Not found' } });
+      }
+
+      if (method === 'POST') {
+        const data = init.body ? JSON.parse(init.body) : {};
+        const record = { id: `p-${nextId++}`, name: data.name || 'Created product', category: data.category || 'Demo', price: Number(data.price) || 1, version: '"v1"' };
+        serverRecords.push(record);
+        return response({ status: 201, json: { ...record }, headerMap: { etag: record.version } });
+      }
+
+      if (method === 'PATCH' && idMatch) {
+        const record = serverRecords.find((item) => item.id === idMatch[1]);
+        if (!record) return response({ status: 404, json: { message: 'Not found' } });
+        const ifMatch = init.headers?.['If-Match'] || init.headers?.['if-match'];
+        if (ifMatch && ifMatch !== record.version) {
+          return response({ status: 412, json: { message: 'Stale version' } });
+        }
+        Object.assign(record, init.body ? JSON.parse(init.body) : {});
+        bumpVersion(record);
+        return response({ status: 200, json: { ...record }, headerMap: { etag: record.version } });
+      }
+
+      return response({ status: 405, json: { message: `Unsupported mock method ${method}` } });
+    }
+
+    const dataSource = new BlinxRestDataSource({
+      baseUrl: '/mock-api',
+      fetch: mockFetch,
+    });
+
+    const store = blinxStore({
+      model: ProductModel,
+      dataSource,
+      view: {
+        name: 'products',
+        resource: 'products',
+        entityType: 'RestDemoProduct',
+        keyField: 'id',
+        versionField: 'version',
+        defaultPage: { mode: 'page', page: 0, limit: 20 },
+      },
+    });
+
+    const status = document.getElementById('status');
+    const log = document.getElementById('rest-log');
+
+    function writeStatus(message) {
+      status.textContent = message;
+      log.textContent = JSON.stringify({
+        message,
+        traffic,
+        localRows: store.toJSON(),
+        diff: store.diff(),
+        serverRows: serverRecords,
+      }, null, 2);
+    }
+
+    function renderTable() {
+      blinxCollection({
+        root: document.getElementById('remote-table'),
+        store,
+        paging: { pageSize: 10 },
+        actions: { create: false, deleteSelected: false },
+        view: {
+          layout: 'table',
+          columns: [
+            { field: 'id', label: 'ID' },
+            { field: 'name', label: 'Name' },
+            { field: 'category', label: 'Category' },
+            { field: 'price', label: 'Price' },
+            { field: 'version', label: 'Version' },
+          ],
+        },
+      });
+    }
+
+    async function reload() {
+      await store.loadFirst();
+      writeStatus('Loaded rows through BlinxRestDataSource.query().');
+    }
+
+    document.getElementById('reload').addEventListener('click', async () => {
+      await reload();
+    });
+
+    document.getElementById('edit-first').addEventListener('click', () => {
+      const first = store.getRecord(0);
+      store.setField(0, 'price', Number(first.price || 0) + 5);
+      writeStatus('Edited first row locally. Diff is queued until save().');
+    });
+
+    document.getElementById('save').addEventListener('click', async () => {
+      const result = await store.save();
+      writeStatus(`Save complete. applied=${result.applied?.length || 0}, conflicts=${result.conflicts?.length || 0}, rejected=${result.rejected?.length || 0}.`);
+    });
+
+    document.getElementById('create-save').addEventListener('click', async () => {
+      const index = store.addRecord({ name: 'Created in demo', category: 'Demo', price: 99 });
+      const beforeId = store.getRecord(index)?.id;
+      const result = await store.save();
+      const afterId = store.getRecord(index)?.id;
+      writeStatus(`Create saved. temporary id ${beforeId} reconciled to ${afterId}. applied=${result.applied?.length || 0}.`);
+    });
+
+    document.getElementById('conflict-save').addEventListener('click', async () => {
+      const serverFirst = serverRecords[0];
+      serverFirst.name = 'Server-side rename';
+      bumpVersion(serverFirst);
+      store.setField(0, 'price', Number(store.getRecord(0)?.price || 0) + 7);
+      const result = await store.save();
+      writeStatus(`Conflict save complete. conflicts=${result.conflicts?.length || 0}. Latest server record was fetched automatically.`);
+    });
+
+    await reload();
+    renderTable();
+  </script>
+</body>
+</html>

--- a/demo/default-view-schema-demo.html
+++ b/demo/default-view-schema-demo.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Blinx Demo - Generated Default Views</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../lib/blinx.css">
+  <style>
+    .demo-shell { max-width: 1180px; margin: 0 auto; }
+    .demo-lede { color: var(--blx-muted); }
+    .demo-grid { display: grid; grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr); gap: var(--blx-space); }
+    .demo-output { max-height: 24rem; overflow: auto; white-space: pre-wrap; padding: 0.75rem; border: 1px solid var(--blx-border); border-radius: var(--blx-radius); background: color-mix(in srgb, var(--blx-surface), white 8%); }
+    @media (max-width: 900px) { .demo-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <main class="blx-page demo-shell" data-blinx-theme>
+    <h1>Default view schema demo: PR #30</h1>
+    <p class="demo-lede">
+      No form or collection views are provided here. Blinx generates safe defaults from the model schema.
+    </p>
+
+    <div class="demo-grid">
+      <section class="blx-card">
+        <h2>Generated form</h2>
+        <div id="generated-form"></div>
+      </section>
+
+      <section class="blx-card">
+        <h2>Generated collection</h2>
+        <div id="generated-table"></div>
+      </section>
+    </div>
+
+    <section class="blx-card blx-stack">
+      <h2>Generated UI view dump</h2>
+      <p class="demo-lede">
+        Long text, JSON, secrets, blobs, arrays, and relationship-like fields are hidden by default.
+      </p>
+      <pre id="dump-output" class="demo-output"></pre>
+    </section>
+  </main>
+
+  <script type="module">
+    import { blinxStore } from '../lib/blinx.store.js';
+    import { blinxForm } from '../lib/blinx.form.js';
+    import { blinxCollection } from '../lib/blinx.collection.js';
+    import { blinxDump } from '../lib/blinx.dump.js';
+    import { BlinxConfig } from '../lib/blinx.config.js';
+
+    BlinxConfig.setDefaultViewGenerationEnabled(true);
+
+    const CustomerModel = {
+      id: 'GeneratedDefaultCustomer',
+      fields: {
+        id: { type: 'string' },
+        name: { type: 'string', required: true },
+        tier: { type: 'enum', values: ['bronze', 'silver', 'gold'] },
+        active: { type: 'boolean' },
+        createdAt: { type: 'date' },
+        accountManager: { type: 'string' },
+        notes: { type: 'longText' },
+        preferences: { type: 'json' },
+        apiToken: { type: 'secret' },
+        avatarBlob: { type: 'blob' },
+        tags: { type: 'array' },
+      },
+    };
+
+    const customers = [
+      { id: 'c-1', name: 'Ada Lovelace', tier: 'gold', active: true, createdAt: '2026-01-03', accountManager: 'Mira', notes: 'VIP', preferences: { theme: 'dark' }, apiToken: 'secret-1', avatarBlob: 'binary', tags: ['math'] },
+      { id: 'c-2', name: 'Grace Hopper', tier: 'silver', active: true, createdAt: '2026-01-05', accountManager: 'Noah', notes: 'Compiler interest', preferences: { theme: 'light' }, apiToken: 'secret-2', avatarBlob: 'binary', tags: ['navy'] },
+      { id: 'c-3', name: 'Katherine Johnson', tier: 'gold', active: false, createdAt: '2026-01-01', accountManager: 'Lin', notes: 'Space program', preferences: { theme: 'contrast' }, apiToken: 'secret-3', avatarBlob: 'binary', tags: ['flight'] },
+    ];
+
+    const store = blinxStore(customers, CustomerModel);
+
+    blinxForm({
+      root: document.getElementById('generated-form'),
+      store,
+      recordIndex: 0,
+    });
+
+    blinxCollection({
+      root: document.getElementById('generated-table'),
+      store,
+      paging: { pageSize: 5 },
+      actions: { create: false, deleteSelected: false },
+    });
+
+    document.getElementById('dump-output').textContent = blinxDump('ui-view');
+  </script>
+</body>
+</html>

--- a/demo/ui-view-declaration-demo.html
+++ b/demo/ui-view-declaration-demo.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Blinx Demo - UI View Declarations</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../lib/blinx.css">
+  <style>
+    .demo-shell { max-width: 1180px; margin: 0 auto; }
+    .demo-lede { color: var(--blx-muted); }
+    .demo-grid { display: grid; grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr); gap: var(--blx-space); }
+    .demo-badge { display: inline-block; padding: 0.15rem 0.45rem; border-radius: 999px; background: var(--blx-primary); color: white; font-size: 0.85rem; }
+    @media (max-width: 900px) { .demo-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <main class="blx-page demo-shell" data-blinx-theme>
+    <h1>UI-view declaration support demo: PR #85</h1>
+    <p class="demo-lede">
+      Demonstrates registry-first view resolution, named view switching, custom renderer capabilities, and fallback to the default renderer.
+    </p>
+
+    <div class="demo-grid">
+      <section class="blx-card">
+        <h2>Registry form view</h2>
+        <p class="demo-lede">The form resolves <code>Asset.form.default</code> from the UI-view registry.</p>
+        <div id="asset-form"></div>
+      </section>
+
+      <section class="blx-card">
+        <h2>Registry collection views + renderer fallback</h2>
+        <div class="blx-toolbar">
+          <button id="view-default" class="blx-btn" data-variant="primary">Default registry view</button>
+          <button id="view-compact" class="blx-btn" data-variant="surface">Compact named view</button>
+          <span id="view-label"></span>
+        </div>
+        <p class="demo-lede">
+          The custom renderer decorates supported cells with <span class="demo-badge">custom</span>. Blob cells are rejected by
+          <code>supportsField()</code> and rendered by the configured fallback renderer instead.
+        </p>
+        <div id="asset-table"></div>
+      </section>
+    </div>
+  </main>
+
+  <script type="module">
+    import { blinxStore } from '../lib/blinx.store.js';
+    import { blinxForm } from '../lib/blinx.form.js';
+    import { blinxCollection } from '../lib/blinx.collection.js';
+    import { BlinxDefaultUI } from '../lib/blinx.adapters.default.js';
+    import { BlinxConfig } from '../lib/blinx.config.js';
+    import { RegisteredUI } from '../lib/blinx.registered-ui.js';
+    import { registerModelViews } from '../lib/blinx.ui-views.js';
+
+    const defaultUI = new BlinxDefaultUI();
+    RegisteredUI.register('demo-compact-renderer', {
+      supportsField({ fieldDef, kind, mode }) {
+        if (kind === 'collection' && mode === 'cell' && fieldDef?.type === 'blob') return false;
+        return true;
+      },
+      createField(args) {
+        return defaultUI.createField(args);
+      },
+      formatCell(value, def = {}) {
+        if (def.type === 'number') return `custom:${value ?? ''}`;
+        if (def.type === 'string') return `custom:${String(value ?? '').toUpperCase()}`;
+        return defaultUI.formatCell(value, def);
+      },
+    });
+
+    BlinxConfig.setUIRendererFallback('default');
+    BlinxConfig.setUIRendererStrict(true);
+
+    const AssetModel = {
+      id: 'UIViewDeclarationAsset',
+      fields: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        owner: { type: 'string' },
+        cost: { type: 'number' },
+        attachment: { type: 'blob' },
+      },
+    };
+
+    registerModelViews(AssetModel, {
+      form: {
+        default: {
+          sections: [{ title: 'Asset', columns: 2, fields: ['id', 'name', 'owner', 'cost'] }],
+        },
+      },
+      collection: {
+        default: {
+          layout: 'table',
+          renderer: 'demo-compact-renderer',
+          columns: [
+            { field: 'name', label: 'Name' },
+            { field: 'owner', label: 'Owner' },
+            { field: 'cost', label: 'Cost' },
+            { field: 'attachment', label: 'Attachment' },
+          ],
+          searchFields: ['name', 'owner'],
+        },
+        compact: {
+          layout: 'table',
+          renderer: 'demo-compact-renderer',
+          columns: [
+            { field: 'name', label: 'Name' },
+            { field: 'cost', label: 'Cost' },
+          ],
+        },
+      },
+    });
+
+    const store = blinxStore([
+      { id: 'a-1', name: 'Laptop', owner: 'Mira', cost: 1800, attachment: 'warranty.pdf' },
+      { id: 'a-2', name: 'Projector', owner: 'Noah', cost: 650, attachment: 'manual.pdf' },
+      { id: 'a-3', name: 'Badge Printer', owner: 'Lin', cost: 420, attachment: 'driver.zip' },
+    ], AssetModel);
+
+    blinxForm({
+      root: document.getElementById('asset-form'),
+      store,
+      recordIndex: 0,
+    });
+
+    const tableRoot = document.getElementById('asset-table');
+    const viewLabel = document.getElementById('view-label');
+
+    function renderCollection(viewName = undefined) {
+      tableRoot.innerHTML = '';
+      viewLabel.textContent = viewName ? `Current view: ${viewName}` : 'Current view: default';
+      blinxCollection({
+        root: tableRoot,
+        store,
+        view: viewName,
+        paging: { pageSize: 10 },
+        actions: { create: false, deleteSelected: false },
+      });
+    }
+
+    document.getElementById('view-default').addEventListener('click', () => renderCollection());
+    document.getElementById('view-compact').addEventListener('click', () => renderCollection('compact'));
+
+    renderCollection();
+  </script>
+</body>
+</html>

--- a/demo/ui-view-design-demo.html
+++ b/demo/ui-view-design-demo.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Blinx Demo - UI View Design</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../lib/blinx.css">
+  <style>
+    .demo-shell { max-width: 1180px; margin: 0 auto; }
+    .demo-lede { color: var(--blx-muted); }
+    .demo-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: var(--blx-space); }
+    @media (max-width: 900px) { .demo-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <main class="blx-page demo-shell" data-blinx-theme>
+    <h1>UI view design demo: PR #29</h1>
+    <p class="demo-lede">
+      Demonstrates registry-first UI views, nested model/collection rendering, and field-level view overrides.
+    </p>
+
+    <div class="demo-grid">
+      <section class="blx-card">
+        <h2>Registered form view</h2>
+        <p class="demo-lede">
+          The order form is resolved from <code>registerModelViews(OrderModel).form.default</code>.
+        </p>
+        <div id="order-form"></div>
+      </section>
+
+      <section class="blx-card">
+        <h2>Registered collection view</h2>
+        <p class="demo-lede">
+          This collection uses a named registry view: <code>view: "summary"</code>.
+        </p>
+        <div id="order-table"></div>
+      </section>
+    </div>
+  </main>
+
+  <script type="module">
+    import { blinxStore } from '../lib/blinx.store.js';
+    import { blinxForm } from '../lib/blinx.form.js';
+    import { blinxCollection } from '../lib/blinx.collection.js';
+    import { registerModelViews } from '../lib/blinx.ui-views.js';
+
+    const AddressModel = {
+      id: 'UIViewDesignAddress',
+      fields: {
+        line1: { type: 'string' },
+        city: { type: 'string' },
+        country: { type: 'string' },
+      },
+    };
+
+    const CustomerModel = {
+      id: 'UIViewDesignCustomer',
+      fields: {
+        customerId: { type: 'string' },
+        name: { type: 'string' },
+        tier: { type: 'enum', values: ['standard', 'gold', 'platinum'] },
+        address: { type: 'model', model: AddressModel },
+      },
+    };
+
+    const OrderItemModel = {
+      id: 'UIViewDesignOrderItem',
+      fields: {
+        sku: { type: 'string' },
+        quantity: { type: 'number' },
+        price: { type: 'number' },
+      },
+    };
+
+    const OrderModel = {
+      id: 'UIViewDesignOrder',
+      fields: {
+        orderId: { type: 'string' },
+        status: { type: 'enum', values: ['draft', 'packed', 'shipped'] },
+        customer: { type: 'model', model: CustomerModel },
+        shippingAddress: { type: 'model', model: AddressModel },
+        items: { type: 'collection', model: OrderItemModel },
+      },
+    };
+
+    registerModelViews(AddressModel, {
+      form: {
+        default: { sections: [{ title: 'Full address', columns: 1, fields: ['line1', 'city', 'country'] }] },
+        compact: { sections: [{ title: 'Compact address', columns: 1, fields: ['city', 'country'] }] },
+      },
+    });
+
+    registerModelViews(CustomerModel, {
+      form: {
+        default: { sections: [{ title: 'Customer', columns: 2, fields: ['customerId', 'name', 'tier', 'address'] }] },
+      },
+    });
+
+    registerModelViews(OrderItemModel, {
+      form: {
+        default: { sections: [{ title: 'Line item', columns: 3, fields: ['sku', 'quantity', 'price'] }] },
+        compact: { sections: [{ title: 'Line item compact', columns: 2, fields: ['sku', 'quantity'] }] },
+      },
+    });
+
+    registerModelViews(OrderModel, {
+      form: {
+        default: {
+          sections: [{
+            title: 'Order',
+            columns: 1,
+            fields: [
+              'orderId',
+              'status',
+              'customer',
+              { field: 'shippingAddress', view: 'compact' },
+              { field: 'items', itemView: 'compact' },
+            ],
+          }],
+        },
+      },
+      collection: {
+        summary: {
+          layout: 'table',
+          columns: [
+            { field: 'orderId', label: 'Order' },
+            { field: 'status', label: 'Status' },
+          ],
+          searchFields: ['orderId', 'status'],
+        },
+      },
+    });
+
+    const orders = [
+      {
+        orderId: 'ord-1001',
+        status: 'packed',
+        customer: {
+          customerId: 'c-1',
+          name: 'Ada Lovelace',
+          tier: 'platinum',
+          address: { line1: '1 Algorithm Ave', city: 'London', country: 'UK' },
+        },
+        shippingAddress: { line1: 'Dock 8', city: 'London', country: 'UK' },
+        items: [
+          { sku: 'lamp', quantity: 2, price: 45 },
+          { sku: 'desk-mat', quantity: 1, price: 30 },
+        ],
+      },
+      {
+        orderId: 'ord-1002',
+        status: 'draft',
+        customer: {
+          customerId: 'c-2',
+          name: 'Grace Hopper',
+          tier: 'gold',
+          address: { line1: '2 Compiler Ct', city: 'Arlington', country: 'US' },
+        },
+        shippingAddress: { line1: 'Warehouse 3', city: 'Arlington', country: 'US' },
+        items: [{ sku: 'usb-hub', quantity: 3, price: 42 }],
+      },
+    ];
+
+    const store = blinxStore(orders, OrderModel);
+
+    blinxForm({
+      root: document.getElementById('order-form'),
+      store,
+      recordIndex: 0,
+    });
+
+    blinxCollection({
+      root: document.getElementById('order-table'),
+      store,
+      view: 'summary',
+      paging: { pageSize: 5 },
+      actions: { create: false, deleteSelected: false },
+      onItemClick: ({ index }) => {
+        document.getElementById('order-form').innerHTML = '';
+        blinxForm({ root: document.getElementById('order-form'), store, recordIndex: index });
+      },
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add standalone front-end demos for computed fields, conditional display, generated default views, registered UI views, UI-view declaration/renderer fallback, and REST data sources
- keep demos self-contained in HTML and importing directly from the current `lib` folder
- avoid modifying any existing files

## Testing
- Browser smoke script against:
  - `/demo/computed-fields-demo.html`
  - `/demo/conditional-display-demo.html`
  - `/demo/default-view-schema-demo.html`
  - `/demo/ui-view-design-demo.html`
  - `/demo/ui-view-declaration-demo.html`
  - `/demo/datasource-rest-demo.html`
- `npm test -- --runTestsByPath __tests__/blinx.computed-fields.test.js __tests__/blinx.present.form.integration.test.js __tests__/blinx.present.collection.integration.test.js __tests__/blinx.schema-default-view.integration.test.js __tests__/blinx.ui-views.registry.test.js __tests__/blinx.renderer-capabilities.test.js __tests__/blinx.datasource.rest.test.js __tests__/blinx.datasource.integration.test.js __tests__/blinx.store.rest.create-and-requeue.test.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8729e53e-efeb-4735-9e66-cd25058dfdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8729e53e-efeb-4735-9e66-cd25058dfdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

